### PR TITLE
In the javalib, always trigger UB for exceptions subject to UB.

### DIFF
--- a/javalib/src/main/scala/java/io/CharArrayReader.scala
+++ b/javalib/src/main/scala/java/io/CharArrayReader.scala
@@ -48,10 +48,10 @@ class CharArrayReader(protected var buf: Array[Char], offset: Int, length: Int) 
 
   override def read(buffer: Array[Char], offset: Int, len: Int): Int = {
     if (offset < 0 || offset > buffer.length)
-      throw new ArrayIndexOutOfBoundsException("Offset out of bounds : " + offset)
+      throw new IndexOutOfBoundsException("Offset out of bounds : " + offset)
 
     if (len < 0 || len > buffer.length - offset)
-      throw new ArrayIndexOutOfBoundsException("Length out of bounds : " + len)
+      throw new IndexOutOfBoundsException("Length out of bounds : " + len)
 
     ensureOpen()
 

--- a/javalib/src/main/scala/java/io/CharArrayReader.scala
+++ b/javalib/src/main/scala/java/io/CharArrayReader.scala
@@ -55,7 +55,9 @@ class CharArrayReader(protected var buf: Array[Char], offset: Int, length: Int) 
 
     ensureOpen()
 
-    if (this.pos < this.count) {
+    if (len == 0) {
+      0
+    } else if (this.pos < this.count) {
       val bytesRead = Math.min(len, this.count - this.pos)
       System.arraycopy(this.buf, this.pos, buffer, offset, bytesRead)
       this.pos += bytesRead

--- a/javalib/src/main/scala/java/io/CharArrayWriter.scala
+++ b/javalib/src/main/scala/java/io/CharArrayWriter.scala
@@ -58,7 +58,7 @@ class CharArrayWriter(initialSize: Int) extends Writer {
 
   override def write(str: String, offset: Int, len: Int): Unit = {
     if (offset < 0 || offset > str.length || len < 0 || len > str.length - offset)
-      throw new StringIndexOutOfBoundsException
+      throw new IndexOutOfBoundsException
 
     ensureCapacity(len)
     str.getChars(offset, offset + len, this.buf, this.count)

--- a/javalib/src/main/scala/java/lang/StringBuilder.scala
+++ b/javalib/src/main/scala/java/lang/StringBuilder.scala
@@ -25,8 +25,7 @@ class StringBuilder extends AnyRef with CharSequence with Appendable with java.i
 
   def this(initialCapacity: Int) = {
     this()
-    if (initialCapacity < 0)
-      throw new NegativeArraySizeException()
+    new Array[Char](initialCapacity) // NegativeArraySize check
   }
 
   def this(seq: CharSequence) = this(seq.toString)

--- a/javalib/src/main/scala/java/lang/StringBuilder.scala
+++ b/javalib/src/main/scala/java/lang/StringBuilder.scala
@@ -48,14 +48,23 @@ class StringBuilder extends AnyRef with CharSequence with Appendable with java.i
 
   def append(s: CharSequence): StringBuilder = append(s: AnyRef)
 
-  def append(s: CharSequence, start: Int, end: Int): StringBuilder =
-    append((if (s == null) "null" else s).subSequence(start, end))
+  def append(s: CharSequence, start: Int, end: Int): StringBuilder = {
+    val s2 = if (s == null) "null" else s
+    checkStartEnd(start, end, s2.length())
+    append(s2.subSequence(start, end).toString())
+  }
 
   def append(str: Array[scala.Char]): StringBuilder =
     append(String.valueOf(str))
 
-  def append(str: Array[scala.Char], offset: Int, len: Int): StringBuilder =
+  def append(str: Array[scala.Char], offset: Int, len: Int): StringBuilder = {
+    /* Since we check offset >= 0, if offset + len can only overflow from the
+     * positives into the negatives, in which case offset + len < offset, which
+     * is reported as well.
+     */
+    checkStartEnd(offset, offset + len, str.length)
     append(String.valueOf(str, offset, len))
+  }
 
   def append(b: scala.Boolean): StringBuilder = append(b.toString())
   def append(c: scala.Char): StringBuilder = append(c.toString())
@@ -73,10 +82,10 @@ class StringBuilder extends AnyRef with CharSequence with Appendable with java.i
   def deleteCharAt(index: Int): StringBuilder = {
     /* This is not equivalent to `delete(index, index + 1)` when
      * `index == length`.
+     *
+     * The two calls to substring imply the required bounds checks.
      */
     val oldContent = content
-    if (index < 0 || index >= oldContent.length)
-      throw new StringIndexOutOfBoundsException(index)
     content = oldContent.substring(0, index) + oldContent.substring(index + 1)
     this
   }
@@ -84,9 +93,12 @@ class StringBuilder extends AnyRef with CharSequence with Appendable with java.i
   def replace(start: Int, end: Int, str: String): StringBuilder = {
     val oldContent = content
     val length = oldContent.length
-    if (start < 0 || start > length || start > end)
-      throw new StringIndexOutOfBoundsException(start)
+
+    // The call to substring implies the bounds checks for 0 <= start <= length
     val firstPart = oldContent.substring(0, start) + str
+    if (end < start)
+      oldContent.charAt(-1)
+
     content =
       if (end >= length) firstPart
       else firstPart + oldContent.substring(end)
@@ -95,6 +107,7 @@ class StringBuilder extends AnyRef with CharSequence with Appendable with java.i
 
   def insert(index: Int, str: Array[scala.Char], offset: Int,
       len: Int): StringBuilder = {
+    // Surprisingly, this overload specifies a StringIOOBE.
     insert(index, String.valueOf(str, offset, len))
   }
 
@@ -102,9 +115,8 @@ class StringBuilder extends AnyRef with CharSequence with Appendable with java.i
     insert(offset, String.valueOf(obj))
 
   def insert(offset: Int, str: String): StringBuilder = {
+    // The first call to substring implies the required bounds checks
     val oldContent = content
-    if (offset < 0 || offset > oldContent.length)
-      throw new StringIndexOutOfBoundsException(offset)
     content =
       oldContent.substring(0, offset) + str + oldContent.substring(offset)
     this
@@ -113,19 +125,26 @@ class StringBuilder extends AnyRef with CharSequence with Appendable with java.i
   def insert(offset: Int, str: Array[scala.Char]): StringBuilder =
     insert(offset, String.valueOf(str))
 
-  def insert(dstOffset: Int, s: CharSequence): StringBuilder =
-    insert(dstOffset, s: AnyRef)
+  def insert(dstOffset: Int, s: CharSequence): StringBuilder = {
+    checkInsertOffset(dstOffset)
+    insert(dstOffset, String.valueOf(s))
+  }
 
   def insert(dstOffset: Int, s: CharSequence, start: Int,
       end: Int): StringBuilder = {
-    insert(dstOffset, (if (s == null) "null" else s).subSequence(start, end))
+    checkInsertOffset(dstOffset)
+    val s2 = if (s == null) "null" else s
+    checkStartEnd(start, end, s2.length())
+    insert(dstOffset, s2.subSequence(start, end).toString())
   }
 
   def insert(offset: Int, b: scala.Boolean): StringBuilder =
     insert(offset, b.toString)
 
-  def insert(offset: Int, c: scala.Char): StringBuilder =
+  def insert(offset: Int, c: scala.Char): StringBuilder = {
+    checkInsertOffset(offset)
     insert(offset, c.toString)
+  }
 
   def insert(offset: Int, i: scala.Int): StringBuilder =
     insert(offset, i.toString)
@@ -138,6 +157,28 @@ class StringBuilder extends AnyRef with CharSequence with Appendable with java.i
 
   def insert(offset: Int, d: scala.Double): StringBuilder =
     insert(offset, d.toString)
+
+  /** Explicitly checks an insertion offset.
+   *
+   *  Used by the overloads of insert() that specify IOOBE, instead of UB
+   *  StringIOOBE.
+   */
+  @inline
+  private def checkInsertOffset(offset: Int): Unit = {
+    if (offset < 0 || offset > content.length)
+      throw new IndexOutOfBoundsException(offset)
+  }
+
+  /** Explicitly checks start and end indices.
+   *
+   *  Used by the overloads of append() and insert() that specify IOOBE,
+   *  instead of UB StringIOOBE.
+   */
+  @inline
+  private def checkStartEnd(start: Int, end: Int, length: Int): Unit = {
+    if (start < 0 || start > end || end > length)
+      throw new IndexOutOfBoundsException()
+  }
 
   def indexOf(str: String): Int = content.indexOf(str)
 
@@ -186,20 +227,20 @@ class StringBuilder extends AnyRef with CharSequence with Appendable with java.i
   def trimToSize(): Unit = ()
 
   def setLength(newLength: Int): Unit = {
-    if (newLength < 0)
-      throw new StringIndexOutOfBoundsException(newLength)
     var newContent = content
-    val additional = newLength - newContent.length // cannot overflow
-    if (additional < 0) {
-      newContent = newContent.substring(0, newLength)
-    } else {
-      var i = 0
-      while (i != additional) {
+    var currentLength = newContent.length()
+
+    if (newLength >= currentLength) {
+      // Implies newLength >= 0, so bounds are OK
+      while (currentLength != newLength) {
         newContent += "\u0000"
-        i += 1
+        currentLength += 1
       }
+      content = newContent
+    } else {
+      // The call to substring implies the required bounds check
+      content = newContent.substring(0, newLength)
     }
-    content = newContent
   }
 
   def charAt(index: Int): Char = content.charAt(index)
@@ -220,9 +261,8 @@ class StringBuilder extends AnyRef with CharSequence with Appendable with java.i
   }
 
   def setCharAt(index: Int, ch: scala.Char): Unit = {
+    // The two calls to substring imply the required bounds checks.
     val oldContent = content
-    if (index < 0 || index >= oldContent.length)
-      throw new StringIndexOutOfBoundsException(index)
     content =
       oldContent.substring(0, index) + ch + oldContent.substring(index + 1)
   }

--- a/javalib/src/main/scala/java/lang/System.scala
+++ b/javalib/src/main/scala/java/lang/System.scala
@@ -91,8 +91,10 @@ object System {
 
     import scala.{Boolean, Char, Byte, Short, Int, Long, Float, Double}
 
-    def mismatch(): Nothing =
-      throw new ArrayStoreException("Incompatible array types")
+    def mismatch(): Unit = {
+      // Trigger an ArrayStoreException subject to UB.
+      new Array[String](1).asInstanceOf[Array[Object]](0) = Integer.valueOf(0)
+    }
 
     def impl(srcLen: Int, destLen: Int, f: BiConsumer[Int, Int]): Unit = {
       /* Perform dummy swaps to trigger an ArrayIndexOutOfBoundsException or

--- a/javalib/src/main/scala/java/lang/_String.scala
+++ b/javalib/src/main/scala/java/lang/_String.scala
@@ -216,10 +216,26 @@ final class _String private () // scalastyle:ignore
     res
   }
 
-  def getChars(srcBegin: Int, srcEnd: Int, dst: Array[Char],
-      dstBegin: Int): Unit = {
-    if (srcEnd > length() || srcBegin < 0 || srcEnd < 0 || srcBegin > srcEnd)
-      throw new StringIndexOutOfBoundsException("Index out of Bound")
+  def getChars(srcBegin: Int, srcEnd: Int, dst: Array[Char], dstBegin: Int): Unit = {
+    val dstLength = dst.length // implies null check
+
+    // Bounds checks on the source
+    if (srcEnd > length() || srcBegin < 0 || srcEnd < 0 || srcBegin > srcEnd) {
+      if (srcBegin < 0)
+        charAt(srcBegin)
+      if (srcEnd > length())
+        charAt(srcEnd)
+      charAt(-1)
+    }
+
+    /* Bounds checks on the destination.
+     * Intuitively, they should throw ArrayIOOBE. However, in practice, the JVM
+     * throws throws a StringIOOBE. We follow that behavior.
+     */
+    if (dstBegin < 0)
+      "".charAt(dstBegin)
+    if (dstBegin > dstLength - (srcEnd - srcBegin))
+      "".charAt(dstBegin + (srcEnd - srcBegin))
 
     val offset = dstBegin - srcBegin
     var i = srcBegin
@@ -967,10 +983,8 @@ object _String { // scalastyle:ignore
     `new`(value, 0, value.length)
 
   def `new`(value: Array[Char], offset: Int, count: Int): String = {
+    checkBoundsForNewFromArray(offset, count, value.length)
     val end = offset + count
-    if (offset < 0 || end < offset || end > value.length)
-      throw new StringIndexOutOfBoundsException
-
     var result = ""
     var i = offset
     while (i != end) {
@@ -1003,10 +1017,8 @@ object _String { // scalastyle:ignore
   }
 
   def `new`(codePoints: Array[Int], offset: Int, count: Int): String = {
+    checkBoundsForNewFromArray(offset, count, codePoints.length)
     val end = offset + count
-    if (offset < 0 || end < offset || end > codePoints.length)
-      throw new StringIndexOutOfBoundsException
-
     var result = ""
     var i = offset
     while (i != end) {
@@ -1027,6 +1039,21 @@ object _String { // scalastyle:ignore
 
   def `new`(builder: java.lang.StringBuilder): String =
     builder.toString
+
+  @inline
+  private def checkBoundsForNewFromArray(offset: Int, count: Int, arrayLength: Int): Unit = {
+    /* Publicly specified as throwing an IndexOutOfBoundsException.
+     * Intuitively, should throw an ArrayIOOBE. However, in practice, the JVM
+     * throws a StringIOOBE. We replicate that behavior.
+     */
+    if (offset < 0 || count < 0 || offset > arrayLength - count) {
+      if (offset < 0 || offset >= arrayLength)
+        "".charAt(offset)
+      if (count < 0)
+        "".charAt(count)
+      "".charAt(offset + count - 1)
+    }
+  }
 
   // Static methods (aka methods on the companion object)
 

--- a/javalib/src/main/scala/java/util/Arrays.scala
+++ b/javalib/src/main/scala/java/util/Arrays.scala
@@ -456,7 +456,6 @@ object Arrays {
   @inline
   private def copyOfImpl[U, T](original: Array[U], newLength: Int)(
       implicit uops: ArrayOps[U], tops: ArrayCreateOps[T]): Array[T] = {
-    checkArrayLength(newLength)
     val copyLength = Math.min(newLength, uops.length(original))
     val ret = tops.create(newLength)
     System.arraycopy(original, 0, ret, 0, copyLength)
@@ -510,11 +509,6 @@ object Arrays {
     val ret = tops.create(retLength)
     System.arraycopy(original, start, ret, 0, copyLength)
     ret
-  }
-
-  @inline private def checkArrayLength(len: Int): Unit = {
-    if (len < 0)
-      throw new NegativeArraySizeException
   }
 
   @noinline def asList[T <: AnyRef](a: Array[T]): List[T] = {

--- a/javalib/src/main/scala/java/util/BitSet.scala
+++ b/javalib/src/main/scala/java/util/BitSet.scala
@@ -70,11 +70,8 @@ class BitSet private (private var bits: Array[Int]) extends Serializable with Cl
   def this(nbits: Int) = {
     this(
       bits = {
-        if (nbits < 0)
-          throw new NegativeArraySizeException
-
+        new Array[Int](nbits) // NegativeArraySize check
         val length = (nbits + BitSet.RightBits) >> BitSet.AddressBitsPerWord
-
         new Array[Int](length)
       }
     )

--- a/linker/shared/src/main/scala/org/scalajs/linker/backend/emitter/FunctionEmitter.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/backend/emitter/FunctionEmitter.scala
@@ -938,6 +938,19 @@ private[emitter] class FunctionEmitter(sjsGen: SJSGen) {
         case Return(expr, label) =>
           pushLhsInto(Lhs.Return(label), expr, tailPosLabels)
 
+        case Transient(CheckArrayLength(length)) =>
+          unnest(length) { (newLength, env0) =>
+            implicit val env = env0
+            val jsLength = transformExprNoChar(newLength)
+
+            if (semantics.negativeArraySizes != CheckedBehavior.Unchecked) {
+              js.If(jsLength < js.IntLiteral(0),
+                  genCallHelper(VarField.throwNegativeArraySizeException))
+            } else {
+              jsLength
+            }
+          }
+
         case Transient(SystemArrayCopy(src, srcPos, dest, destPos, length)) =>
           unnest(List(src, srcPos, dest, destPos, length)) { (newArgs, env0) =>
             implicit val env = env0
@@ -2377,7 +2390,7 @@ private[emitter] class FunctionEmitter(sjsGen: SJSGen) {
 
         case _:Skip | _:VarDef | _:Assign | _:While | _:Debugger |
             _:JSSuperConstructorCall | _:JSDelete | _:StoreModule |
-            Transient(_: SystemArrayCopy) =>
+            Transient(_:CheckArrayLength | _:SystemArrayCopy) =>
           /* Go "back" to transformStat() after having dived into
            * expression statements. This can only happen for Lhs.Discard and
            * for Lhs.Return's whose target is a statement.

--- a/linker/shared/src/main/scala/org/scalajs/linker/backend/emitter/Transients.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/backend/emitter/Transients.scala
@@ -96,6 +96,31 @@ object Transients {
     }
   }
 
+  /** Check an array length as a statement.
+   *
+   *  This node is produced by the optimizer when a NewArray ends up in
+   *  statement position. We then only need to check the array length, but not
+   *  actually allocate the array.
+   *
+   *  This is important because we intentionally use `new Array[x](n)` in
+   *  statement position to trigger NegativeArraySizeException's subject to UB.
+   */
+  final case class CheckArrayLength(length: Tree) extends Transient.Value {
+    val tpe: Type = VoidType
+
+    def traverse(traverser: Traverser): Unit =
+      traverser.traverse(length)
+
+    def transform(t: Transformer)(implicit pos: Position): Tree =
+      Transient(CheckArrayLength(t.transform(length)))
+
+    def printIR(out: IRTreePrinter): Unit = {
+      out.print("$checkArrayLength(")
+      out.print(length)
+      out.print(")")
+    }
+  }
+
   /** Intrinsic for `System.arraycopy`.
    *
    *  This node *assumes* that `src` and `dest` are non-null. It is the

--- a/linker/shared/src/main/scala/org/scalajs/linker/backend/wasmemitter/FunctionEmitter.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/backend/wasmemitter/FunctionEmitter.scala
@@ -3571,6 +3571,26 @@ private class FunctionEmitter private (
       case Transients.Cast(expr, tpe) =>
         genCast(expr, tpe, tree.pos)
 
+      case Transients.CheckArrayLength(length) =>
+        if (semantics.negativeArraySizes == CheckedBehavior.Unchecked) {
+          genTree(length, VoidType)
+        } else {
+          // if length < 0
+          genTree(length, IntType)
+          markPosition(tree)
+          val lengthLocal = addSyntheticLocal(watpe.Int32)
+          fb += wa.LocalTee(lengthLocal)
+          fb += wa.I32Const(0)
+          fb += wa.I32LtS
+          fb.ifThen() {
+            // then throw NegativeArraySizeException
+            fb += wa.LocalGet(lengthLocal)
+            fb += wa.Call(genFunctionID.throwNegativeArraySizeException)
+            fb += wa.Unreachable
+          }
+        }
+        VoidType
+
       case value: Transients.SystemArrayCopy =>
         genSystemArrayCopy(tree, value)
 

--- a/linker/shared/src/main/scala/org/scalajs/linker/frontend/optimizer/OptimizerCore.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/frontend/optimizer/OptimizerCore.scala
@@ -1844,10 +1844,13 @@ private[optimizer] abstract class OptimizerCore(
     case LoadModule(moduleClassName) =>
       if (hasElidableConstructors(moduleClassName)) Skip()(stat.pos)
       else stat
-    case NewArray(_, length) if isNonNegativeIntLiteral(length) =>
-      Skip()(stat.pos)
-    case NewArray(_, length) if semantics.negativeArraySizes == CheckedBehavior.Unchecked =>
-      keepOnlySideEffects(length)
+    case NewArray(_, length) =>
+      if (isNonNegativeIntLiteral(length))
+        Skip()(stat.pos)
+      else if (semantics.negativeArraySizes == CheckedBehavior.Unchecked)
+        keepOnlySideEffects(length)
+      else
+        Transient(CheckArrayLength(length))(stat.pos)
     case ArrayValue(_, elems) =>
       Block(elems.map(keepOnlySideEffects(_)))(stat.pos)
     case ArraySelect(array, index)

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -2074,15 +2074,15 @@ object Build {
           case `default212Version` =>
             if (!useMinifySizes) {
               Some(ExpectedSizes(
-                  fastLink = 620000 to 621000,
-                  fullLink = 284000 to 285000,
-                  fastLinkGz = 75000 to 79000,
+                  fastLink = 619000 to 620000,
+                  fullLink = 283000 to 284000,
+                  fastLinkGz = 75000 to 76000,
                   fullLinkGz = 43000 to 44000,
               ))
             } else {
               Some(ExpectedSizes(
                   fastLink = 425000 to 426000,
-                  fullLink = 284000 to 285000,
+                  fullLink = 283000 to 284000,
                   fastLinkGz = 61000 to 62000,
                   fullLinkGz = 43000 to 44000,
               ))

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -2092,14 +2092,14 @@ object Build {
             if (!useMinifySizes) {
               Some(ExpectedSizes(
                   fastLink = 438000 to 439000,
-                  fullLink = 263000 to 264000,
+                  fullLink = 262000 to 263000,
                   fastLinkGz = 57000 to 58000,
                   fullLinkGz = 43000 to 44000,
               ))
             } else {
               Some(ExpectedSizes(
                   fastLink = 304000 to 305000,
-                  fullLink = 263000 to 264000,
+                  fullLink = 262000 to 263000,
                   fastLinkGz = 48000 to 49000,
                   fullLinkGz = 43000 to 44000,
               ))

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/io/CharArrayReaderTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/io/CharArrayReaderTest.scala
@@ -87,8 +87,15 @@ class CharArrayReaderTest {
   @Test def readCharArray(): Unit = {
     withClose(new CharArrayReader(hw)) { cr =>
       val c = new Array[Char](11)
-      cr.read(c, 1, 10)
-      assertArrayEquals(Array(0.toChar) ++ hw, c)
+      assertEquals(4, cr.read(c, 1, 4))
+      assertEquals("\u0000Hell" + "\u0000" * 6, String.valueOf(c))
+      assertEquals(0, cr.read(c, 3, 0))
+      assertThrows(classOf[IndexOutOfBoundsException], cr.read(c, 3, 10))
+      assertEquals("\u0000Hell" + "\u0000" * 6, String.valueOf(c))
+      assertEquals(6, cr.read(c, 3, 8))
+      assertEquals("\u0000HeoWorld" + "\u0000" * 2, String.valueOf(c))
+      assertEquals(-1, cr.read(c, 3, 1))
+      assertEquals(0, cr.read(c, 3, 0))
     }
   }
 

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/io/CharArrayWriterTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/io/CharArrayWriterTest.scala
@@ -116,6 +116,11 @@ class CharArrayWriterTest {
       cw.write("HelloWorld", 5, 5)
       assertEquals("World", cw.toString)
       assertArrayEquals("World".toCharArray, cw.toCharArray)
+
+      assertThrows(classOf[IndexOutOfBoundsException], cw.write("foo", 1, 3))
+      assertThrows(classOf[IndexOutOfBoundsException], cw.write("foo", -1, 3))
+      assertThrows(classOf[IndexOutOfBoundsException], cw.write("foo", 2, -1))
+      assertArrayEquals("World".toCharArray, cw.toCharArray)
     }
   }
 

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/lang/StringBufferTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/lang/StringBufferTest.scala
@@ -15,7 +15,7 @@ package org.scalajs.testsuite.javalib.lang
 import org.junit.Test
 import org.junit.Assert._
 
-import org.scalajs.testsuite.utils.AssertThrows.assertThrows
+import org.scalajs.testsuite.utils.AssertThrows.{assertThrows, _}
 import org.scalajs.testsuite.utils.Platform.executingInJVM
 
 import WrappedStringCharSequence.charSequence
@@ -167,10 +167,8 @@ class StringBufferTest {
     assertEquals("hello", resultFor("hello", 5, 5))
     assertEquals("hel", resultFor("hello", 3, 8))
 
-    assertThrows(classOf[StringIndexOutOfBoundsException],
-        resultFor("hello", -1, 2))
-    assertThrows(classOf[StringIndexOutOfBoundsException],
-        resultFor("hello", 3, 2))
+    assertThrowsStringIIOBEIfCompliant(resultFor("hello", -1, 2))
+    assertThrowsStringIIOBEIfCompliant(resultFor("hello", 3, 2))
   }
 
   @Test def deleteCharAt(): Unit = {
@@ -181,10 +179,8 @@ class StringBufferTest {
     assertEquals("123", resultFor("0123", 0))
     assertEquals("012", resultFor("0123", 3))
 
-    assertThrows(classOf[StringIndexOutOfBoundsException],
-        resultFor("0123", -1))
-    assertThrows(classOf[StringIndexOutOfBoundsException],
-        resultFor("0123", 4))
+    assertThrowsStringIIOBEIfCompliant(resultFor("0123", -1))
+    assertThrowsStringIIOBEIfCompliant(resultFor("0123", 4))
   }
 
   @Test def replace(): Unit = {
@@ -199,12 +195,9 @@ class StringBufferTest {
     assertEquals("0xxxx123", resultFor("0123", 1, 1, "xxxx"))
     assertEquals("0123x", resultFor("0123", 4, 5, "x"))
 
-    assertThrows(classOf[StringIndexOutOfBoundsException],
-        resultFor("0123", -1, 3, "x"))
-    assertThrows(classOf[StringIndexOutOfBoundsException],
-        resultFor("0123", 4, 3, "x"))
-    assertThrows(classOf[StringIndexOutOfBoundsException],
-        resultFor("0123", 5, 8, "x"))
+    assertThrowsStringIIOBEIfCompliant(resultFor("0123", -1, 3, "x"))
+    assertThrowsStringIIOBEIfCompliant(resultFor("0123", 4, 3, "x"))
+    assertThrowsStringIIOBEIfCompliant(resultFor("0123", 5, 8, "x"))
 
     if (executingInJVM)
       assertThrows(classOf[NullPointerException], resultFor("0123", 1, 3, null))
@@ -221,16 +214,12 @@ class StringBufferTest {
     assertEquals("0bc12", resultFor("012", 1, arr, 1, 2))
     assertEquals("abcdef", resultFor("abef", 2, arr, 2, 2))
 
-    assertThrows(classOf[StringIndexOutOfBoundsException],
-        resultFor("1234", -1, arr, 1, 2))
-    assertThrows(classOf[StringIndexOutOfBoundsException],
-        resultFor("1234", 6, arr, 1, 2))
-    assertThrows(classOf[StringIndexOutOfBoundsException],
-        resultFor("1234", 1, arr, -1, 2))
-    assertThrows(classOf[StringIndexOutOfBoundsException],
-        resultFor("1234", 1, arr, 1, -2))
-    assertThrows(classOf[StringIndexOutOfBoundsException],
-        resultFor("1234", 1, arr, 4, 3))
+    // Surprisingly, this overload specifies a StringIOOBE.
+    assertThrowsStringIIOBEIfCompliant(resultFor("1234", -1, arr, 1, 2))
+    assertThrowsStringIIOBEIfCompliant(resultFor("1234", 6, arr, 1, 2))
+    assertThrowsStringIIOBEIfCompliant(resultFor("1234", 1, arr, -1, 2))
+    assertThrowsStringIIOBEIfCompliant(resultFor("1234", 1, arr, 1, -2))
+    assertThrowsStringIIOBEIfCompliant(resultFor("1234", 1, arr, 4, 3))
 
     if (executingInJVM) {
       assertThrows(classOf[NullPointerException],
@@ -247,10 +236,8 @@ class StringBufferTest {
     assertEquals("01hello234", resultFor("01234", 2, "hello"))
     assertEquals("01foobar234", resultFor("01234", 2, charSequence("foobar")))
 
-    assertThrows(classOf[StringIndexOutOfBoundsException],
-        resultFor("1234", -1, "foo"))
-    assertThrows(classOf[StringIndexOutOfBoundsException],
-        resultFor("1234", 6, "foo"))
+    assertThrowsStringIIOBEIfCompliant(resultFor("1234", -1, "foo"))
+    assertThrowsStringIIOBEIfCompliant(resultFor("1234", 6, "foo"))
   }
 
   @Test def insertString(): Unit = {
@@ -260,10 +247,8 @@ class StringBufferTest {
     assertEquals("01null234", resultFor("01234", 2, null))
     assertEquals("01hello234", resultFor("01234", 2, "hello"))
 
-    assertThrows(classOf[StringIndexOutOfBoundsException],
-        resultFor("1234", -1, "foo"))
-    assertThrows(classOf[StringIndexOutOfBoundsException],
-        resultFor("1234", 6, "foo"))
+    assertThrowsStringIIOBEIfCompliant(resultFor("1234", -1, "foo"))
+    assertThrowsStringIIOBEIfCompliant(resultFor("1234", 6, "foo"))
   }
 
   @Test def insertCharArray(): Unit = {
@@ -275,10 +260,8 @@ class StringBufferTest {
     assertEquals("0abcde12", resultFor("012", 1, arr))
     assertEquals("ababcdeef", resultFor("abef", 2, arr))
 
-    assertThrows(classOf[StringIndexOutOfBoundsException],
-        resultFor("1234", -1, arr))
-    assertThrows(classOf[StringIndexOutOfBoundsException],
-        resultFor("1234", 6, arr))
+    assertThrowsStringIIOBEIfCompliant(resultFor("1234", -1, arr))
+    assertThrowsStringIIOBEIfCompliant(resultFor("1234", 6, arr))
 
     if (executingInJVM)
       assertThrows(classOf[NullPointerException], resultFor("1234", 1, null))
@@ -337,10 +320,8 @@ class StringBufferTest {
     assertEquals("a4bcd", initBuffer("abcd").insert(1, 4.toByte).toString)
     assertEquals("a304bcd", initBuffer("abcd").insert(1, 304.toShort).toString)
 
-    assertThrows(classOf[StringIndexOutOfBoundsException],
-        initBuffer("abcd").insert(5, 56))
-    assertThrows(classOf[StringIndexOutOfBoundsException],
-        initBuffer("abcd").insert(-1, 56))
+    assertThrowsStringIIOBEIfCompliant(initBuffer("abcd").insert(5, 56))
+    assertThrowsStringIIOBEIfCompliant(initBuffer("abcd").insert(-1, 56))
   }
 
   @Test def indexOfString(): Unit = {
@@ -419,7 +400,7 @@ class StringBufferTest {
   @Test def setLength(): Unit = {
     val b = initBuffer("foobar")
 
-    assertThrows(classOf[StringIndexOutOfBoundsException], b.setLength(-3))
+    assertThrowsStringIIOBEIfCompliant(b.setLength(-3))
 
     b.setLength(3)
     assertEquals("foo", b.toString)
@@ -435,11 +416,9 @@ class StringBufferTest {
     assertEquals('\ud801', resultFor("ab\ud801\udc02cd", 2))
     assertEquals('\udc02', resultFor("ab\ud801\udc02cd", 3))
 
-    if (executingInJVM) {
-      assertThrows(classOf[IndexOutOfBoundsException], resultFor("hello", -1))
-      assertThrows(classOf[IndexOutOfBoundsException], resultFor("hello", 5))
-      assertThrows(classOf[IndexOutOfBoundsException], resultFor("hello", 6))
-    }
+    assertThrowsStringIIOBEIfCompliant(resultFor("hello", -1))
+    assertThrowsStringIIOBEIfCompliant(resultFor("hello", 5))
+    assertThrowsStringIIOBEIfCompliant(resultFor("hello", 6))
   }
 
   @Test def codePointAt(): Unit = {
@@ -456,12 +435,8 @@ class StringBufferTest {
     assertEquals(0xdf06, resultFor("\udf06abc", 0))
     assertEquals(0xd834, resultFor("abc\ud834", 3))
 
-    if (executingInJVM) {
-      assertThrows(classOf[IndexOutOfBoundsException],
-          resultFor("abc\ud834\udf06def", -1))
-      assertThrows(classOf[IndexOutOfBoundsException],
-          resultFor("abc\ud834\udf06def", 15))
-    }
+    assertThrowsStringIIOBEIfCompliant(resultFor("abc\ud834\udf06def", -1))
+    assertThrowsStringIIOBEIfCompliant(resultFor("abc\ud834\udf06def", 15))
   }
 
   @Test def codePointBefore(): Unit = {
@@ -477,12 +452,8 @@ class StringBufferTest {
     assertEquals(0xd834, resultFor("\ud834abc", 1))
     assertEquals(0xdf06, resultFor("\udf06abc", 1))
 
-    if (executingInJVM) {
-      assertThrows(classOf[IndexOutOfBoundsException],
-          resultFor("abc\ud834\udf06def", 0))
-      assertThrows(classOf[IndexOutOfBoundsException],
-          resultFor("abc\ud834\udf06def", 15))
-    }
+    assertThrowsStringIIOBEIfCompliant(resultFor("abc\ud834\udf06def", 0))
+    assertThrowsStringIIOBEIfCompliant(resultFor("abc\ud834\udf06def", 15))
   }
 
   @Test def codePointCount(): Unit = {
@@ -568,10 +539,8 @@ class StringBufferTest {
     assertEquals("foxbar", resultFor("foobar", 2, 'x'))
     assertEquals("foobah", resultFor("foobar", 5, 'h'))
 
-    assertThrows(classOf[StringIndexOutOfBoundsException],
-        resultFor("foobar", -1, 'h'))
-    assertThrows(classOf[StringIndexOutOfBoundsException],
-        resultFor("foobar", 6, 'h'))
+    assertThrowsStringIIOBEIfCompliant(resultFor("foobar", -1, 'h'))
+    assertThrowsStringIIOBEIfCompliant(resultFor("foobar", 6, 'h'))
   }
 
   @Test def substringStart(): Unit = {
@@ -581,12 +550,8 @@ class StringBufferTest {
     assertEquals("llo", resultFor("hello", 2))
     assertEquals("", resultFor("hello", 5))
 
-    if (executingInJVM) {
-      assertThrows(classOf[StringIndexOutOfBoundsException],
-          resultFor("hello", -1))
-      assertThrows(classOf[StringIndexOutOfBoundsException],
-          resultFor("hello", 8))
-    }
+    assertThrowsStringIIOBEIfCompliant(resultFor("hello", -1))
+    assertThrowsStringIIOBEIfCompliant(resultFor("hello", 8))
   }
 
   @Test def subSequence(): Unit = {
@@ -601,16 +566,10 @@ class StringBufferTest {
     assertEquals("", resultFor("hello", 5, 5))
     assertEquals("hel", resultFor("hello", 0, 3))
 
-    if (executingInJVM) {
-      assertThrows(classOf[StringIndexOutOfBoundsException],
-          resultFor("hello", -1, 3))
-      assertThrows(classOf[StringIndexOutOfBoundsException],
-          resultFor("hello", 8, 8))
-      assertThrows(classOf[StringIndexOutOfBoundsException],
-          resultFor("hello", 3, 2))
-      assertThrows(classOf[StringIndexOutOfBoundsException],
-          resultFor("hello", 3, 8))
-    }
+    assertThrowsStringIIOBEIfCompliant(resultFor("hello", -1, 3))
+    assertThrowsStringIIOBEIfCompliant(resultFor("hello", 8, 8))
+    assertThrowsStringIIOBEIfCompliant(resultFor("hello", 3, 2))
+    assertThrowsStringIIOBEIfCompliant(resultFor("hello", 3, 8))
   }
 
   @Test def substringStartEnd(): Unit = {
@@ -621,15 +580,9 @@ class StringBufferTest {
     assertEquals("", resultFor("hello", 5, 5))
     assertEquals("hel", resultFor("hello", 0, 3))
 
-    if (executingInJVM) {
-      assertThrows(classOf[StringIndexOutOfBoundsException],
-          resultFor("hello", -1, 3))
-      assertThrows(classOf[StringIndexOutOfBoundsException],
-          resultFor("hello", 8, 8))
-      assertThrows(classOf[StringIndexOutOfBoundsException],
-          resultFor("hello", 3, 2))
-      assertThrows(classOf[StringIndexOutOfBoundsException],
-          resultFor("hello", 3, 8))
-    }
+    assertThrowsStringIIOBEIfCompliant(resultFor("hello", -1, 3))
+    assertThrowsStringIIOBEIfCompliant(resultFor("hello", 8, 8))
+    assertThrowsStringIIOBEIfCompliant(resultFor("hello", 3, 2))
+    assertThrowsStringIIOBEIfCompliant(resultFor("hello", 3, 8))
   }
 }

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/lang/StringBufferTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/lang/StringBufferTest.scala
@@ -34,8 +34,11 @@ class StringBufferTest {
   @Test def init(): Unit =
     assertEquals("", new StringBuffer().toString())
 
-  @Test def initInt(): Unit =
+  @Test def initInt(): Unit = {
     assertEquals("", new StringBuffer(5).toString())
+
+    assertThrowsNegArraySizeIfCompliant(new StringBuffer(-3))
+  }
 
   @Test def initString(): Unit = {
     assertEquals("hello", new StringBuffer("hello").toString())

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/lang/StringBuilderTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/lang/StringBuilderTest.scala
@@ -17,7 +17,7 @@ import java.lang.StringBuilder
 import org.junit.Test
 import org.junit.Assert._
 
-import org.scalajs.testsuite.utils.AssertThrows.assertThrows
+import org.scalajs.testsuite.utils.AssertThrows.{assertThrows, _}
 import org.scalajs.testsuite.utils.Platform.executingInJVM
 
 import WrappedStringCharSequence.charSequence
@@ -169,10 +169,8 @@ class StringBuilderTest {
     assertEquals("hello", resultFor("hello", 5, 5))
     assertEquals("hel", resultFor("hello", 3, 8))
 
-    assertThrows(classOf[StringIndexOutOfBoundsException],
-        resultFor("hello", -1, 2))
-    assertThrows(classOf[StringIndexOutOfBoundsException],
-        resultFor("hello", 3, 2))
+    assertThrowsStringIIOBEIfCompliant(resultFor("hello", -1, 2))
+    assertThrowsStringIIOBEIfCompliant(resultFor("hello", 3, 2))
   }
 
   @Test def deleteCharAt(): Unit = {
@@ -183,10 +181,8 @@ class StringBuilderTest {
     assertEquals("123", resultFor("0123", 0))
     assertEquals("012", resultFor("0123", 3))
 
-    assertThrows(classOf[StringIndexOutOfBoundsException],
-        resultFor("0123", -1))
-    assertThrows(classOf[StringIndexOutOfBoundsException],
-        resultFor("0123", 4))
+    assertThrowsStringIIOBEIfCompliant(resultFor("0123", -1))
+    assertThrowsStringIIOBEIfCompliant(resultFor("0123", 4))
   }
 
   @Test def replace(): Unit = {
@@ -201,12 +197,9 @@ class StringBuilderTest {
     assertEquals("0xxxx123", resultFor("0123", 1, 1, "xxxx"))
     assertEquals("0123x", resultFor("0123", 4, 5, "x"))
 
-    assertThrows(classOf[StringIndexOutOfBoundsException],
-        resultFor("0123", -1, 3, "x"))
-    assertThrows(classOf[StringIndexOutOfBoundsException],
-        resultFor("0123", 4, 3, "x"))
-    assertThrows(classOf[StringIndexOutOfBoundsException],
-        resultFor("0123", 5, 8, "x"))
+    assertThrowsStringIIOBEIfCompliant(resultFor("0123", -1, 3, "x"))
+    assertThrowsStringIIOBEIfCompliant(resultFor("0123", 4, 3, "x"))
+    assertThrowsStringIIOBEIfCompliant(resultFor("0123", 5, 8, "x"))
 
     if (executingInJVM)
       assertThrows(classOf[NullPointerException], resultFor("0123", 1, 3, null))
@@ -223,16 +216,12 @@ class StringBuilderTest {
     assertEquals("0bc12", resultFor("012", 1, arr, 1, 2))
     assertEquals("abcdef", resultFor("abef", 2, arr, 2, 2))
 
-    assertThrows(classOf[StringIndexOutOfBoundsException],
-        resultFor("1234", -1, arr, 1, 2))
-    assertThrows(classOf[StringIndexOutOfBoundsException],
-        resultFor("1234", 6, arr, 1, 2))
-    assertThrows(classOf[StringIndexOutOfBoundsException],
-        resultFor("1234", 1, arr, -1, 2))
-    assertThrows(classOf[StringIndexOutOfBoundsException],
-        resultFor("1234", 1, arr, 1, -2))
-    assertThrows(classOf[StringIndexOutOfBoundsException],
-        resultFor("1234", 1, arr, 4, 3))
+    // Surprisingly, this overload specifies a StringIOOBE.
+    assertThrowsStringIIOBEIfCompliant(resultFor("1234", -1, arr, 1, 2))
+    assertThrowsStringIIOBEIfCompliant(resultFor("1234", 6, arr, 1, 2))
+    assertThrowsStringIIOBEIfCompliant(resultFor("1234", 1, arr, -1, 2))
+    assertThrowsStringIIOBEIfCompliant(resultFor("1234", 1, arr, 1, -2))
+    assertThrowsStringIIOBEIfCompliant(resultFor("1234", 1, arr, 4, 3))
 
     if (executingInJVM) {
       assertThrows(classOf[NullPointerException],
@@ -249,10 +238,8 @@ class StringBuilderTest {
     assertEquals("01hello234", resultFor("01234", 2, "hello"))
     assertEquals("01foobar234", resultFor("01234", 2, charSequence("foobar")))
 
-    assertThrows(classOf[StringIndexOutOfBoundsException],
-        resultFor("1234", -1, "foo"))
-    assertThrows(classOf[StringIndexOutOfBoundsException],
-        resultFor("1234", 6, "foo"))
+    assertThrowsStringIIOBEIfCompliant(resultFor("1234", -1, "foo"))
+    assertThrowsStringIIOBEIfCompliant(resultFor("1234", 6, "foo"))
   }
 
   @Test def insertString(): Unit = {
@@ -262,10 +249,8 @@ class StringBuilderTest {
     assertEquals("01null234", resultFor("01234", 2, null))
     assertEquals("01hello234", resultFor("01234", 2, "hello"))
 
-    assertThrows(classOf[StringIndexOutOfBoundsException],
-        resultFor("1234", -1, "foo"))
-    assertThrows(classOf[StringIndexOutOfBoundsException],
-        resultFor("1234", 6, "foo"))
+    assertThrowsStringIIOBEIfCompliant(resultFor("1234", -1, "foo"))
+    assertThrowsStringIIOBEIfCompliant(resultFor("1234", 6, "foo"))
   }
 
   @Test def insertCharArray(): Unit = {
@@ -277,10 +262,8 @@ class StringBuilderTest {
     assertEquals("0abcde12", resultFor("012", 1, arr))
     assertEquals("ababcdeef", resultFor("abef", 2, arr))
 
-    assertThrows(classOf[StringIndexOutOfBoundsException],
-        resultFor("1234", -1, arr))
-    assertThrows(classOf[StringIndexOutOfBoundsException],
-        resultFor("1234", 6, arr))
+    assertThrowsStringIIOBEIfCompliant(resultFor("1234", -1, arr))
+    assertThrowsStringIIOBEIfCompliant(resultFor("1234", 6, arr))
 
     if (executingInJVM)
       assertThrows(classOf[NullPointerException], resultFor("1234", 1, null))
@@ -339,10 +322,8 @@ class StringBuilderTest {
     assertEquals("a4bcd", initBuilder("abcd").insert(1, 4.toByte).toString)
     assertEquals("a304bcd", initBuilder("abcd").insert(1, 304.toShort).toString)
 
-    assertThrows(classOf[StringIndexOutOfBoundsException],
-        initBuilder("abcd").insert(5, 56))
-    assertThrows(classOf[StringIndexOutOfBoundsException],
-        initBuilder("abcd").insert(-1, 56))
+    assertThrowsStringIIOBEIfCompliant(initBuilder("abcd").insert(5, 56))
+    assertThrowsStringIIOBEIfCompliant(initBuilder("abcd").insert(-1, 56))
   }
 
   @Test def indexOfString(): Unit = {
@@ -421,7 +402,7 @@ class StringBuilderTest {
   @Test def setLength(): Unit = {
     val b = initBuilder("foobar")
 
-    assertThrows(classOf[StringIndexOutOfBoundsException], b.setLength(-3))
+    assertThrowsStringIIOBEIfCompliant(b.setLength(-3))
 
     b.setLength(3)
     assertEquals("foo", b.toString)
@@ -437,11 +418,9 @@ class StringBuilderTest {
     assertEquals('\ud801', resultFor("ab\ud801\udc02cd", 2))
     assertEquals('\udc02', resultFor("ab\ud801\udc02cd", 3))
 
-    if (executingInJVM) {
-      assertThrows(classOf[IndexOutOfBoundsException], resultFor("hello", -1))
-      assertThrows(classOf[IndexOutOfBoundsException], resultFor("hello", 5))
-      assertThrows(classOf[IndexOutOfBoundsException], resultFor("hello", 6))
-    }
+    assertThrowsStringIIOBEIfCompliant(resultFor("hello", -1))
+    assertThrowsStringIIOBEIfCompliant(resultFor("hello", 5))
+    assertThrowsStringIIOBEIfCompliant(resultFor("hello", 6))
   }
 
   @Test def codePointAt(): Unit = {
@@ -458,12 +437,8 @@ class StringBuilderTest {
     assertEquals(0xdf06, resultFor("\udf06abc", 0))
     assertEquals(0xd834, resultFor("abc\ud834", 3))
 
-    if (executingInJVM) {
-      assertThrows(classOf[IndexOutOfBoundsException],
-          resultFor("abc\ud834\udf06def", -1))
-      assertThrows(classOf[IndexOutOfBoundsException],
-          resultFor("abc\ud834\udf06def", 15))
-    }
+    assertThrowsStringIIOBEIfCompliant(resultFor("abc\ud834\udf06def", -1))
+    assertThrowsStringIIOBEIfCompliant(resultFor("abc\ud834\udf06def", 15))
   }
 
   @Test def codePointBefore(): Unit = {
@@ -479,12 +454,8 @@ class StringBuilderTest {
     assertEquals(0xd834, resultFor("\ud834abc", 1))
     assertEquals(0xdf06, resultFor("\udf06abc", 1))
 
-    if (executingInJVM) {
-      assertThrows(classOf[IndexOutOfBoundsException],
-          resultFor("abc\ud834\udf06def", 0))
-      assertThrows(classOf[IndexOutOfBoundsException],
-          resultFor("abc\ud834\udf06def", 15))
-    }
+    assertThrowsStringIIOBEIfCompliant(resultFor("abc\ud834\udf06def", 0))
+    assertThrowsStringIIOBEIfCompliant(resultFor("abc\ud834\udf06def", 15))
   }
 
   @Test def codePointCount(): Unit = {
@@ -505,6 +476,7 @@ class StringBuilderTest {
     assertEquals(0, sb.codePointCount(sb.length - 1, sb.length - 1))
     assertEquals(0, sb.codePointCount(sb.length, sb.length))
 
+    // Actually mandated IOOBE, not StringIIOBE
     assertThrows(classOf[IndexOutOfBoundsException], sb.codePointCount(-3, 4))
     assertThrows(classOf[IndexOutOfBoundsException], sb.codePointCount(6, 2))
     assertThrows(classOf[IndexOutOfBoundsException], sb.codePointCount(10, 30))
@@ -527,6 +499,7 @@ class StringBuilderTest {
     assertEquals(sb.length - 1, sb.offsetByCodePoints(sb.length - 1, 0))
     assertEquals(sb.length, sb.offsetByCodePoints(sb.length, 0))
 
+    // Actually mandated IOOBE, not StringIIOBE
     assertThrows(classOf[IndexOutOfBoundsException], sb.offsetByCodePoints(-3, 4))
     assertThrows(classOf[IndexOutOfBoundsException], sb.offsetByCodePoints(6, 18))
     assertThrows(classOf[IndexOutOfBoundsException], sb.offsetByCodePoints(30, 2))
@@ -549,6 +522,7 @@ class StringBuilderTest {
     assertEquals(sb.length - 1, sb.offsetByCodePoints(sb.length - 1, -0))
     assertEquals(sb.length, sb.offsetByCodePoints(sb.length, -0))
 
+    // Actually mandated IOOBE, not StringIIOBE
     assertThrows(classOf[IndexOutOfBoundsException], sb.offsetByCodePoints(-3, 4))
     assertThrows(classOf[IndexOutOfBoundsException], sb.offsetByCodePoints(6, 18))
     assertThrows(classOf[IndexOutOfBoundsException], sb.offsetByCodePoints(30, 2))
@@ -570,10 +544,8 @@ class StringBuilderTest {
     assertEquals("foxbar", resultFor("foobar", 2, 'x'))
     assertEquals("foobah", resultFor("foobar", 5, 'h'))
 
-    assertThrows(classOf[StringIndexOutOfBoundsException],
-        resultFor("foobar", -1, 'h'))
-    assertThrows(classOf[StringIndexOutOfBoundsException],
-        resultFor("foobar", 6, 'h'))
+    assertThrowsStringIIOBEIfCompliant(resultFor("foobar", -1, 'h'))
+    assertThrowsStringIIOBEIfCompliant(resultFor("foobar", 6, 'h'))
   }
 
   @Test def substringStart(): Unit = {
@@ -583,12 +555,8 @@ class StringBuilderTest {
     assertEquals("llo", resultFor("hello", 2))
     assertEquals("", resultFor("hello", 5))
 
-    if (executingInJVM) {
-      assertThrows(classOf[StringIndexOutOfBoundsException],
-          resultFor("hello", -1))
-      assertThrows(classOf[StringIndexOutOfBoundsException],
-          resultFor("hello", 8))
-    }
+    assertThrowsStringIIOBEIfCompliant(resultFor("hello", -1))
+    assertThrowsStringIIOBEIfCompliant(resultFor("hello", 8))
   }
 
   @Test def subSequence(): Unit = {
@@ -603,16 +571,10 @@ class StringBuilderTest {
     assertEquals("", resultFor("hello", 5, 5))
     assertEquals("hel", resultFor("hello", 0, 3))
 
-    if (executingInJVM) {
-      assertThrows(classOf[StringIndexOutOfBoundsException],
-          resultFor("hello", -1, 3))
-      assertThrows(classOf[StringIndexOutOfBoundsException],
-          resultFor("hello", 8, 8))
-      assertThrows(classOf[StringIndexOutOfBoundsException],
-          resultFor("hello", 3, 2))
-      assertThrows(classOf[StringIndexOutOfBoundsException],
-          resultFor("hello", 3, 8))
-    }
+    assertThrowsStringIIOBEIfCompliant(resultFor("hello", -1, 3))
+    assertThrowsStringIIOBEIfCompliant(resultFor("hello", 8, 8))
+    assertThrowsStringIIOBEIfCompliant(resultFor("hello", 3, 2))
+    assertThrowsStringIIOBEIfCompliant(resultFor("hello", 3, 8))
   }
 
   @Test def substringStartEnd(): Unit = {
@@ -623,16 +585,10 @@ class StringBuilderTest {
     assertEquals("", resultFor("hello", 5, 5))
     assertEquals("hel", resultFor("hello", 0, 3))
 
-    if (executingInJVM) {
-      assertThrows(classOf[StringIndexOutOfBoundsException],
-          resultFor("hello", -1, 3))
-      assertThrows(classOf[StringIndexOutOfBoundsException],
-          resultFor("hello", 8, 8))
-      assertThrows(classOf[StringIndexOutOfBoundsException],
-          resultFor("hello", 3, 2))
-      assertThrows(classOf[StringIndexOutOfBoundsException],
-          resultFor("hello", 3, 8))
-    }
+    assertThrowsStringIIOBEIfCompliant(resultFor("hello", -1, 3))
+    assertThrowsStringIIOBEIfCompliant(resultFor("hello", 8, 8))
+    assertThrowsStringIIOBEIfCompliant(resultFor("hello", 3, 2))
+    assertThrowsStringIIOBEIfCompliant(resultFor("hello", 3, 8))
   }
 
   @Test def stringInterpolationToSurviveNullAndUndefined(): Unit = {

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/lang/StringBuilderTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/lang/StringBuilderTest.scala
@@ -36,8 +36,11 @@ class StringBuilderTest {
   @Test def init(): Unit =
     assertEquals("", new StringBuilder().toString())
 
-  @Test def initInt(): Unit =
+  @Test def initInt(): Unit = {
     assertEquals("", new StringBuilder(5).toString())
+
+    assertThrowsNegArraySizeIfCompliant(new StringBuilder(-3))
+  }
 
   @Test def initString(): Unit = {
     assertEquals("hello", new StringBuilder("hello").toString())

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/ArraysTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/ArraysTest.scala
@@ -685,6 +685,20 @@ class ArraysTest {
     assertArrayEquals(Array[A](B(1), B(2), B(3), null, null), bscopyAsA)
   }
 
+  @Test def copyOfNegativeNewSize(): Unit = {
+    assumeTrue("requires compliant NegativeArraySizeException's", hasCompliantNegativeArraySizes)
+
+    assertThrows(classOf[NegativeArraySizeException], Arrays.copyOf(new Array[Boolean](3), -3))
+    assertThrows(classOf[NegativeArraySizeException], Arrays.copyOf(new Array[Char](3), -3))
+    assertThrows(classOf[NegativeArraySizeException], Arrays.copyOf(new Array[Byte](3), -3))
+    assertThrows(classOf[NegativeArraySizeException], Arrays.copyOf(new Array[Short](3), -3))
+    assertThrows(classOf[NegativeArraySizeException], Arrays.copyOf(new Array[Int](3), -3))
+    assertThrows(classOf[NegativeArraySizeException], Arrays.copyOf(new Array[Long](3), -3))
+    assertThrows(classOf[NegativeArraySizeException], Arrays.copyOf(new Array[Float](3), -3))
+    assertThrows(classOf[NegativeArraySizeException], Arrays.copyOf(new Array[Double](3), -3))
+    assertThrows(classOf[NegativeArraySizeException], Arrays.copyOf(new Array[Object](3), -3))
+  }
+
   @Test def copyOfRangeAnyRef(): Unit = {
     val anyrefs: Array[AnyRef] = Array("a", "b", "c", "d", "e")
     val anyrefscopy = Arrays.copyOfRange(anyrefs, 2, 4)

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/BitSetTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/BitSetTest.scala
@@ -43,8 +43,7 @@ class BitSetTest {
       assertEquals("Failed to round BitSet element size", 96, bs.size())
     }
 
-    // "Failed to throw exception when creating a new BitSet with negative element value"
-    assertThrows(classOf[NegativeArraySizeException], new BitSet(-9))
+    assertThrowsNegArraySizeIfCompliant(new BitSet(-9))
   }
 
   @Test def test_clone(): Unit = {

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/utils/AssertThrows.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/utils/AssertThrows.scala
@@ -31,4 +31,9 @@ object AssertThrows {
     if (Platform.hasCompliantStringIndexOutOfBounds)
       assertThrows(classOf[StringIndexOutOfBoundsException], code)
   }
+
+  def assertThrowsNegArraySizeIfCompliant(code: => Unit): Unit = {
+    if (Platform.hasCompliantNegativeArraySizes)
+      assertThrows(classOf[NegativeArraySizeException], code)
+  }
 }

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/utils/AssertThrows.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/utils/AssertThrows.scala
@@ -26,4 +26,9 @@ object AssertThrows {
     if (Platform.hasCompliantNullPointers)
       assertThrows(classOf[NullPointerException], code)
   }
+
+  def assertThrowsStringIIOBEIfCompliant(code: => Unit): Unit = {
+    if (Platform.hasCompliantStringIndexOutOfBounds)
+      assertThrows(classOf[StringIndexOutOfBoundsException], code)
+  }
 }


### PR DESCRIPTION
When an NPE, a CCE, or other exceptions subject to UB are triggered by the language rules, the exception is subject to the `CheckedBehavior` configurations in the `Semantics`. However, before this PR, when they are thrown by javalib methods, some might be subject to the same rules, and some might be always-compliant.

We adjust all the situations of the javalib where such exceptions are thrown. Now, they are consistently subject to the `CheckedBehavior` configurations.

The case of `NullPointerException` is particularly tricky in the methods `ju.Objects.requireNonNull` with a specific `message`.