### PR TITLE
Fix #5283: Case-fold by code point in `String` methods ignoring case.

### DIFF
--- a/javalib/src/main/scala/java/lang/_String.scala
+++ b/javalib/src/main/scala/java/lang/_String.scala
@@ -141,10 +141,11 @@ final class _String private () // scalastyle:ignore
 
     var i = 0
     while (i != minLength) {
-      val cmp = caseFold(this.charAt(i)) - caseFold(str.charAt(i))
+      val thisCP = this.codePointAt(i)
+      val cmp = caseFold(thisCP) - caseFold(str.codePointAt(i))
       if (cmp != 0)
         return cmp
-      i += 1
+      i += Character.charCount(thisCP)
     }
     thisLength - strLength
     // scalastyle:on return
@@ -159,24 +160,30 @@ final class _String private () // scalastyle:ignore
     } else {
       var i = 0
       while (i != len) {
-        if (caseFold(this.charAt(i)) != caseFold(anotherString.charAt(i)))
+        val thisCP = this.codePointAt(i)
+        if (caseFold(thisCP) != caseFold(anotherString.codePointAt(i)))
           return false
-        i += 1
+        i += Character.charCount(thisCP)
       }
       true
     }
     // scalastyle:on return
   }
 
-  /** Performs case folding of a single character for use by `equalsIgnoreCase`
-   *  and `compareToIgnoreCase`.
+  /** Performs case folding of a single code point for use by
+   *  `equalsIgnoreCase`, `compareToIgnoreCase` and `regionMatches`.
    *
    *  This implementation respects the specification of those two methods,
    *  although that behavior does not generally conform to Unicode Case
    *  Folding.
+   *
+   *  Note that `charCount(caseFold(cp)) == charCount(cp)` for all code points.
+   *  In other words, `caseFold(cp)` is a supplementary code point iff `cp` is
+   *  a supplementary code point. This means that length- and index-related
+   *  operations in the `xIgnoreCase` methods are meaningful.
    */
-  @inline private def caseFold(c: Char): Char =
-    Character.toLowerCase(Character.toUpperCase(c))
+  @inline private def caseFold(cp: Int): Int =
+    Character.toLowerCase(Character.toUpperCase(cp))
 
   @inline
   def concat(s: String): String =

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/lang/StringTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/lang/StringTest.scala
@@ -55,6 +55,26 @@ class StringTest {
 
     // null is a valid input
     assertFalse("foo".equalsIgnoreCase(null))
+
+    if (!executingInJVMOnLowerThanJDK(17)) {
+      // #5283 Case folding is done by code point
+
+      /* Letters from the Warang Citi script.
+       * "𑢹𑣗𑣁𑣜𑣊 𑣏𑣂𑣕𑣂" is the native name for "Warang Citi"
+       */
+      assertTrue(
+          // "𑢹𑣗𑣁𑣜𑣊" == "𑣙𑣗𑣁𑣜𑣊"; folding on the the first code point
+          "\ud806\udcb9\ud806\udcd7\ud806\udcc1\ud806\udcdc\ud806\udcca".equalsIgnoreCase(
+              "\ud806\udcd9\ud806\udcd7\ud806\udcc1\ud806\udcdc\ud806\udcca"))
+      assertTrue(
+          // "𑢹𑣗𑣁𑣜𑣊" == "𑢹𑢷𑢡𑢼𑢪"; folding on the second code point and following
+          "\ud806\udcb9\ud806\udcd7\ud806\udcc1\ud806\udcdc\ud806\udcca".equalsIgnoreCase(
+              "\ud806\udcb9\ud806\udcb7\ud806\udca1\ud806\udcbc\ud806\udcaa"))
+      assertFalse(
+          // "𑢹𑣗𑣁𑣜𑣊" != "𑣙𑣗𑣁𑣏𑣊"; mimatch on the next-to-last code point
+          "\ud806\udcb9\ud806\udcd7\ud806\udcc1\ud806\udcdc\ud806\udcca".equalsIgnoreCase(
+              "\ud806\udcd9\ud806\udcd7\ud806\udcc1\ud806\udccf\ud806\udcca"))
+    }
   }
 
   @Test def compareTo(): Unit = {
@@ -77,6 +97,34 @@ class StringTest {
 
     // "ı" and 'i' are considered equal, as well as their uppercase variants
     assertEquals(0, "ıiIİ ıiIİ ıiIİ ıiIİ".compareToIgnoreCase("ıııı iiii IIII İİİİ"))
+
+    if (!executingInJVMOnLowerThanJDK(17)) {
+      // #5283 Case folding is done by code point
+
+      /* Letters from the Warang Citi script.
+       * "𑢹𑣗𑣁𑣜𑣊 𑣏𑣂𑣕𑣂" is the native name for "Warang Citi"
+       */
+      assertEquals(
+          // "𑢹𑣗𑣁𑣜𑣊" == "𑣙𑣗𑣁𑣜𑣊"; folding on the the first code point
+          0,
+          "\ud806\udcb9\ud806\udcd7\ud806\udcc1\ud806\udcdc\ud806\udcca".compareToIgnoreCase(
+              "\ud806\udcd9\ud806\udcd7\ud806\udcc1\ud806\udcdc\ud806\udcca"))
+      assertEquals(
+          // "𑢹𑣗𑣁𑣜𑣊" == "𑢹𑢷𑢡𑢼𑢪"; folding on the second code point and following
+          0,
+          "\ud806\udcb9\ud806\udcd7\ud806\udcc1\ud806\udcdc\ud806\udcca".compareToIgnoreCase(
+              "\ud806\udcb9\ud806\udcb7\ud806\udca1\ud806\udcbc\ud806\udcaa"))
+      assertEquals(
+          // "𑢹𑣗𑣁𑣜𑣊" > "𑣙𑣗𑣁𑣏𑣊"; mismatch on the next-to-last code point
+          13,
+          "\ud806\udcb9\ud806\udcd7\ud806\udcc1\ud806\udcdc\ud806\udcca".compareToIgnoreCase(
+              "\ud806\udcd9\ud806\udcd7\ud806\udcc1\ud806\udccf\ud806\udcca"))
+      assertEquals(
+          // "𑣙𑣗𑣁𑢯𑣊" < "𑢹𑣗𑣁𑣜𑣊"; mismatch on the next-to-last code point; diff on the folded CPs
+          -13,
+          "\ud806\udcd9\ud806\udcd7\ud806\udcc1\ud806\udcaf\ud806\udcca".compareToIgnoreCase(
+              "\ud806\udcb9\ud806\udcd7\ud806\udcc1\ud806\udcdc\ud806\udcca"))
+    }
   }
 
   @Test def isEmpty(): Unit = {
@@ -525,6 +573,32 @@ class StringTest {
     assertFalse(testU.regionMatches(true, 1, "bCdx", 0, 4))
     assertFalse(testU.regionMatches(true, 1, "bCdx", 1, 3))
     assertTrue(testU.regionMatches(true, 0, "xaBcd", 1, 4))
+
+    if (!executingInJVMOnLowerThanJDK(17)) {
+      // #5283 Case folding is done by code point
+
+      /* Letters from the Warang Citi script.
+       * "𑢹𑣗𑣁𑣜𑣊 𑣏𑣂𑣕𑣂" is the native name for "Warang Citi"
+       * Note that indices are expressed in chars, not in code points.
+       * For example, the chars [2:6) represent the code points [1:3) in these tests.
+       */
+      assertFalse(
+          // "𑢹𑣗𑣁𑣜𑣊"[0:4) != "𑣙𑣗𑣁𑣜𑢹"[0:4) case-sensitive
+          "\ud806\udcb9\ud806\udcd7\ud806\udcc1\ud806\udcdc\ud806\udcca".regionMatches(
+              false, 0, "\ud806\udcd9\ud806\udcd7\ud806\udcc1\ud806\udcdc\ud806\udcca", 0, 4))
+      assertTrue(
+          // "𑢹𑣗𑣁𑣜𑣊"[2:6) == "𑣙𑣗𑣁𑣜𑢹"[2:6) case-sensitive
+          "\ud806\udcb9\ud806\udcd7\ud806\udcc1\ud806\udcdc\ud806\udcca".regionMatches(
+              false, 2, "\ud806\udcd9\ud806\udcd7\ud806\udcc1\ud806\udcdc\ud806\udcca", 2, 4))
+      assertTrue(
+          // "𑢹𑣗𑣁𑣜𑣊"[0:4) == "𑣙𑣗𑣁𑣜𑢹"[0:4) case-insensitive
+          "\ud806\udcb9\ud806\udcd7\ud806\udcc1\ud806\udcdc\ud806\udcca".regionMatches(
+              true, 0, "\ud806\udcd9\ud806\udcd7\ud806\udcc1\ud806\udcdc\ud806\udcca", 0, 4))
+      assertTrue(
+          // "𑢹𑣗𑣁𑣜𑣊"[2:6) == "𑣙𑣗𑣁𑣜𑢹"[2:6) case-insensitive
+          "\ud806\udcb9\ud806\udcd7\ud806\udcc1\ud806\udcdc\ud806\udcca".regionMatches(
+              true, 2, "\ud806\udcd9\ud806\udcd7\ud806\udcc1\ud806\udcdc\ud806\udcca", 2, 4))
+    }
 
     /* If len is negative, you must return true in some cases. See
      * http://docs.oracle.com/javase/8/docs/api/java/lang/String.html#regionMatches-boolean-int-java.lang.String-int-int-


### PR DESCRIPTION
The implementation of `regionMatches` delegates to `equalsIgnoreCase`, which is why it needs no changes.