### PR TITLE
Use `Character.toString(codePoint)` in Formatter for 'c' conversion

### DIFF
--- a/javalib/src/main/scala/java/util/Formatter.scala
+++ b/javalib/src/main/scala/java/util/Formatter.scala
@@ -391,13 +391,7 @@ final class Formatter private (private[this] var dest: Appendable,
           case arg: Int =>
             if (!Character.isValidCodePoint(arg))
               throwIllegalFormatCodePointException(arg)
-            if (arg < Character.MIN_SUPPLEMENTARY_CODE_POINT) {
-              js.Dynamic.global.String.fromCharCode(arg).asInstanceOf[String]
-            } else {
-              js.Dynamic.global.String
-                .fromCharCode(0xd800 | ((arg >> 10) - (0x10000 >> 10)), 0xdc00 | (arg & 0x3ff))
-                .asInstanceOf[String]
-            }
+            Character.toString(arg)
           case _ =>
             illegalFormatConversion()
         }


### PR DESCRIPTION
The original code manually computed surrogate pairs for historical reasons, as `Character.toString(Int)` didn't exist at that time. `Character.toString(Int)` was added in 2020 https://github.com/scala-js/scala-js/commit/b7b3da033, while Formatter was rewritten in 2018 https://github.com/scala-js/scala-js/commit/ab1d39777.

Using `Character.toString` could lead to potential optimization with ES2015's `String.fromCodePoint()` or Wasm intrinsics by `OptimizerCore`.

Upstreamed the change from https://github.com/scala-wasm/scala-wasm/pull/165#discussion_r2705551823