### PR TITLE
Fix the buffer growing logic in InputStream.readNBytes.

### DIFF
--- a/javalib/src/main/scala/java/io/InputStream.scala
+++ b/javalib/src/main/scala/java/io/InputStream.scala
@@ -75,7 +75,7 @@ abstract class InputStream extends Closeable {
            * - len <= Integer.MAX_VALUE (because of its type)
            */
           val newLen =
-            if (Integer.MAX_VALUE / 2 > buf.length) Integer.MAX_VALUE
+            if (buf.length > Integer.MAX_VALUE / 2) Integer.MAX_VALUE
             else buf.length * 2
           buf = Arrays.copyOf(buf, Math.min(len, newLen))
         }

--- a/test-suite/shared/src/test/require-jdk11/org/scalajs/testsuite/javalib/io/InputStreamTestOnJDK11.scala
+++ b/test-suite/shared/src/test/require-jdk11/org/scalajs/testsuite/javalib/io/InputStreamTestOnJDK11.scala
@@ -42,6 +42,7 @@ class InputStreamTestOnJDK11 {
 
   @Test def readAllBytes(): Unit = {
     assertBytesEqual(0 until 100, chunkedStream(10, 0 until 100).readAllBytes())
+    assertBytesEqual(0 until 4000, chunkedStream(100, 0 until 4000).readAllBytes())
     assertBytesEqual(Nil, emptyStream().readAllBytes())
   }
 
@@ -53,6 +54,7 @@ class InputStreamTestOnJDK11 {
 
     // test buffer growing
     assertBytesEqual(0 until 2000, chunkedStream(200, 0 until 2000).readNBytes(2000))
+    assertBytesEqual(0 until 20000, chunkedStream(2000, 0 until 20000).readNBytes(20000))
 
     assertThrows(classOf[IllegalArgumentException], emptyStream().readNBytes(-1))
   }


### PR DESCRIPTION
The comparison was the wrong way around. On the first resize, we jumped straight to a buffer of size `min(Int.MaxValue, len)`.

That was not too bad for `readNBytes` per se, but devastating for `readAllBytes`, which calls `readNBytes` with `len = Int.MaxValue`.