### PR TITLE
Close #5311: Deprecate support for JDK < 17.

### DIFF
--- a/partest/src/main/scala/scala/tools/nsc/MainGenericRunner.scala
+++ b/partest/src/main/scala/scala/tools/nsc/MainGenericRunner.scala
@@ -86,7 +86,7 @@ class MainGenericRunner {
     if (command.howToRun != AsObject)
       return errorFn("Scala.js runner can only run an object")
 
-    val logger = new ScalaConsoleLogger(Level.Warn)
+    val logger = new ScalaConsoleLogger(Level.Error)
     val semantics0 = readSemantics()
     val semantics = if (optMode == FullOpt) semantics0.optimized else semantics0
 

--- a/sbt-plugin/src/main/scala/org/scalajs/sbtplugin/ScalaJSPlugin.scala
+++ b/sbt-plugin/src/main/scala/org/scalajs/sbtplugin/ScalaJSPlugin.scala
@@ -372,6 +372,21 @@ object ScalaJSPlugin extends AutoPlugin {
 
         scalaJSLoggerFactory := Loggers.sbtLogger2ToolsLogger _,
 
+        // Show a deprecation message if we load the build on JDK < 17
+        onLoad := {
+          onLoad.value.andThen { state =>
+            val fullVersion = System.getProperty("java.version")
+            val v = fullVersion.stripPrefix("1.").takeWhile(_.isDigit).toInt
+            if (v < 17) {
+              sLog.value.warn(
+                  s"Using sbt-scalajs on JDK $v is deprecated. " +
+                  "A future minor version will require at least JDK 17."
+              )
+            }
+            state
+          }
+        },
+
         // Clear the IR cache stats every time a sequence of tasks ends
         onComplete := {
           val prev = onComplete.value


### PR DESCRIPTION
We display a warning in two places:

* when loading an sbt build with sbt-scalajs, and
* when calling the `link` method of a `StandardLinkerImpl`.