### PR TITLE
Fix #5331: Transform the body of a void typed closure as a statement.

### DIFF
--- a/linker/shared/src/main/scala/org/scalajs/linker/frontend/optimizer/OptimizerCore.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/frontend/optimizer/OptimizerCore.scala
@@ -834,7 +834,7 @@ private[optimizer] abstract class OptimizerCore(
       .withLocalDefs(paramLocalDefs)
       .withLocalDefs(restParamLocalDef.toList)
 
-    transformCapturingBody(captureParams, tcaptureValues, body, innerEnv) {
+    transformCapturingBody(captureParams, tcaptureValues, resultType, body, innerEnv) {
       (newCaptureParams, newCaptureValues, newBody) =>
         val newClosure = {
           Closure(flags, newCaptureParams, newParams, newRestParam, resultType,
@@ -845,7 +845,7 @@ private[optimizer] abstract class OptimizerCore(
   }
 
   private def transformCapturingBody(captureParams: List[ParamDef],
-      tcaptureValues: List[PreTransform], body: Tree, innerEnv: OptEnv)(
+      tcaptureValues: List[PreTransform], resultType: Type, body: Tree, innerEnv: OptEnv)(
       inner: (List[ParamDef], List[Tree], Tree) => PreTransTree)(cont: PreTransCont)(
       implicit scope: Scope, pos: Position): TailRec[Tree] = {
     /* Process captures.
@@ -913,7 +913,7 @@ private[optimizer] abstract class OptimizerCore(
 
     val innerScope = scope.withEnv(innerEnv.withLocalDefs(captureParamLocalDefs.result()))
 
-    val newBody = transformExpr(body)(innerScope)
+    val newBody = transform(body, isStat = resultType == VoidType)(innerScope)
 
     withNewLocalDefs(captureValueBindings.result()) { (localDefs, cont1) =>
       val (finalCaptureParams, finalCaptureValues) = (for {
@@ -2540,7 +2540,8 @@ private[optimizer] abstract class OptimizerCore(
 
             val methodDef = getMethodBody(targetMethod)
 
-            transformCapturingBody(methodDef.args, targs, methodDef.body.get, OptEnv.Empty) {
+            transformCapturingBody(methodDef.args, targs, AnyType,
+                methodDef.body.get, OptEnv.Empty) {
               (newCaptureParams, newCaptureValues, newBody) =>
                 if (!importReplacement.used.value.isUsed)
                   cancelFun()

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/compiler/RegressionTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/compiler/RegressionTest.scala
@@ -982,6 +982,19 @@ class RegressionTest {
     assertEquals("g", hide(b.bar))
   }
 
+  @Test
+  def typedClosureWithStatementBodyMustBeTransformedAsStat_Issue5331(): Unit = {
+    final class Box(var x: Int)
+
+    @noinline
+    def escapeAndCall(body: Runnable): Unit = body.run()
+
+    val box = new Box(5)
+    val task: Runnable = () => box.x = 6 // SAM for Runnable
+    escapeAndCall(task)
+    assertEquals(6, box.x)
+  }
+
 }
 
 object RegressionTest {


### PR DESCRIPTION
I locally tested that the fix applies in the original cats-effect situation.