### PR TITLE
RFC Introduce IR ops for "system calls".

### DIFF
--- a/ir/shared/src/main/scala/org/scalajs/ir/Hashers.scala
+++ b/ir/shared/src/main/scala/org/scalajs/ir/Hashers.scala
@@ -335,6 +335,10 @@ object Hashers {
           mixTree(fun)
           mixType(tree.tpe)
 
+        case NullaryOp(op) =>
+          mixTag(TagNullaryOp)
+          mixInt(op)
+
         case UnaryOp(op, lhs) =>
           mixTag(TagUnaryOp)
           mixInt(op)

--- a/ir/shared/src/main/scala/org/scalajs/ir/Printers.scala
+++ b/ir/shared/src/main/scala/org/scalajs/ir/Printers.scala
@@ -400,6 +400,15 @@ object Printers {
 
           undent(); println(); print(')')
 
+        case NullaryOp(op) =>
+          import NullaryOp._
+
+          (op: @switch) match {
+            case CurrentTimeMillis  => print("<currentTimeMillis>()")
+            case NanoTime           => print("<nanoTime>()")
+            case InsecureRandomSeed => print("<insecureRandomSeed>()")
+          }
+
         case UnaryOp(op, lhs) =>
           import UnaryOp._
 
@@ -454,6 +463,9 @@ object Printers {
             case Long_clz => p("<clz>(", ")")
 
             case UnsignedIntToLong => p("<toLongUnsigned>(", ")")
+
+            case PrintStdout => p("<printStdout>(", ")")
+            case PrintStderr => p("<printStderr>(", ")")
           }
 
         case BinaryOp(BinaryOp.Int_-, IntLiteral(0), rhs) =>

--- a/ir/shared/src/main/scala/org/scalajs/ir/Serializers.scala
+++ b/ir/shared/src/main/scala/org/scalajs/ir/Serializers.scala
@@ -408,6 +408,10 @@ object Serializers {
           writeTree(fun)
           writeType(tree.tpe)
 
+        case NullaryOp(op) =>
+          writeTagAndPos(TagNullaryOp)
+          writeByte(op)
+
         case UnaryOp(op, lhs) =>
           writeTagAndPos(TagUnaryOp)
           writeByte(op); writeTree(lhs)
@@ -1340,8 +1344,12 @@ object Serializers {
               readClassNames(), readMethodName(), readTypes(), readType())
           NewLambda(descriptor, readTree())(readType())
 
-        case TagUnaryOp  => UnaryOp(readByte(), readTree())
-        case TagBinaryOp => BinaryOp(readByte(), readTree(), readTree())
+        case TagNullaryOp =>
+          NullaryOp(readByte())
+        case TagUnaryOp =>
+          UnaryOp(readByte(), readTree())
+        case TagBinaryOp =>
+          BinaryOp(readByte(), readTree(), readTree())
 
         case TagArrayLength | TagGetClass | TagClone | TagIdentityHashCode |
             TagWrapAsThrowable | TagUnwrapFromThrowable | TagThrow =>

--- a/ir/shared/src/main/scala/org/scalajs/ir/Tags.scala
+++ b/ir/shared/src/main/scala/org/scalajs/ir/Tags.scala
@@ -138,6 +138,9 @@ private[ir] object Tags {
   // New in 1.20
   final val TagLinkTimeIf = TagJSAwait + 1
 
+  // New in 1.21
+  final val TagNullaryOp = TagLinkTimeIf + 1
+
   // Tags for member defs
 
   final val TagFieldDef = 1

--- a/ir/shared/src/main/scala/org/scalajs/ir/Transformers.scala
+++ b/ir/shared/src/main/scala/org/scalajs/ir/Transformers.scala
@@ -205,7 +205,7 @@ object Transformers {
         // Trees that need not be transformed
 
         case _:Skip | _:Debugger | _:LoadModule | _:StoreModule |
-            _:SelectStatic | _:SelectJSNativeMember | _:LoadJSConstructor |
+            _:SelectStatic | _:SelectJSNativeMember | _:NullaryOp | _:LoadJSConstructor |
             _:LoadJSModule | _:JSNewTarget | _:JSImportMeta |
             _:Literal | _:VarRef | _:JSGlobalRef | _:LinkTimeProperty =>
           tree

--- a/ir/shared/src/main/scala/org/scalajs/ir/Traversers.scala
+++ b/ir/shared/src/main/scala/org/scalajs/ir/Traversers.scala
@@ -214,7 +214,7 @@ object Traversers {
       // Trees that need not be traversed
 
       case _:Skip | _:Debugger | _:LoadModule | _:StoreModule |
-          _:SelectStatic | _:SelectJSNativeMember | _:LoadJSConstructor |
+          _:SelectStatic | _:SelectJSNativeMember | _:NullaryOp | _:LoadJSConstructor |
           _:LoadJSModule | _:JSNewTarget | _:JSImportMeta |
           _:Literal | _:VarRef | _:JSGlobalRef | _:LinkTimeProperty =>
     }

--- a/ir/shared/src/test/scala/org/scalajs/ir/PrintersTest.scala
+++ b/ir/shared/src/test/scala/org/scalajs/ir/PrintersTest.scala
@@ -477,6 +477,14 @@ class PrintersTest {
     )
   }
 
+  @Test def printNullaryOp(): Unit = {
+    import NullaryOp._
+
+    assertPrintEquals("<currentTimeMillis>()", NullaryOp(CurrentTimeMillis))
+    assertPrintEquals("<nanoTime>()", NullaryOp(NanoTime))
+    assertPrintEquals("<insecureRandomSeed>()", NullaryOp(InsecureRandomSeed))
+  }
+
   @Test def printUnaryOp(): Unit = {
     import UnaryOp._
 
@@ -531,6 +539,9 @@ class PrintersTest {
     assertPrintEquals("<clz>(x)", UnaryOp(Long_clz, ref("x", LongType)))
 
     assertPrintEquals("<toLongUnsigned>(x)", UnaryOp(UnsignedIntToLong, ref("x", IntType)))
+
+    assertPrintEquals("<printStdout>(x)", UnaryOp(PrintStdout, ref("x", StringType)))
+    assertPrintEquals("<printStderr>(x)", UnaryOp(PrintStderr, ref("x", StringType)))
   }
 
   @Test def printPseudoUnaryOp(): Unit = {

--- a/javalib/src/main/scala/java/lang/Math.scala
+++ b/javalib/src/main/scala/java/lang/Math.scala
@@ -173,7 +173,13 @@ object Math {
   @inline def atan(a: scala.Double): scala.Double = js.Math.atan(a)
   @inline def atan2(y: scala.Double, x: scala.Double): scala.Double = js.Math.atan2(y, x)
 
-  @inline def random(): scala.Double = js.Math.random()
+  // In a separate object to keep jl.Math's constructor pure
+  private object MathRandom {
+    val rnd = new java.util.Random()
+  }
+
+  @inline def random(): scala.Double =
+    MathRandom.rnd.nextDouble()
 
   @inline def toDegrees(a: scala.Double): scala.Double = {
     /* According to

--- a/javalib/src/main/scala/java/lang/System.scala
+++ b/javalib/src/main/scala/java/lang/System.scala
@@ -68,20 +68,11 @@ object System {
 
   @inline
   def currentTimeMillis(): scala.Long =
-    js.Date.now().toLong
-
-  private object NanoTime {
-    val highPrecisionTimer: js.Dynamic = {
-      if (js.typeOf(global.performance) != "undefined" && !Utils.isUndefined(global.performance.now))
-        global.performance
-      else
-        global.Date
-    }
-  }
+    throw new Error("stub") // body replaced by the compiler back-end
 
   @inline
   def nanoTime(): scala.Long =
-    (NanoTime.highPrecisionTimer.now().asInstanceOf[scala.Double] * 1000000).toLong
+    throw new Error("stub") // body replaced by the compiler back-end
 
   // arraycopy ----------------------------------------------------------------
 
@@ -294,6 +285,22 @@ object System {
 
   @inline
   def gc(): Unit = Runtime.getRuntime().gc()
+
+  // Non-standard, but known of the compiler backend --------------------------
+
+  // These methods are protected[java] to get a non-mangled name.
+
+  @inline
+  protected[java] def insecureRandomSeed(): scala.Long =
+    throw new Error("stub") // body replaced by the compiler back-end
+
+  @inline
+  protected[java] def printStdout(line: String): Unit =
+    throw new Error("stub") // body replaced by the compiler back-end
+
+  @inline
+  protected[java] def printStderr(line: String): Unit =
+    throw new Error("stub") // body replaced by the compiler back-end
 }
 
 private final class JSConsoleBasedPrintStream(isErr: scala.Boolean)
@@ -372,15 +379,12 @@ private final class JSConsoleBasedPrintStream(isErr: scala.Boolean)
 
   override def close(): Unit = ()
 
+  @inline
   private def doWriteLine(line: String): Unit = {
-    import js.DynamicImplicits.truthValue
-
-    if (js.typeOf(global.console) != "undefined") {
-      if (isErr && global.console.error)
-        global.console.error(line)
-      else
-        global.console.log(line)
-    }
+    if (isErr)
+      System.printStderr(line)
+    else
+      System.printStdout(line)
   }
 }
 

--- a/javalib/src/main/scala/java/util/Random.scala
+++ b/javalib/src/main/scala/java/util/Random.scala
@@ -37,7 +37,7 @@ class Random(seed_in: Long) extends AnyRef with RandomGenerator with java.io.Ser
 
   setSeed(seed_in)
 
-  def this() = this(Random.randomSeed())
+  def this() = this(System.insecureRandomSeed())
 
   def setSeed(seed_in: Long): Unit = {
     val seed = ((seed_in ^ 0x5deece66dL) & ((1L << 48) - 1)) // as documented
@@ -183,15 +183,4 @@ class Random(seed_in: Long) extends AnyRef with RandomGenerator with java.io.Ser
       x * c
     }
   }
-}
-
-object Random {
-
-  /** Generate a random long from JS RNG to seed a new Random */
-  private def randomSeed(): Long =
-    (randomInt().toLong << 32) | (randomInt().toLong & 0xffffffffL)
-
-  private def randomInt(): Int =
-    (Math.floor(Math.random() * 4294967296.0) - 2147483648.0).toInt
-
 }

--- a/linker/shared/src/main/scala/org/scalajs/linker/backend/emitter/CoreJSLib.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/backend/emitter/CoreJSLib.scala
@@ -104,6 +104,9 @@ private[emitter] object CoreJSLib {
     private val TypeErrorRef = globalRef("TypeError")
     private def BigIntRef = globalRef("BigInt")
     private val SymbolRef = globalRef("Symbol")
+    private val DateRef = globalRef("Date")
+    private val performanceRef = globalRef("performance")
+    private val consoleRef = globalRef("console")
 
     // Conditional global references that we often use
     private def ReflectRef = globalRef("Reflect")
@@ -568,6 +571,14 @@ private[emitter] object CoreJSLib {
       }
     }
 
+    /** Returns `BigInt(Math.floor(value))` if we use bigints for longs, `value` otherwise. */
+    private def floorToBigIntIfUseBigInts(value: Tree): Tree = {
+      if (useBigIntForLongs)
+        Apply(BigIntRef, List(Apply(genIdentBracketSelect(MathRef, "floor"), List(value))))
+      else
+        value
+    }
+
     private def defineRuntimeFunctions(): List[Tree] = (
       condDefs(asInstanceOfs != CheckedBehavior.Unchecked || arrayStores != CheckedBehavior.Unchecked)(
         /* Returns a safe string description of a value.
@@ -681,6 +692,65 @@ private[emitter] object CoreJSLib {
       defineFunction1(VarField.noIsInstance) { instance =>
         Throw(New(TypeErrorRef,
             str("Cannot call isInstance() on a Class representing a JS trait/object") :: Nil))
+      } :::
+
+      extractWithGlobals(globalVarDef(VarField.currentTimeMillis, CoreVar, {
+        val dateNow = genIdentBracketSelect(DateRef, "now")
+
+        if (useBigIntForLongs)
+          genArrowFunction(Nil, Return(floorToBigIntIfUseBigInts(Apply(dateNow, Nil))))
+        else
+          dateNow
+      })) :::
+
+      extractWithGlobals(globalVarDef(VarField.nanoTime, CoreVar, {
+        def makeForReceiver(receiver: Tree): Tree = {
+          genArrowFunction(Nil, Return {
+            floorToBigIntIfUseBigInts(
+                Apply(genIdentBracketSelect(receiver, "now"), Nil) * double(1000000.0))
+          })
+        }
+
+        If(UnaryOp(JSUnaryOp.typeof, performanceRef) !== str("undefined") &&
+            genIdentBracketSelect(performanceRef, "now"), {
+          makeForReceiver(performanceRef)
+        }, {
+          makeForReceiver(DateRef)
+        })
+      })) :::
+
+      defineFunction0(VarField.randomSeed) {
+        // Math.random() * 2**32
+        val randomTwoPow32 =
+          Apply(genIdentBracketSelect(MathRef, "random"), Nil) * double((1L << 32).toDouble)
+
+        if (useBigIntForLongs) {
+          // Build up the full 64-bit random number from two random ints
+          val randomU32BigInt = Apply(BigIntRef, List(randomTwoPow32 >>> 0))
+          val randomU64BigInt = (randomU32BigInt << BigIntLiteral(32)) | randomU32BigInt
+          val randomS64BigInt =
+            Apply(genIdentBracketSelect(BigIntRef, "asIntN"), 64 :: randomU64BigInt :: Nil)
+          Return(randomS64BigInt)
+        } else {
+          // Return a single random 32-bit integer
+          Return(randomTwoPow32 | 0)
+        }
+      } :::
+
+      defineFunction1(VarField.printStdout) { line =>
+        If(UnaryOp(JSUnaryOp.typeof, consoleRef) !== str("undefined"), {
+          Apply(genIdentBracketSelect(consoleRef, "log"), List(line))
+        })
+      } :::
+
+      defineFunction1(VarField.printStderr) { line =>
+        If(UnaryOp(JSUnaryOp.typeof, consoleRef) !== str("undefined"), {
+          If(genIdentBracketSelect(consoleRef, "error"), {
+            Apply(genIdentBracketSelect(consoleRef, "error"), List(line))
+          }, {
+            Apply(genIdentBracketSelect(consoleRef, "log"), List(line))
+          })
+        })
       } :::
 
       defineFunction1(VarField.objectClone) { instance =>

--- a/linker/shared/src/main/scala/org/scalajs/linker/backend/emitter/FunctionEmitter.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/backend/emitter/FunctionEmitter.scala
@@ -766,6 +766,15 @@ private[emitter] class FunctionEmitter(sjsGen: SJSGen) {
           }
           js.Assign(globalVar(VarField.n, enclosingClassName), js.This())
 
+        case UnaryOp(op @ (UnaryOp.PrintStdout | UnaryOp.PrintStderr), line) =>
+          unnest(line) { (newLine, env0) =>
+            implicit val env = env0
+            val helper =
+              if (op == UnaryOp.PrintStdout) VarField.printStdout
+              else VarField.printStderr
+            genCallHelper(helper, transformExprNoChar(newLine))
+          }
+
         case While(cond, body) =>
           val loopEnv = env.withInLoopForVarCapture(true)
 
@@ -1353,7 +1362,7 @@ private[emitter] class FunctionEmitter(sjsGen: SJSGen) {
       import UnaryOp._
 
       tree.op match {
-        case Throw =>
+        case Throw | PrintStdout | PrintStderr =>
           false
         case WrapAsThrowable | UnwrapFromThrowable =>
           isDuplicatable(tree.lhs)
@@ -1430,6 +1439,14 @@ private[emitter] class FunctionEmitter(sjsGen: SJSGen) {
         // Other trees of type long cannot be split
         case _ if !allowUnsplittableLongs && isSplitLongType(tree.tpe) =>
           false
+
+        case NullaryOp(op) =>
+          if (isSplitLongType(tree.tpe))
+            false
+          else if (NullaryOp.isSideEffectFreeOp(op))
+            allowUnpure
+          else
+            allowSideEffects
 
         case tree @ UnaryOp(op, lhs) if canUnaryOpBeExpression(tree) =>
           if (op == UnaryOp.CheckNotNull)
@@ -1658,9 +1675,11 @@ private[emitter] class FunctionEmitter(sjsGen: SJSGen) {
      */
     def isRTLongBoxingAvoidable(tree: Tree)(implicit env: Env): Boolean = {
       tree match {
-        case _:Labeled | _:If | _:TryCatch | _:TryFinally | _:Match | _:ArraySelect =>
+        case _:Labeled | _:If | _:TryCatch | _:TryFinally | _:Match |
+            _:ArraySelect | _:NullaryOp =>
           /* Trees resulting in JS statements we can push the LHS into.
            * See the comment on `JSLongArraySelect` why `ArraySelect` is here.
+           * `NullaryOp` receives a similar treatment.
            */
           true
         case _ =>
@@ -2082,7 +2101,41 @@ private[emitter] class FunctionEmitter(sjsGen: SJSGen) {
             redo(ApplyTypedClosure(flags, newFun, newArgs))(env)
           }
 
-        case UnaryOp(op, lhs) =>
+        case NullaryOp(op) =>
+          import NullaryOp._
+          import TreeDSL._
+
+          assert(isSplitLongType(rhs.tpe),
+              s"$rhs of non-split long type should have been handled as an expression at $pos")
+
+          def redoWithPackTwoJSExprs(lo: js.Tree, hi: js.Tree): js.Tree = {
+            withTempJSVar(lo) { loJSVarRef =>
+              withTempJSVar(hi) { hiJSVarRef =>
+                val loVarRef = Transient(JSVarRef(
+                    loJSVarRef.ident.asInstanceOf[js.Ident], mutable = false)(IntType))
+                val hiVarRef = Transient(JSVarRef(
+                    hiJSVarRef.ident.asInstanceOf[js.Ident], mutable = false)(IntType))
+                redo(Transient(PackLong(loVarRef, hiVarRef)))
+              }
+            }
+          }
+
+          op match {
+            case CurrentTimeMillis | NanoTime =>
+              val doubleValue =
+                if (op == NullaryOp.CurrentTimeMillis) genCallHelper(VarField.currentTimeMillis)
+                else genCallHelper(VarField.nanoTime)
+              withTempJSVar(doubleValue) { doubleTimeVarRef =>
+                val twoPowM32 = js.DoubleLiteral(1.0 / (1L << 32).toDouble)
+                redoWithPackTwoJSExprs(doubleTimeVarRef | 0, (doubleTimeVarRef * twoPowM32) | 0)
+              }
+
+            case NullaryOp.InsecureRandomSeed =>
+              redoWithPackTwoJSExprs(
+                  genCallHelper(VarField.randomSeed), genCallHelper(VarField.randomSeed))
+          }
+
+        case UnaryOp(op, lhs) if rhs.tpe != VoidType =>
           op match {
             case UnaryOp.Throw =>
               pushLhsInto(Lhs.Throw, lhs, tailPosLabels)
@@ -2377,7 +2430,7 @@ private[emitter] class FunctionEmitter(sjsGen: SJSGen) {
 
         case _:Skip | _:VarDef | _:Assign | _:While | _:Debugger |
             _:JSSuperConstructorCall | _:JSDelete | _:StoreModule |
-            Transient(_: SystemArrayCopy) =>
+            _:UnaryOp | Transient(_: SystemArrayCopy) =>
           /* Go "back" to transformStat() after having dived into
            * expression statements. This can only happen for Lhs.Discard and
            * for Lhs.Return's whose target is a statement.
@@ -2762,6 +2815,24 @@ private[emitter] class FunctionEmitter(sjsGen: SJSGen) {
                   s"Unexpected type for the fun of ApplyTypedClosure: ${fun.tpe}")
           }
           js.Apply.makeProtected(newFun, newArgs)
+
+        case NullaryOp(op) =>
+          import NullaryOp._
+          import TreeDSL._
+
+          assert(!isSplitLongType(tree.tpe),
+              s"$tree of split long type should not reach transformExpr at $pos")
+
+          (op: @switch) match {
+            case CurrentTimeMillis =>
+              genCallHelper(VarField.currentTimeMillis)
+
+            case NanoTime =>
+              genCallHelper(VarField.nanoTime)
+
+            case InsecureRandomSeed =>
+              genCallHelper(VarField.randomSeed)
+          }
 
         case UnaryOp(op, lhs) =>
           import UnaryOp._

--- a/linker/shared/src/main/scala/org/scalajs/linker/backend/emitter/VarField.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/backend/emitter/VarField.scala
@@ -276,6 +276,16 @@ private[emitter] object VarField {
 
   final val moduleDefault = mk("$moduleDefault")
 
+  final val currentTimeMillis = mk("$currentTimeMillis")
+
+  final val nanoTime = mk("$nanoTime")
+
+  final val randomSeed = mk("$randomSeed")
+
+  final val printStdout = mk("$printStdout")
+
+  final val printStderr = mk("$printStderr")
+
   // Arithmetic Call Helpers
 
   final val checkIntDivisor = mk("$checkIntDivisor")

--- a/linker/shared/src/main/scala/org/scalajs/linker/backend/wasmemitter/CoreWasmLib.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/backend/wasmemitter/CoreWasmLib.scala
@@ -314,6 +314,12 @@ final class CoreWasmLib(coreSpec: CoreSpec, globalInfo: LinkedGlobalInfo) {
     addHelperImport(genFunctionID.longToString, List(Int64), List(RefType.extern))
     addHelperImport(genFunctionID.doubleToString, List(Float64), List(RefType.extern))
 
+    addHelperImport(genFunctionID.jsDateNow, Nil, List(Float64))
+    addHelperImport(genFunctionID.jsPerformanceNow, Nil, List(Float64))
+    addHelperImport(genFunctionID.jsRandom, Nil, List(Float64))
+    addHelperImport(genFunctionID.printStdout, List(RefType.extern), Nil)
+    addHelperImport(genFunctionID.printStderr, List(RefType.extern), Nil)
+
     addHelperImport(genFunctionID.jsValueType, List(RefType.any), List(Int32))
     addHelperImport(genFunctionID.jsValueDescription, List(anyref), List(RefType.extern))
     addHelperImport(genFunctionID.bigintHashCode, List(RefType.any), List(Int32))

--- a/linker/shared/src/main/scala/org/scalajs/linker/backend/wasmemitter/FunctionEmitter.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/backend/wasmemitter/FunctionEmitter.scala
@@ -599,6 +599,7 @@ private class FunctionEmitter private (
 
     val generatedType: Type = tree match {
       case t: Literal            => genLiteral(t, expectedTypeNoCast)
+      case t: NullaryOp          => genNullaryOp(t)
       case t: UnaryOp            => genUnaryOp(t)
       case t: BinaryOp           => genBinaryOp(t)
       case t: VarRef             => genVarRef(t)
@@ -1508,6 +1509,39 @@ private class FunctionEmitter private (
     tree.tpe
   }
 
+  private def genNullaryOp(tree: NullaryOp): Type = {
+    import NullaryOp._
+
+    val NullaryOp(op) = tree
+
+    markPosition(tree)
+
+    (op: @switch) match {
+      case CurrentTimeMillis =>
+        fb += wa.Call(genFunctionID.jsDateNow)
+        fb += wa.I64TruncF64U
+
+      case NanoTime =>
+        fb += wa.Call(genFunctionID.jsPerformanceNow)
+        fb += wa.F64Const(1000000.0)
+        fb += wa.F64Mul
+        fb += wa.I64TruncF64U
+
+      case InsecureRandomSeed =>
+        for (_ <- 0 until 2) {
+          fb += wa.Call(genFunctionID.jsRandom)
+          fb += wa.F64Const((1L << 32).toDouble)
+          fb += wa.F64Mul
+          fb += wa.I64TruncF64U
+        }
+        fb += wa.I64Const(32)
+        fb += wa.I64Shl
+        fb += wa.I64Or
+    }
+
+    tree.tpe
+  }
+
   private def genUnaryOp(tree: UnaryOp): Type = {
     // scalastyle:off return
 
@@ -1726,6 +1760,11 @@ private class FunctionEmitter private (
 
       case UnsignedIntToLong =>
         fb += wa.I64ExtendI32U
+
+      case PrintStdout =>
+        fb += wa.Call(genFunctionID.printStdout)
+      case PrintStderr =>
+        fb += wa.Call(genFunctionID.printStderr)
     }
 
     tree.tpe

--- a/linker/shared/src/main/scala/org/scalajs/linker/backend/wasmemitter/LoaderContent.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/backend/wasmemitter/LoaderContent.scala
@@ -108,6 +108,25 @@ const scalaJSHelpers = {
   longToString: (l) => "" + l, // l must be a bigint here
   doubleToString: (d) => "" + d,
 
+  // Core external functions
+  jsDateNow: Date.now,
+  jsPerformanceNow: (
+    (typeof performance !== "undefined" && performance.now)
+      ? (() => performance.now())
+      : Date.now
+  ),
+  jsRandom: Math.random,
+  printStdout : (
+    (typeof console !== "undefined")
+      ? ((s) => console.log(s))
+      : ((s) => void 0)
+  ),
+  printStderr : (
+    (typeof console !== "undefined")
+      ? (console.error ? ((s) => console.error(s)) : ((s) => console.log(s)))
+      : ((s) => void 0)
+  ),
+
   // Get the type of JS value of `x` in a single JS helper call, for the purpose of dispatch.
   jsValueType: (x) => {
     if (typeof x === 'number')

--- a/linker/shared/src/main/scala/org/scalajs/linker/backend/wasmemitter/VarGen.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/backend/wasmemitter/VarGen.scala
@@ -145,6 +145,12 @@ object VarGen {
     case object longToString extends JSHelperFunctionID
     case object doubleToString extends JSHelperFunctionID
 
+    case object jsDateNow extends JSHelperFunctionID
+    case object jsPerformanceNow extends JSHelperFunctionID
+    case object jsRandom extends JSHelperFunctionID
+    case object printStdout extends JSHelperFunctionID
+    case object printStderr extends JSHelperFunctionID
+
     case object jsValueType extends JSHelperFunctionID
     case object jsValueDescription extends JSHelperFunctionID
     case object bigintHashCode extends JSHelperFunctionID

--- a/linker/shared/src/main/scala/org/scalajs/linker/checker/ClassDefChecker.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/checker/ClassDefChecker.scala
@@ -878,6 +878,8 @@ private final class ClassDefChecker(classDef: ClassDef,
             checkTree(fun, env)
         }
 
+      case NullaryOp(_) =>
+
       case UnaryOp(_, lhs) =>
         checkTree(lhs, env)
 

--- a/linker/shared/src/main/scala/org/scalajs/linker/checker/IRChecker.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/checker/IRChecker.scala
@@ -515,6 +515,8 @@ private final class IRChecker(linkTimeProperties: LinkTimeProperties,
         val closureType = ClosureType(descriptor.paramTypes, descriptor.resultType, nullable = false)
         typecheckExpect(fun, env, closureType)
 
+      case NullaryOp(_) =>
+
       case UnaryOp(UnaryOp.CheckNotNull, lhs) =>
         // CheckNotNull accepts any closure type in addition to `AnyType`
         lhs.tpe match {
@@ -568,6 +570,8 @@ private final class IRChecker(linkTimeProperties: LinkTimeProperties,
             ClassType(CloneableClass, nullable = false, exact = false)
           case UnwrapFromThrowable =>
             ClassType(ThrowableClass, nullable = false, exact = false)
+          case PrintStdout | PrintStderr =>
+            ClassType(BoxedStringClass, nullable = false, exact = false)
         }
         typecheckExpect(lhs, env, expectedArgType)
 

--- a/linker/shared/src/main/scala/org/scalajs/linker/frontend/optimizer/OptimizerCore.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/frontend/optimizer/OptimizerCore.scala
@@ -796,7 +796,7 @@ private[optimizer] abstract class OptimizerCore(
       // Trees that need not be transformed
 
       case _:Skip | _:Debugger | _:StoreModule |
-          _:SelectStatic | _:JSNewTarget | _:JSImportMeta |
+          _:SelectStatic | _:NullaryOp | _:JSNewTarget | _:JSImportMeta |
           _:JSGlobalRef | _:JSTypeOfGlobalRef | _:Literal =>
         tree
 

--- a/linker/shared/src/test/scala/org/scalajs/linker/LibrarySizeTest.scala
+++ b/linker/shared/src/test/scala/org/scalajs/linker/LibrarySizeTest.scala
@@ -71,8 +71,8 @@ class LibrarySizeTest {
     )
 
     testLinkedSizes(
-      expectedFastLinkSize = 143862,
-      expectedFullLinkSize = 87488,
+      expectedFastLinkSize = 144422,
+      expectedFullLinkSize = 88211,
       classDefs,
       moduleInitializers = MainTestModuleInitializers
     )
@@ -105,8 +105,8 @@ class LibrarySizeTest {
     )
 
     testLinkedSizes(
-      expectedFastLinkSize = 65253,
-      expectedFullLinkSize = 44710,
+      expectedFastLinkSize = 65843,
+      expectedFullLinkSize = 45300,
       classDefs,
       moduleInitializers = MainTestModuleInitializers
     )
@@ -122,8 +122,8 @@ class LibrarySizeTest {
     )
 
     testLinkedSizes(
-      expectedFastLinkSize = 94876,
-      expectedFullLinkSize = 73586,
+      expectedFastLinkSize = 95466,
+      expectedFullLinkSize = 74176,
       classDefs,
       moduleInitializers = MainTestModuleInitializers
     )
@@ -140,8 +140,8 @@ class LibrarySizeTest {
     )
 
     testLinkedSizes(
-      expectedFastLinkSize = 96670,
-      expectedFullLinkSize = 75038,
+      expectedFastLinkSize = 97260,
+      expectedFullLinkSize = 75628,
       classDefs,
       moduleInitializers = MainTestModuleInitializers
     )

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -2077,29 +2077,29 @@ object Build {
                   fastLink = 620000 to 621000,
                   fullLink = 284000 to 285000,
                   fastLinkGz = 75000 to 79000,
-                  fullLinkGz = 43000 to 44000,
+                  fullLinkGz = 44000 to 45000,
               ))
             } else {
               Some(ExpectedSizes(
-                  fastLink = 425000 to 426000,
+                  fastLink = 426000 to 427000,
                   fullLink = 284000 to 285000,
                   fastLinkGz = 61000 to 62000,
-                  fullLinkGz = 43000 to 44000,
+                  fullLinkGz = 44000 to 45000,
               ))
             }
 
           case `default213Version` =>
             if (!useMinifySizes) {
               Some(ExpectedSizes(
-                  fastLink = 438000 to 439000,
-                  fullLink = 263000 to 264000,
-                  fastLinkGz = 57000 to 58000,
+                  fastLink = 439000 to 440000,
+                  fullLink = 264000 to 265000,
+                  fastLinkGz = 58000 to 59000,
                   fullLinkGz = 43000 to 44000,
               ))
             } else {
               Some(ExpectedSizes(
-                  fastLink = 304000 to 305000,
-                  fullLink = 263000 to 264000,
+                  fastLink = 305000 to 306000,
+                  fullLink = 264000 to 265000,
                   fastLinkGz = 48000 to 49000,
                   fullLinkGz = 43000 to 44000,
               ))


### PR DESCRIPTION
This is mostly an RFC at this point. @gzm0 Do you think this is a viable path forward? Currently, in scala-wasm/scala-wasm, these 5 operations are special-cased in a very ugly way in the emitter:
https://github.com/scala-wasm/scala-wasm/blob/557c6469a2095d4439120f1f56b440105b409596/linker/shared/src/main/scala/org/scalajs/linker/backend/wasmemitter/ClassEmitter.scala#L1768-L1783

Later on, we will also face the problem of the two `scalajsCom` functions (`init` and `send`). For these, I think we will need to actually use the Wasm interop features. Since they are not core to the javalib, though, IMO they are less problematic. They are also currently special-cased at
https://github.com/scala-wasm/scala-wasm/blob/557c6469a2095d4439120f1f56b440105b409596/linker/shared/src/main/scala/org/scalajs/linker/backend/wasmemitter/ClassEmitter.scala#L1790-L1799

---

We introduce new ops for 5 operations that the javalib performs, and that cannot possibly be implemented without asking the "system" to perform them.

`printStdout` and `printStderr` are `UnaryOp`s whose result type is `void`. They print their string argument to the standard outputs, on a best-effort basis.

The other operations are "nullary" ops. They take no argument and all result in a `long`:

* `currentTimeMillis`: the wall clock time.
* `nanoTime`: a monotonic clock with high precision.
* `insecureRandomSeed`: acquiring a random number from an external source, though not suited for cryptographic usage.

These are the 5 operations from the javalib that a compilation to Wasm without a JS env will need from the outside. Everything else can be implemented in user land.

Well, not quite. There is also `ju.Timer` and `ju.TimerTask`. However, these are a entire classes. They could be split out in a separate library. The same cannot be said for the 5 operations above, which are individual methods in core classes.

The code size increase is due to the 5 top-level function definitions, which we unconditionally emit. They can be removed by a JavaScript minifier.