### PR TITLE
Make ju.Objects.requireNonNull overloads follow Semantics for UB NPE.

### DIFF
--- a/javalib/src/main/scala/java/io/FilterReader.scala
+++ b/javalib/src/main/scala/java/io/FilterReader.scala
@@ -12,9 +12,11 @@
 
 package java.io
 
+import java.util.Objects.requireNonNull
+
 abstract class FilterReader protected (protected val in: Reader) extends Reader {
 
-  in.getClass() // null check
+  requireNonNull(in)
 
   override def close(): Unit = in.close()
 

--- a/javalib/src/main/scala/java/io/InputStream.scala
+++ b/javalib/src/main/scala/java/io/InputStream.scala
@@ -13,6 +13,7 @@
 package java.io
 
 import java.util.Arrays
+import java.util.Objects.requireNonNull
 
 abstract class InputStream extends Closeable {
   def read(): Int
@@ -143,7 +144,7 @@ abstract class InputStream extends Closeable {
   def markSupported(): Boolean = false
 
   def transferTo(out: OutputStream): Long = {
-    out.getClass() // Trigger NPE (if enabled).
+    val outNonNull = requireNonNull(out)
 
     var transferred = 0L
     val buf = new Array[Byte](4096)
@@ -152,7 +153,7 @@ abstract class InputStream extends Closeable {
     while (bytesRead != -1) {
       bytesRead = read(buf)
       if (bytesRead != -1) {
-        out.write(buf, 0, bytesRead)
+        outNonNull.write(buf, 0, bytesRead)
         transferred += bytesRead
       }
     }

--- a/javalib/src/main/scala/java/io/Reader.scala
+++ b/javalib/src/main/scala/java/io/Reader.scala
@@ -12,18 +12,17 @@
 
 package java.io
 
-import java.nio.CharBuffer
-
 import scala.annotation.tailrec
+
+import java.nio.CharBuffer
+import java.util.Objects.requireNonNull
 
 abstract class Reader() extends Readable with Closeable {
   protected var lock: Object = this
 
   protected def this(lock: Object) = {
     this()
-    if (lock eq null)
-      throw new NullPointerException()
-    this.lock = lock
+    this.lock = requireNonNull(lock)
   }
 
   def read(target: CharBuffer): Int = {

--- a/javalib/src/main/scala/java/io/Writer.scala
+++ b/javalib/src/main/scala/java/io/Writer.scala
@@ -12,14 +12,14 @@
 
 package java.io
 
+import java.util.Objects.requireNonNull
+
 abstract class Writer() extends Appendable with Closeable with Flushable {
   protected var lock: Object = this
 
   protected def this(lock: Object) = {
     this()
-    if (lock eq null)
-      throw new NullPointerException()
-    this.lock = lock
+    this.lock = requireNonNull(lock)
   }
 
   def write(c: Int): Unit =

--- a/javalib/src/main/scala/java/lang/StringBuilder.scala
+++ b/javalib/src/main/scala/java/lang/StringBuilder.scala
@@ -12,15 +12,15 @@
 
 package java.lang
 
+import java.util.Objects.requireNonNull
+
 class StringBuilder extends AnyRef with CharSequence with Appendable with java.io.Serializable {
 
   private[this] var content: String = ""
 
   def this(str: String) = {
     this()
-    if (str eq null)
-      throw new NullPointerException
-    content = str
+    content = requireNonNull(str)
   }
 
   def this(initialCapacity: Int) = {

--- a/javalib/src/main/scala/java/lang/StringBuilder.scala
+++ b/javalib/src/main/scala/java/lang/StringBuilder.scala
@@ -90,11 +90,12 @@ class StringBuilder extends AnyRef with CharSequence with Appendable with java.i
   }
 
   def replace(start: Int, end: Int, str: String): StringBuilder = {
+    val strNonNull = requireNonNull(str)
     val oldContent = content
     val length = oldContent.length
 
     // The call to substring implies the bounds checks for 0 <= start <= length
-    val firstPart = oldContent.substring(0, start) + str
+    val firstPart = oldContent.substring(0, start) + strNonNull
     if (end < start)
       oldContent.charAt(-1)
 

--- a/javalib/src/main/scala/java/lang/System.scala
+++ b/javalib/src/main/scala/java/lang/System.scala
@@ -20,6 +20,7 @@ import scala.scalajs.LinkingInfo
 
 import java.{util => ju}
 import java.util.function._
+import java.util.Objects.requireNonNull
 
 object System {
   /* System contains a bag of unrelated features. If we naively implement
@@ -92,6 +93,9 @@ object System {
     import scala.{Boolean, Char, Byte, Short, Int, Long, Float, Double}
 
     def mismatch(): Unit = {
+      requireNonNull(src)
+      requireNonNull(dest)
+
       // Trigger an ArrayStoreException subject to UB.
       new Array[String](1).asInstanceOf[Array[Object]](0) = Integer.valueOf(0)
     }
@@ -122,9 +126,7 @@ object System {
       }
     }
 
-    if (src == null || dest == null) {
-      throw new NullPointerException()
-    } else (src match {
+    src match {
       case src: Array[AnyRef] =>
         dest match {
           case dest: Array[AnyRef] => impl(src.length, dest.length, (i, j) => dest(i) = src(j))
@@ -172,7 +174,7 @@ object System {
         }
       case _ =>
         mismatch()
-    })
+    }
   }
 
   @inline
@@ -284,9 +286,7 @@ object System {
 
   @inline
   def getenv(name: String): String = {
-    if (name eq null)
-      throw new NullPointerException
-
+    requireNonNull(name)
     null
   }
 

--- a/javalib/src/main/scala/java/lang/Throwables.scala
+++ b/javalib/src/main/scala/java/lang/Throwables.scala
@@ -13,6 +13,7 @@
 package java.lang
 
 import java.util.function._
+import java.util.Objects.requireNonNull
 
 import scala.scalajs.js.annotation.JSExport
 
@@ -64,8 +65,7 @@ class Throwable protected (s: String, private var e: Throwable,
     if (writableStackTrace) {
       var i = 0
       while (i < stackTrace.length) {
-        if (stackTrace(i) eq null)
-          throw new NullPointerException()
+        requireNonNull(stackTrace(i))
         i += 1
       }
 
@@ -155,8 +155,7 @@ class Throwable protected (s: String, private var e: Throwable,
   }
 
   def addSuppressed(exception: Throwable): Unit = {
-    if (exception eq null)
-      throw new NullPointerException
+    requireNonNull(exception)
     if (exception eq this)
       throw new IllegalArgumentException
 

--- a/javalib/src/main/scala/java/lang/_String.scala
+++ b/javalib/src/main/scala/java/lang/_String.scala
@@ -14,10 +14,7 @@ package java.lang
 
 import scala.annotation.{switch, tailrec}
 
-import java.util.Comparator
-
 import scala.scalajs.js
-import scala.scalajs.js.annotation._
 import scala.scalajs.js.JSStringOps.enableJSStringOps
 import scala.scalajs.LinkingInfo
 import scala.scalajs.LinkingInfo.ESVersion
@@ -25,7 +22,8 @@ import scala.scalajs.LinkingInfo.ESVersion
 import java.lang.constant.{Constable, ConstantDesc}
 import java.nio.ByteBuffer
 import java.nio.charset.Charset
-import java.util.Locale
+import java.util.{Comparator, Locale}
+import java.util.Objects.requireNonNull
 import java.util.function._
 import java.util.regex._
 
@@ -196,8 +194,9 @@ final class _String private () // scalastyle:ignore
   @inline
   def endsWith(suffix: String): scala.Boolean = {
     if (LinkingInfo.esVersion >= ESVersion.ES2015) {
-      suffix.getClass() // null check
-      thisString.asInstanceOf[js.Dynamic].endsWith(suffix).asInstanceOf[scala.Boolean]
+      thisString.asInstanceOf[js.Dynamic]
+        .endsWith(requireNonNull(suffix))
+        .asInstanceOf[scala.Boolean]
     } else {
       thisString.jsSubstring(this.length() - suffix.length()) == suffix
     }
@@ -294,16 +293,15 @@ final class _String private () // scalastyle:ignore
    */
   def regionMatches(ignoreCase: scala.Boolean, toffset: Int, other: String,
       ooffset: Int, len: Int): scala.Boolean = {
-    if (other == null) {
-      throw new NullPointerException()
-    } else if (toffset < 0 || ooffset < 0 || len > this.length() - toffset ||
-        len > other.length() - ooffset) {
+    val otherNonNull = requireNonNull(other)
+    if (toffset < 0 || ooffset < 0 || len > this.length() - toffset ||
+        len > otherNonNull.length() - ooffset) {
       false
     } else if (len <= 0) {
       true
     } else {
       val left = this.substring(toffset, toffset + len)
-      val right = other.substring(ooffset, ooffset + len)
+      val right = otherNonNull.substring(ooffset, ooffset + len)
       if (ignoreCase) left.equalsIgnoreCase(right) else left == right
     }
   }
@@ -364,8 +362,9 @@ final class _String private () // scalastyle:ignore
   @inline
   def startsWith(prefix: String): scala.Boolean = {
     if (LinkingInfo.esVersion >= ESVersion.ES2015) {
-      prefix.getClass() // null check
-      thisString.asInstanceOf[js.Dynamic].startsWith(prefix).asInstanceOf[scala.Boolean]
+      thisString.asInstanceOf[js.Dynamic]
+        .startsWith(requireNonNull(prefix))
+        .asInstanceOf[scala.Boolean]
     } else {
       thisString.jsSubstring(0, prefix.length()) == prefix
     }
@@ -387,8 +386,9 @@ final class _String private () // scalastyle:ignore
 
     toffset <= length() && toffset >= 0 && {
       if (LinkingInfo.esVersion >= ESVersion.ES2015) {
-        prefix.getClass() // null check
-        thisString.asInstanceOf[js.Dynamic].startsWith(prefix, toffset).asInstanceOf[scala.Boolean]
+        thisString.asInstanceOf[js.Dynamic]
+          .startsWith(requireNonNull(prefix), toffset)
+          .asInstanceOf[scala.Boolean]
       } else {
         thisString.jsSubstring(toffset, toffset + prefix.length()) == prefix
       }
@@ -1040,11 +1040,8 @@ object _String { // scalastyle:ignore
     result
   }
 
-  def `new`(original: String): String = {
-    if (original == null)
-      throw new NullPointerException
-    original
-  }
+  def `new`(original: String): String =
+    requireNonNull(original)
 
   def `new`(buffer: java.lang.StringBuffer): String =
     buffer.toString

--- a/javalib/src/main/scala/java/lang/_String.scala
+++ b/javalib/src/main/scala/java/lang/_String.scala
@@ -373,13 +373,25 @@ final class _String private () // scalastyle:ignore
 
   @inline
   def startsWith(prefix: String, toffset: Int): scala.Boolean = {
-    if (LinkingInfo.esVersion >= ESVersion.ES2015) {
-      prefix.getClass() // null check
-      (toffset <= length() && toffset >= 0 &&
-        thisString.asInstanceOf[js.Dynamic].startsWith(prefix, toffset).asInstanceOf[scala.Boolean])
-    } else {
-      (toffset <= length() && toffset >= 0 &&
-      thisString.jsSubstring(toffset, toffset + prefix.length()) == prefix)
+    /* If `prefix == null` and the offset is out of bounds, the result is not
+     * clearly specified. The JavaDoc could be interpreted as either returning
+     * false or throwing. The JVM is inconsistent. On Temurin, it returns
+     * `false` for a negative `toffset`, but throws an NPE for
+     * `toffset >= this.length()`.
+     *
+     * Since our NPEs are UB, we choose to be maximally tolerant. We want to
+     * delay the UB until there is no other choice. This guarantees that *if*
+     * the JVM returns `false`, *then* we don't run into UB. We run into UB
+     * *only if* the JVM throws an NPE (but not always).
+     */
+
+    toffset <= length() && toffset >= 0 && {
+      if (LinkingInfo.esVersion >= ESVersion.ES2015) {
+        prefix.getClass() // null check
+        thisString.asInstanceOf[js.Dynamic].startsWith(prefix, toffset).asInstanceOf[scala.Boolean]
+      } else {
+        thisString.jsSubstring(toffset, toffset + prefix.length()) == prefix
+      }
     }
   }
 

--- a/javalib/src/main/scala/java/lang/reflect/Array.scala
+++ b/javalib/src/main/scala/java/lang/reflect/Array.scala
@@ -12,6 +12,8 @@
 
 package java.lang.reflect
 
+import java.util.Objects.requireNonNull
+
 object Array {
   @inline
   def newInstance(componentType: Class[_], length: Int): AnyRef =
@@ -208,7 +210,7 @@ object Array {
   }
 
   private def mismatch(array: AnyRef): Nothing = {
-    array.getClass() // null check
+    requireNonNull(array)
     throw new IllegalArgumentException("argument type mismatch")
   }
 }

--- a/javalib/src/main/scala/java/math/BigDecimal.scala
+++ b/javalib/src/main/scala/java/math/BigDecimal.scala
@@ -27,6 +27,7 @@ import scala.annotation.tailrec
 
 import java.lang.{Double => JDouble}
 import java.util.Arrays
+import java.util.Objects.requireNonNull
 import java.util.ScalaOps._
 
 object BigDecimal {
@@ -393,9 +394,7 @@ class BigDecimal() extends Number with Comparable[BigDecimal] {
 
     val last = offset + len - 1 // last index to be copied
 
-    if (in == null)
-      throw new NullPointerException("in == null")
-
+    // implicit null check for `in`
     if (last >= in.length || offset < 0 || len <= 0 || last < 0) {
       throw new NumberFormatException(
           s"Bad offset/length: offset=${offset} len=$len in.length=${in.length}")
@@ -557,11 +556,8 @@ class BigDecimal() extends Number with Comparable[BigDecimal] {
 
   def this(unscaledVal: BigInteger, scale: Int) = {
     this()
-    if (unscaledVal == null)
-      throw new NullPointerException("unscaledVal == null")
-
     _scale = scale
-    setUnscaledValue(unscaledVal)
+    setUnscaledValue(requireNonNull(unscaledVal))
   }
 
   def this(bi: BigInteger) = {
@@ -743,9 +739,8 @@ class BigDecimal() extends Number with Comparable[BigDecimal] {
     divide(divisor, scale, RoundingMode.valueOf(roundingMode))
 
   def divide(divisor: BigDecimal, scale: Int, roundingMode: RoundingMode): BigDecimal = {
-    if (roundingMode == null)
-      throw new NullPointerException("roundingMode == null")
-    else if (divisor.isZero)
+    requireNonNull(roundingMode)
+    if (divisor.isZero)
       throw new ArithmeticException("Division by zero")
 
     val diffScale = {
@@ -1181,8 +1176,7 @@ class BigDecimal() extends Number with Comparable[BigDecimal] {
   }
 
   def setScale(newScale: Int, roundingMode: RoundingMode): BigDecimal = {
-    if (roundingMode == null)
-      throw new NullPointerException("roundingMode == null")
+    requireNonNull(roundingMode)
 
     val diffScale = newScale - _scale.toLong
     if (diffScale == 0) {

--- a/javalib/src/main/scala/java/math/BigInteger.scala
+++ b/javalib/src/main/scala/java/math/BigInteger.scala
@@ -43,6 +43,7 @@ package java.math
 
 import scala.annotation.tailrec
 
+import java.util.Objects.requireNonNull
 import java.util.Random
 import java.util.ScalaOps._
 import java.util.function._
@@ -117,14 +118,6 @@ object BigInteger {
     }
   }
 
-  @inline
-  private def checkNotNull[T <: AnyRef](reference: T): reference.type = {
-    if (reference == null)
-      throw new NullPointerException
-    else
-      reference
-  }
-
   private[math] def checkRangeBasedOnIntArrayLength(byteLength: Int): Unit = {
     if (byteLength < 0 || byteLength >= ((Int.MaxValue + 1) >>> 5))
       throw new ArithmeticException("BigInteger would overflow supported range")
@@ -182,7 +175,7 @@ class BigInteger extends Number with Comparable[BigInteger] {
 
   def this(signum: Int, magnitude: Array[Byte]) = {
     this()
-    checkNotNull(magnitude)
+    requireNonNull(magnitude)
     if ((signum < -1) || (signum > 1))
       throw new NumberFormatException("Invalid signum value")
     if (signum == 0) {
@@ -238,7 +231,7 @@ class BigInteger extends Number with Comparable[BigInteger] {
 
   def this(s: String, radix: Int) = {
     this()
-    checkNotNull(s)
+    requireNonNull(s)
     if (Character.isRadixInvalid(radix))
       throw new NumberFormatException("Radix out of range")
     if (s.isEmpty)

--- a/javalib/src/main/scala/java/math/MathContext.scala
+++ b/javalib/src/main/scala/java/math/MathContext.scala
@@ -23,6 +23,8 @@
 
 package java.math
 
+import java.util.Objects.requireNonNull
+
 object MathContext {
 
   val DECIMAL128 = MathContext(34, RoundingMode.HALF_EVEN)
@@ -37,10 +39,9 @@ object MathContext {
     new MathContext(precision, roundingMode)
 
   private def getArgs(s: String): (Int, RoundingMode) = {
-    checkNotNull(s, "null string")
     val precisionLength = "precision=".length
     val roundingModeLength = "roundingMode=".length
-    val spaceIndex = s.indexOf(' ', precisionLength)
+    val spaceIndex = s.indexOf(' ', precisionLength) // implicit null check for `s`
 
     if (!s.startsWith("precision=") || spaceIndex == -1)
       invalidMathContext("Missing precision", s)
@@ -66,18 +67,15 @@ object MathContext {
 
   private def invalidMathContext(reason: String, s: String): Nothing =
     throw new IllegalArgumentException(reason + ": " + s)
-
-  private def checkNotNull(reference: AnyRef, errorMessage: AnyRef): Unit = {
-    if (reference == null)
-      throw new NullPointerException(String.valueOf(errorMessage))
-  }
 }
 
 class MathContext(setPrecision: Int, setRoundingMode: RoundingMode) {
+  if (setPrecision < 0)
+    throw new IllegalArgumentException("Negative precision: " + setPrecision)
 
   private[math] val precision = setPrecision
 
-  private[math] val roundingMode = setRoundingMode
+  private[math] val roundingMode = requireNonNull(setRoundingMode)
 
   def getPrecision(): Int = precision
 
@@ -93,7 +91,6 @@ class MathContext(setPrecision: Int, setRoundingMode: RoundingMode) {
 
   def this(s: String) = {
     this(MathContext.getArgs(s))
-    checkValid()
   }
 
   override def equals(x: Any): Boolean = x match {
@@ -108,11 +105,4 @@ class MathContext(setPrecision: Int, setRoundingMode: RoundingMode) {
 
   override def toString(): String =
     "precision=" + precision + " roundingMode=" + roundingMode
-
-  private def checkValid(): Unit = {
-    if (precision < 0)
-      throw new IllegalArgumentException("Negative precision: " + precision)
-    if (roundingMode == null)
-      throw new NullPointerException("roundingMode == null")
-  }
 }

--- a/javalib/src/main/scala/java/nio/ByteBuffer.scala
+++ b/javalib/src/main/scala/java/nio/ByteBuffer.scala
@@ -12,6 +12,8 @@
 
 package java.nio
 
+import java.util.Objects.requireNonNull
+
 import scala.scalajs.js
 import scala.scalajs.js.typedarray._
 
@@ -167,9 +169,7 @@ abstract class ByteBuffer private[nio] (
     else ByteOrder.LITTLE_ENDIAN
 
   final def order(bo: ByteOrder): ByteBuffer = {
-    if (bo == null)
-      throw new NullPointerException
-    _isBigEndian = bo == ByteOrder.BIG_ENDIAN
+    _isBigEndian = requireNonNull(bo) == ByteOrder.BIG_ENDIAN
     this
   }
 

--- a/javalib/src/main/scala/java/util/ArrayDeque.scala
+++ b/javalib/src/main/scala/java/util/ArrayDeque.scala
@@ -15,6 +15,7 @@ package java.util
 import java.lang.Cloneable
 import java.lang.Utils._
 
+import java.util.Objects.requireNonNull
 import java.util.ScalaOps._
 
 class ArrayDeque[E] private (initialCapacity: Int)
@@ -45,33 +46,27 @@ class ArrayDeque[E] private (initialCapacity: Int)
     offerLast(e)
 
   def offerFirst(e: E): Boolean = {
-    if (e == null) {
-      throw new NullPointerException()
-    } else {
-      ensureCapacityForAdd()
-      startIndex -= 1
-      if (startIndex < 0)
-        startIndex = inner.length - 1
-      inner(startIndex) = e.asInstanceOf[AnyRef]
-      status += 1
-      empty = false
-      true
-    }
+    requireNonNull(e)
+    ensureCapacityForAdd()
+    startIndex -= 1
+    if (startIndex < 0)
+      startIndex = inner.length - 1
+    inner(startIndex) = e.asInstanceOf[AnyRef]
+    status += 1
+    empty = false
+    true
   }
 
   def offerLast(e: E): Boolean = {
-    if (e == null) {
-      throw new NullPointerException()
-    } else {
-      ensureCapacityForAdd()
-      endIndex += 1
-      if (endIndex > inner.length)
-        endIndex = 1
-      inner(endIndex - 1) = e.asInstanceOf[AnyRef]
-      status += 1
-      empty = false
-      true
-    }
+    requireNonNull(e)
+    ensureCapacityForAdd()
+    endIndex += 1
+    if (endIndex > inner.length)
+      endIndex = 1
+    inner(endIndex - 1) = e.asInstanceOf[AnyRef]
+    status += 1
+    empty = false
+    true
   }
 
   def removeFirst(): E = {

--- a/javalib/src/main/scala/java/util/Comparator.scala
+++ b/javalib/src/main/scala/java/util/Comparator.scala
@@ -12,6 +12,7 @@
 
 package java.util
 
+import java.util.Objects.requireNonNull
 import java.util.function._
 
 // scalastyle:off equals.hash.code
@@ -39,7 +40,7 @@ trait Comparator[A] { self =>
 
   @inline
   def thenComparing(other: Comparator[_ >: A]): Comparator[A] = {
-    other.getClass() // null check
+    requireNonNull(other)
     new Comparator[A] with Serializable {
       def compare(o1: A, o2: A) = {
         val cmp = self.compare(o1, o2)
@@ -126,8 +127,8 @@ object Comparator {
   @inline
   def comparing[T, U](keyExtractor: Function[_ >: T, _ <: U],
       keyComparator: Comparator[_ >: U]): Comparator[T] = {
-    keyExtractor.getClass() // null check
-    keyComparator.getClass() // null check
+    requireNonNull(keyExtractor)
+    requireNonNull(keyComparator)
     new Comparator[T] with Serializable {
       def compare(o1: T, o2: T): Int =
         keyComparator.compare(keyExtractor(o1), keyExtractor(o2))
@@ -140,7 +141,7 @@ object Comparator {
   @inline
   def comparing[T, U <: Comparable[U]](
       keyExtractor: Function[_ >: T, _ <: U]): Comparator[T] = {
-    keyExtractor.getClass() // null check
+    requireNonNull(keyExtractor)
     new Comparator[T] with Serializable {
       def compare(o1: T, o2: T): Int =
         keyExtractor(o1).compareTo(keyExtractor(o2))
@@ -149,7 +150,7 @@ object Comparator {
 
   @inline
   def comparingInt[T](keyExtractor: ToIntFunction[_ >: T]): Comparator[T] = {
-    keyExtractor.getClass() // null check
+    requireNonNull(keyExtractor)
     new Comparator[T] with Serializable {
       def compare(o1: T, o2: T): Int =
         Integer.compare(keyExtractor.applyAsInt(o1), keyExtractor.applyAsInt(o2))
@@ -158,7 +159,7 @@ object Comparator {
 
   @inline
   def comparingLong[T](keyExtractor: ToLongFunction[_ >: T]): Comparator[T] = {
-    keyExtractor.getClass() // null check
+    requireNonNull(keyExtractor)
     new Comparator[T] with Serializable {
       def compare(o1: T, o2: T): Int =
         java.lang.Long.compare(keyExtractor.applyAsLong(o1), keyExtractor.applyAsLong(o2))
@@ -167,7 +168,7 @@ object Comparator {
 
   @inline
   def comparingDouble[T](keyExtractor: ToDoubleFunction[_ >: T]): Comparator[T] = {
-    keyExtractor.getClass() // null check
+    requireNonNull(keyExtractor)
     new Comparator[T] with Serializable {
       def compare(o1: T, o2: T): Int =
         java.lang.Double.compare(keyExtractor.applyAsDouble(o1), keyExtractor.applyAsDouble(o2))

--- a/javalib/src/main/scala/java/util/NullRejectingHashMap.scala
+++ b/javalib/src/main/scala/java/util/NullRejectingHashMap.scala
@@ -12,6 +12,8 @@
 
 package java.util
 
+import java.util.Objects.requireNonNull
+
 /** A subclass of `HashMap` that systematically rejects `null` keys and values.
  *
  *  This class is used as the implementation of some other hashtable-like data
@@ -39,27 +41,17 @@ private[util] class NullRejectingHashMap[K, V](
     new NullRejectingHashMap.Node(key, hash, value, previous, next)
   }
 
-  override def get(key: Any): V = {
-    if (key == null)
-      throw new NullPointerException()
-    super.get(key)
-  }
+  override def get(key: Any): V =
+    super.get(requireNonNull(key))
 
-  override def containsKey(key: Any): Boolean = {
-    if (key == null)
-      throw new NullPointerException()
-    super.containsKey(key)
-  }
+  override def containsKey(key: Any): Boolean =
+    super.containsKey(requireNonNull(key))
 
-  override def put(key: K, value: V): V = {
-    if (key == null || value == null)
-      throw new NullPointerException()
-    super.put(key, value)
-  }
+  override def put(key: K, value: V): V =
+    super.put(requireNonNull(key), requireNonNull(value))
 
   override def putIfAbsent(key: K, value: V): V = {
-    if (value == null)
-      throw new NullPointerException()
+    requireNonNull(value)
     val old = get(key) // throws if `key` is null
     if (old == null)
       super.put(key, value)
@@ -83,11 +75,8 @@ private[util] class NullRejectingHashMap[K, V](
     impl(m)
   }
 
-  override def remove(key: Any): V = {
-    if (key == null)
-      throw new NullPointerException()
-    super.remove(key)
-  }
+  override def remove(key: Any): V =
+    super.remove(requireNonNull(key))
 
   override def remove(key: Any, value: Any): Boolean = {
     val old = get(key) // throws if `key` is null
@@ -100,8 +89,8 @@ private[util] class NullRejectingHashMap[K, V](
   }
 
   override def replace(key: K, oldValue: V, newValue: V): Boolean = {
-    if (oldValue == null || newValue == null)
-      throw new NullPointerException()
+    requireNonNull(oldValue)
+    requireNonNull(newValue)
     val old = get(key) // throws if `key` is null
     if (oldValue.equals(old)) { // false if `old` is null
       super.put(key, newValue)
@@ -112,19 +101,15 @@ private[util] class NullRejectingHashMap[K, V](
   }
 
   override def replace(key: K, value: V): V = {
-    if (value == null)
-      throw new NullPointerException()
+    requireNonNull(value)
     val old = get(key) // throws if `key` is null
     if (old != null)
       super.put(key, value)
     old
   }
 
-  override def containsValue(value: Any): Boolean = {
-    if (value == null)
-      throw new NullPointerException()
-    super.containsValue(value)
-  }
+  override def containsValue(value: Any): Boolean =
+    super.containsValue(requireNonNull(value))
 
   override def clone(): AnyRef =
     new NullRejectingHashMap[K, V](this)
@@ -135,10 +120,7 @@ private object NullRejectingHashMap {
       previous: HashMap.Node[K, V], next: HashMap.Node[K, V])
       extends HashMap.Node[K, V](key, hash, value, previous, next) {
 
-    override def setValue(v: V): V = {
-      if (v == null)
-        throw new NullPointerException()
-      super.setValue(v)
-    }
+    override def setValue(v: V): V =
+      super.setValue(requireNonNull(v))
   }
 }

--- a/javalib/src/main/scala/java/util/Objects.scala
+++ b/javalib/src/main/scala/java/util/Objects.scala
@@ -66,14 +66,17 @@ object Objects {
     if (a.asInstanceOf[AnyRef] eq b.asInstanceOf[AnyRef]) 0
     else c.compare(a, b)
 
+  // Intrinsic
   @inline
-  def requireNonNull[T](obj: T): T =
-    if (obj == null) throw new NullPointerException
-    else obj
+  def requireNonNull[T](obj: T): T = {
+    obj.getClass() // null check
+    obj
+  }
 
+  // Intrinsic
   @inline
   def requireNonNull[T](obj: T, message: String): T =
-    if (obj == null) throw new NullPointerException(message)
+    if (obj == null) throwNPEWithMessage(message)
     else obj
 
   @inline
@@ -84,8 +87,65 @@ object Objects {
   def nonNull(obj: Any): Boolean =
     obj != null
 
+  // Intrinsic
   @inline
   def requireNonNull[T](obj: T, messageSupplier: Supplier[String]): T =
-    if (obj == null) throw new NullPointerException(messageSupplier.get())
+    if (obj == null) throwNPEWithMessage(messageSupplier)
     else obj
+
+  /* The following methods are our best attempt to deal with the overloads of
+   * `requireNonNull` with an explicit message. We want to trigger a UB NPE.
+   * However, if we do that, we lose the `message`. This is fine for the
+   * Unchecked behavior, debatable for Fatal, and plain wrong for Compliant.
+   *
+   * To recover the message in Compliant mode, we immediately catch a genuine
+   * NPE if that is what the UB throws, and rethrow a genuine NPE with the
+   * correct message.
+   *
+   * In Fatal mode, there is unfortunately nothing we can do. We have no way
+   * of constructing another UndefinedBehaviorError with a different cause.
+   *
+   * ---
+   *
+   * For the overload with a Supplier, there is an additional semantic decision
+   * to make: when `obj == null`, when exactly do we call
+   * `messageSupplier.get()`? There are two valid choices:
+   *
+   * - always, regardless of the checked behavior, or
+   * - only if and when we actually need a message, which would only happen in
+   *   Compliant mode.
+   *
+   * We choose the latter alternative, because it is better optimizable.
+   * A program that would rely on the supplier being evaluated in non-Compliant
+   * mode would be dubious anyway. That would only result in well-defined
+   * semantics if its `get()` method threw an exception itself.
+   *
+   * ---
+   *
+   * The methods are `@noinline` because they are in a slow path anyway.
+   * We don't want the try..catch'es to appear at call site. That pollutes
+   * performance for the entire enclosing function in some engines.
+   */
+
+  @noinline private def throwNPEWithMessage(message: String): Nothing = {
+    try {
+      throw null
+    } catch {
+      case _: NullPointerException =>
+        throw new NullPointerException(message)
+    }
+  }
+
+  @noinline private def throwNPEWithMessage(messageSupplier: Supplier[String]): Nothing = {
+    try {
+      throw null
+    } catch {
+      case _: NullPointerException =>
+        /* It is important that we only call `messageSupplier.get()` here (after UB).
+         * Otherwise a throwing messageSupplier might mask UB in Unchecked mode.
+         * For example in: `requireNonNull(null, () => throw new IllegalArgumentException())`.
+         */
+        throw new NullPointerException(messageSupplier.get())
+    }
+  }
 }

--- a/javalib/src/main/scala/java/util/Optional.scala
+++ b/javalib/src/main/scala/java/util/Optional.scala
@@ -13,6 +13,7 @@
 package java.util
 
 import java.util.function._
+import java.util.Objects.requireNonNull
 
 final class Optional[T] private (value: T) {
   import Optional._
@@ -95,12 +96,8 @@ final class Optional[T] private (value: T) {
 object Optional {
   def empty[T](): Optional[T] = new Optional[T](null.asInstanceOf[T])
 
-  def of[T](value: T): Optional[T] = {
-    if (value == null)
-      throw new NullPointerException()
-    else
-      new Optional[T](value)
-  }
+  def of[T](value: T): Optional[T] =
+    new Optional[T](requireNonNull(value))
 
   def ofNullable[T](value: T): Optional[T] = new Optional[T](value)
 

--- a/javalib/src/main/scala/java/util/PriorityQueue.scala
+++ b/javalib/src/main/scala/java/util/PriorityQueue.scala
@@ -18,6 +18,8 @@ import scala.annotation.tailrec
 
 import java.lang.Utils.roundUpToPowerOfTwo
 
+import java.util.Objects.requireNonNull
+
 import scala.scalajs.LinkingInfo
 
 class PriorityQueue[E] private (
@@ -87,9 +89,7 @@ class PriorityQueue[E] private (
   private var inner: innerImpl.Repr[E] = innerImpl.make[E](initialCapacity)
 
   override def add(e: E): Boolean = {
-    if (e == null)
-      throw new NullPointerException()
-    val newInner = innerImpl.push(inner, e)
+    val newInner = innerImpl.push(inner, requireNonNull(e))
     if (LinkingInfo.isWebAssembly) // opt: for JS we know it's always the same
       inner = newInner
     fixUp(innerImpl.length(inner) - 1)

--- a/javalib/src/main/scala/java/util/Throwables.scala
+++ b/javalib/src/main/scala/java/util/Throwables.scala
@@ -12,6 +12,8 @@
 
 package java.util
 
+import java.util.Objects.requireNonNull
+
 class ServiceConfigurationError(s: String, e: Throwable) extends Error(s, e) {
   def this(s: String) = this(s, null)
 }
@@ -21,8 +23,7 @@ class ConcurrentModificationException(s: String) extends RuntimeException(s) {
 }
 
 class DuplicateFormatFlagsException(f: String) extends IllegalFormatException {
-  if (f == null)
-    throw new NullPointerException()
+  requireNonNull(f)
 
   def getFlags(): String = f
   override def getMessage(): String = "Flags = '" + f + "'"
@@ -31,9 +32,7 @@ class DuplicateFormatFlagsException(f: String) extends IllegalFormatException {
 class EmptyStackException extends RuntimeException
 
 class FormatFlagsConversionMismatchException(f: String, c: Char) extends IllegalFormatException {
-
-  if (f == null)
-    throw new NullPointerException()
+  requireNonNull(f)
 
   def getFlags(): String = f
   def getConversion(): Char = c
@@ -48,9 +47,7 @@ class IllegalFormatCodePointException(c: Int) extends IllegalFormatException {
 }
 
 class IllegalFormatConversionException(c: Char, arg: Class[_]) extends IllegalFormatException {
-
-  if (arg == null)
-    throw new NullPointerException()
+  requireNonNull(arg)
 
   def getConversion(): Char = c
   def getArgumentClass(): Class[_] = arg
@@ -61,8 +58,7 @@ class IllegalFormatConversionException(c: Char, arg: Class[_]) extends IllegalFo
 class IllegalFormatException private[util] () extends IllegalArgumentException
 
 class IllegalFormatFlagsException(f: String) extends IllegalFormatException {
-  if (f == null)
-    throw new NullPointerException()
+  requireNonNull(f)
 
   def getFlags(): String = f
   override def getMessage(): String = "Flags = '" + f + "'"
@@ -107,16 +103,14 @@ class InvalidPropertiesFormatException(s: String) extends java.io.IOException(s)
 }
 
 class MissingFormatArgumentException(s: String) extends IllegalFormatException {
-  if (s == null)
-    throw new NullPointerException()
+  requireNonNull(s)
 
   def getFormatSpecifier(): String = s
   override def getMessage(): String = "Format specifier '" + s + "'"
 }
 
 class MissingFormatWidthException(s: String) extends IllegalFormatException {
-  if (s == null)
-    throw new NullPointerException()
+  requireNonNull(s)
 
   def getFormatSpecifier(): String = s
   override def getMessage(): String = s
@@ -139,17 +133,14 @@ class TooManyListenersException(s: String) extends Exception(s) {
 }
 
 class UnknownFormatConversionException(s: String) extends IllegalFormatException {
-
-  if (s == null)
-    throw new NullPointerException()
+  requireNonNull(s)
 
   def getConversion(): String = s
   override def getMessage(): String = "Conversion = '" + s + "'"
 }
 
 class UnknownFormatFlagsException(f: String) extends IllegalFormatException {
-  if (f == null)
-    throw new NullPointerException()
+  requireNonNull(f)
 
   def getFlags(): String = f
   override def getMessage(): String = "Flags = " + f

--- a/javalib/src/main/scala/java/util/TreeMap.scala
+++ b/javalib/src/main/scala/java/util/TreeMap.scala
@@ -13,6 +13,7 @@
 package java.util
 
 import java.lang.Cloneable
+import java.util.Objects.requireNonNull
 import java.util.{RedBlackTree => RB}
 import java.util.function.{Function, BiFunction}
 
@@ -113,7 +114,7 @@ class TreeMap[K, V] private (tree: RB.Tree[K, V])(
   }
 
   override def merge(key: K, value: V, remappingFunction: BiFunction[_ >: V, _ >: V, _ <: V]): V = {
-    value.getClass() // null check
+    requireNonNull(value)
 
     val node = RB.getNode(tree, key)
     if (node eq null) {

--- a/javalib/src/main/scala/java/util/concurrent/ConcurrentHashMap.scala
+++ b/javalib/src/main/scala/java/util/concurrent/ConcurrentHashMap.scala
@@ -16,6 +16,7 @@ import java.util.function.{BiConsumer, Consumer}
 
 import java.io.Serializable
 import java.util._
+import java.util.Objects.requireNonNull
 
 class ConcurrentHashMap[K, V] private (initialCapacity: Int, loadFactor: Float)
     extends AbstractMap[K, V] with ConcurrentMap[K, V] with Serializable {
@@ -68,11 +69,8 @@ class ConcurrentHashMap[K, V] private (initialCapacity: Int, loadFactor: Float)
     new ConcurrentHashMap.KeySetView[K, V](this.inner, null.asInstanceOf[V])
   }
 
-  def keySet(mappedValue: V): ConcurrentHashMap.KeySetView[K, V] = {
-    if (mappedValue == null)
-      throw new NullPointerException()
-    new ConcurrentHashMap.KeySetView[K, V](this.inner, mappedValue)
-  }
+  def keySet(mappedValue: V): ConcurrentHashMap.KeySetView[K, V] =
+    new ConcurrentHashMap.KeySetView[K, V](this.inner, requireNonNull(mappedValue))
 
   def forEach(parallelismThreshold: Long, action: BiConsumer[_ >: K, _ >: V]): Unit = {
     // Note: It is tempting to simply call inner.forEach here:

--- a/javalib/src/main/scala/java/util/concurrent/ConcurrentLinkedQueue.scala
+++ b/javalib/src/main/scala/java/util/concurrent/ConcurrentLinkedQueue.scala
@@ -13,6 +13,7 @@
 package java.util.concurrent
 
 import java.util._
+import java.util.Objects.requireNonNull
 import java.util.ScalaOps._
 
 class ConcurrentLinkedQueue[E]() extends AbstractQueue[E] with Queue[E] with Serializable {
@@ -30,22 +31,18 @@ class ConcurrentLinkedQueue[E]() extends AbstractQueue[E] with Queue[E] with Ser
   private var _size: Double = 0
 
   override def add(e: E): Boolean = {
-    if (e == null) {
-      throw new NullPointerException()
-    } else {
-      val oldLast = last
+    val oldLast = last
 
-      last = new Node(e)
+    last = new Node(requireNonNull(e))
 
-      _size += 1
+    _size += 1
 
-      if (oldLast ne null)
-        oldLast.next = last
-      else
-        head = last
+    if (oldLast ne null)
+      oldLast.next = last
+    else
+      head = last
 
-      true
-    }
+    true
   }
 
   override def offer(e: E): Boolean =

--- a/javalib/src/main/scala/java/util/concurrent/ConcurrentSkipListSet.scala
+++ b/javalib/src/main/scala/java/util/concurrent/ConcurrentSkipListSet.scala
@@ -14,6 +14,7 @@ package java.util.concurrent
 
 import java.lang.Cloneable
 import java.util._
+import java.util.Objects.requireNonNull
 
 class ConcurrentSkipListSet[E] private (inner: TreeSet[E])
     extends AbstractSet[E] with NavigableSet[E] with Cloneable with Serializable {
@@ -44,12 +45,10 @@ class ConcurrentSkipListSet[E] private (inner: TreeSet[E])
     else inner.contains(o)
 
   override def add(e: E): Boolean =
-    if (e == null) throw new NullPointerException()
-    else inner.add(e)
+    inner.add(requireNonNull(e))
 
   override def remove(o: Any): Boolean =
-    if (o == null) throw new NullPointerException()
-    else inner.remove(o)
+    inner.remove(requireNonNull(o))
 
   override def clear(): Unit =
     inner.clear()

--- a/linker/shared/src/main/scala/org/scalajs/linker/frontend/optimizer/OptimizerCore.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/frontend/optimizer/OptimizerCore.scala
@@ -3341,6 +3341,81 @@ private[optimizer] abstract class OptimizerCore(
             default
         }
 
+      // java.util.Objects
+
+      case RequireNonNullNoMessage =>
+        // Replace by a checkNotNull so that the result gets a refined type in the process
+        val List(tobj) = targs
+        cont(checkNotNull(tobj))
+
+      case RequireNonNullWithMessage | RequireNonNullWithMessageSupplier =>
+        val List(tobj, tmessage) = targs
+
+        def objBinding = Binding.temp(LocalName("obj"), tobj)
+        def messageBinding = Binding.temp(LocalName("message"), tmessage)
+
+        semantics.nullPointers match {
+          case CheckedBehavior.Compliant if tobj.tpe.isNullable =>
+            /* Inline the specified semantics. We don't use the regular inlined
+             * body because it throws a dummy NPE that it catches before
+             * rethrowing the correct one.
+             *
+             * The constructor of NullPointerException and the `get()` method
+             * of `Supplier` must be reachable, since the javalib code must
+             * reference them (otherwise it could not be valid in the first
+             * place).
+             */
+            withNewLocalDefs(List(objBinding, messageBinding)) { (localDefs, cont1) =>
+              val List(objLocalDef, messageLocalDef) = localDefs
+
+              val actualMessage: Tree = if (intrinsicCode == RequireNonNullWithMessage) {
+                messageLocalDef.newReplacement
+              } else {
+                trampoline {
+                  pretransformApply(ApplyFlags.empty, messageLocalDef.toPreTransform,
+                      MethodIdent(SupplierGetMethodName), Nil, AnyType,
+                      isStat = false, usePreTransform = true) { tresultAny =>
+                    TailCalls.done {
+                      finishTransformExpr(foldAsInstanceOf(tresultAny, StringClassType))
+                    }
+                  }
+                }
+              }
+
+              val resultType = objLocalDef.tpe.base.toNonNullable
+
+              cont1(PreTransTree(Block(
+                If(BinaryOp(BinaryOp.===, objLocalDef.newReplacement, Null()), {
+                  UnaryOp(UnaryOp.Throw,
+                      New(NullPointerExceptionClass,
+                          MethodIdent(StringArgConstructorName), List(actualMessage)))
+                }, {
+                  finishTransformExpr(foldCast(objLocalDef.toPreTransform, resultType))
+                })(resultType)
+              )))
+            }(cont)
+
+          case _ =>
+            /* Evaluate the arguments, drop the message{,Supplier}, and check
+             * the obj for null (which is a cast in Unchecked). We can do this
+             * because the chosen semantics for the Fatal and Unchecked
+             * overloads of `requireNonNull` disregard the message{,Supplier}.
+             */
+            finishTransformStat(tmessage) match {
+              case Skip() =>
+                // Avoid the binding for tobj; use it as is
+                cont(checkNotNull(tobj))
+
+              case evalMessageStat =>
+                withNewLocalDef(objBinding) { (objLocalDef, cont1) =>
+                  cont1(PreTransBlock(
+                    evalMessageStat,
+                    checkNotNull(objLocalDef.toPreTransform)
+                  ))
+                }(cont)
+            }
+        }
+
       // js.special
 
       case ObjectLiteral =>
@@ -6399,12 +6474,15 @@ private[optimizer] object OptimizerCore {
     FieldName(JavaScriptExceptionClass, SimpleFieldName("exception"))
 
   private val AnyArgConstructorName = MethodName.constructor(List(ClassRef(ObjectClass)))
+  private val StringArgConstructorName = MethodName.constructor(List(ClassRef(BoxedStringClass)))
 
   private val TupleFirstMethodName = MethodName("_1", Nil, ClassRef(ObjectClass))
   private val TupleSecondMethodName = MethodName("_2", Nil, ClassRef(ObjectClass))
 
   private val ClassTagApplyMethodName =
     MethodName("apply", List(ClassRef(ClassClass)), ClassRef(ClassName("scala.reflect.ClassTag")))
+
+  private val SupplierGetMethodName = MethodName("get", Nil, ObjectRef)
 
   def isUnsignedPowerOf2(x: Int): Boolean =
     (x & (x - 1)) == 0 && x != 0
@@ -7303,7 +7381,11 @@ private[optimizer] object OptimizerCore {
 
     final val ClassGetName = GenericArrayBuilderResult + 1
 
-    final val ArrayToJSArray = ClassGetName + 1
+    final val RequireNonNullNoMessage = ClassGetName + 1
+    final val RequireNonNullWithMessage = RequireNonNullNoMessage + 1
+    final val RequireNonNullWithMessageSupplier = RequireNonNullWithMessage + 1
+
+    final val ArrayToJSArray = RequireNonNullWithMessageSupplier + 1
 
     final val ObjectLiteral = ArrayToJSArray + 1
 
@@ -7338,6 +7420,7 @@ private[optimizer] object OptimizerCore {
     private val O = ClassRef(ObjectClass)
     private val ClassClassRef = ClassRef(ClassClass)
     private val StringClassRef = ClassRef(BoxedStringClass)
+    private val SupplierClassRef = ClassRef(ClassName("java.util.function.Supplier"))
     private val SeqClassRef = ClassRef(ClassName("scala.collection.Seq"))
     private val ImmutableSeqClassRef = ClassRef(ClassName("scala.collection.immutable.Seq"))
     private val JSObjectClassRef = ClassRef(ClassName("scala.scalajs.js.Object"))
@@ -7360,6 +7443,11 @@ private[optimizer] object OptimizerCore {
       ),
       ClassName("java.lang.Class") -> List(
         m("getName", Nil, StringClassRef) -> ClassGetName
+      ),
+      ClassName("java.util.Objects$") -> List(
+        m("requireNonNull", List(O), O) -> RequireNonNullNoMessage,
+        m("requireNonNull", List(O, StringClassRef), O) -> RequireNonNullWithMessage,
+        m("requireNonNull", List(O, SupplierClassRef), O) -> RequireNonNullWithMessageSupplier
       ),
       ClassName("scala.scalajs.runtime.package$") -> List(
         m("genericArrayToJSArray", List(O), JSArrayClassRef) -> ArrayToJSArray,

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/lang/StringBufferTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/lang/StringBufferTest.scala
@@ -16,7 +16,6 @@ import org.junit.Test
 import org.junit.Assert._
 
 import org.scalajs.testsuite.utils.AssertThrows.{assertThrows, _}
-import org.scalajs.testsuite.utils.Platform.executingInJVM
 
 import WrappedStringCharSequence.charSequence
 
@@ -43,19 +42,13 @@ class StringBufferTest {
   @Test def initString(): Unit = {
     assertEquals("hello", new StringBuffer("hello").toString())
 
-    if (executingInJVM) {
-      assertThrows(classOf[NullPointerException],
-          new StringBuffer(null: String))
-    }
+    assertThrowsNPEIfCompliant(new StringBuffer(null: String))
   }
 
   @Test def initCharSequence(): Unit = {
     assertEquals("hello", new StringBuffer(charSequence("hello")).toString())
 
-    if (executingInJVM) {
-      assertThrows(classOf[NullPointerException],
-          new StringBuffer(null: CharSequence))
-    }
+    assertThrowsNPEIfCompliant(new StringBuffer(null: CharSequence))
   }
 
   @Test def appendAnyRef(): Unit = {
@@ -113,8 +106,7 @@ class StringBufferTest {
 
     assertEquals("hello", resultFor(Array('h', 'e', 'l', 'l', 'o')))
 
-    if (executingInJVM)
-      assertThrows(classOf[NullPointerException], resultFor(null))
+    assertThrowsNPEIfCompliant(resultFor(null))
   }
 
   @Test def appendCharArrayOffsetLen(): Unit = {
@@ -125,8 +117,7 @@ class StringBufferTest {
     assertEquals("hello", resultFor(arr, 0, 5))
     assertEquals("ell", resultFor(arr, 1, 3))
 
-    if (executingInJVM)
-      assertThrows(classOf[NullPointerException], resultFor(null, 0, 0))
+    assertThrowsNPEIfCompliant(resultFor(null, 0, 0))
 
     assertThrows(classOf[IndexOutOfBoundsException], resultFor(arr, -1, 2))
     assertThrows(classOf[IndexOutOfBoundsException], resultFor(arr, 3, 3))
@@ -202,8 +193,7 @@ class StringBufferTest {
     assertThrowsStringIIOBEIfCompliant(resultFor("0123", 4, 3, "x"))
     assertThrowsStringIIOBEIfCompliant(resultFor("0123", 5, 8, "x"))
 
-    if (executingInJVM)
-      assertThrows(classOf[NullPointerException], resultFor("0123", 1, 3, null))
+    assertThrowsNPEIfCompliant(resultFor("0123", 1, 3, null))
   }
 
   @Test def insertCharArrayOffsetLen(): Unit = {
@@ -224,10 +214,7 @@ class StringBufferTest {
     assertThrowsStringIIOBEIfCompliant(resultFor("1234", 1, arr, 1, -2))
     assertThrowsStringIIOBEIfCompliant(resultFor("1234", 1, arr, 4, 3))
 
-    if (executingInJVM) {
-      assertThrows(classOf[NullPointerException],
-          resultFor("1234", 1, null, 0, 0))
-    }
+    assertThrowsNPEIfCompliant(resultFor("1234", 1, null, 0, 0))
   }
 
   @Test def insertAnyRef(): Unit = {
@@ -266,8 +253,7 @@ class StringBufferTest {
     assertThrowsStringIIOBEIfCompliant(resultFor("1234", -1, arr))
     assertThrowsStringIIOBEIfCompliant(resultFor("1234", 6, arr))
 
-    if (executingInJVM)
-      assertThrows(classOf[NullPointerException], resultFor("1234", 1, null))
+    assertThrowsNPEIfCompliant(resultFor("1234", 1, null))
   }
 
   @Test def insertCharSequence(): Unit = {

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/lang/StringBuilderTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/lang/StringBuilderTest.scala
@@ -45,19 +45,13 @@ class StringBuilderTest {
   @Test def initString(): Unit = {
     assertEquals("hello", new StringBuilder("hello").toString())
 
-    if (executingInJVM) {
-      assertThrows(classOf[NullPointerException],
-          new StringBuilder(null: String))
-    }
+    assertThrowsNPEIfCompliant(new StringBuilder(null: String))
   }
 
   @Test def initCharSequence(): Unit = {
     assertEquals("hello", new StringBuilder(charSequence("hello")).toString())
 
-    if (executingInJVM) {
-      assertThrows(classOf[NullPointerException],
-          new StringBuilder(null: CharSequence))
-    }
+    assertThrowsNPEIfCompliant(new StringBuilder(null: CharSequence))
   }
 
   @Test def appendAnyRef(): Unit = {
@@ -115,8 +109,7 @@ class StringBuilderTest {
 
     assertEquals("hello", resultFor(Array('h', 'e', 'l', 'l', 'o')))
 
-    if (executingInJVM)
-      assertThrows(classOf[NullPointerException], resultFor(null))
+    assertThrowsNPEIfCompliant(resultFor(null))
   }
 
   @Test def appendCharArrayOffsetLen(): Unit = {
@@ -127,8 +120,7 @@ class StringBuilderTest {
     assertEquals("hello", resultFor(arr, 0, 5))
     assertEquals("ell", resultFor(arr, 1, 3))
 
-    if (executingInJVM)
-      assertThrows(classOf[NullPointerException], resultFor(null, 0, 0))
+    assertThrowsNPEIfCompliant(resultFor(null, 0, 0))
 
     assertThrows(classOf[IndexOutOfBoundsException], resultFor(arr, -1, 2))
     assertThrows(classOf[IndexOutOfBoundsException], resultFor(arr, 3, 3))
@@ -204,8 +196,7 @@ class StringBuilderTest {
     assertThrowsStringIIOBEIfCompliant(resultFor("0123", 4, 3, "x"))
     assertThrowsStringIIOBEIfCompliant(resultFor("0123", 5, 8, "x"))
 
-    if (executingInJVM)
-      assertThrows(classOf[NullPointerException], resultFor("0123", 1, 3, null))
+    assertThrowsNPEIfCompliant(resultFor("0123", 1, 3, null))
   }
 
   @Test def insertCharArrayOffsetLen(): Unit = {
@@ -226,10 +217,7 @@ class StringBuilderTest {
     assertThrowsStringIIOBEIfCompliant(resultFor("1234", 1, arr, 1, -2))
     assertThrowsStringIIOBEIfCompliant(resultFor("1234", 1, arr, 4, 3))
 
-    if (executingInJVM) {
-      assertThrows(classOf[NullPointerException],
-          resultFor("1234", 1, null, 0, 0))
-    }
+    assertThrowsNPEIfCompliant(resultFor("1234", 1, null, 0, 0))
   }
 
   @Test def insertAnyRef(): Unit = {
@@ -268,8 +256,7 @@ class StringBuilderTest {
     assertThrowsStringIIOBEIfCompliant(resultFor("1234", -1, arr))
     assertThrowsStringIIOBEIfCompliant(resultFor("1234", 6, arr))
 
-    if (executingInJVM)
-      assertThrows(classOf[NullPointerException], resultFor("1234", 1, null))
+    assertThrowsNPEIfCompliant(resultFor("1234", 1, null))
   }
 
   @Test def insertCharSequence(): Unit = {

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/lang/StringTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/lang/StringTest.scala
@@ -484,7 +484,21 @@ class StringTest {
     assertFalse("Scala.js".startsWith("", -1))
     assertFalse("Scala.js".startsWith("", 9))
 
+    // When the offset is within bounds, a null prefix causes an NPE
+    assertThrowsNPEIfCompliant("Scala.js".startsWith(null, 0))
     assertThrowsNPEIfCompliant("Scala.js".startsWith(null, 2))
+    assertThrowsNPEIfCompliant("Scala.js".startsWith(null, 8))
+
+    /* But if the offset is out of bounds, the result is not clearly specified,
+     * and the JVM is inconsistent.
+     * Our chosen semantics is to be maximally tolerant, to delay UB until
+     * there is no other choice. We test that behavior.
+     */
+    if (!executingInJVM) {
+      assertFalse("Scala.js".startsWith(null, -1))
+      assertFalse("Scala.js".startsWith(null, 9))
+      assertFalse("Scala.js".startsWith(null, 50))
+    }
   }
 
   @Test def toCharArray(): Unit =

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/math/BigDecimalConstructorsTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/math/BigDecimalConstructorsTest.scala
@@ -22,7 +22,7 @@ import java.math._
 import org.junit.Test
 import org.junit.Assert._
 
-import org.scalajs.testsuite.utils.AssertThrows.assertThrows
+import org.scalajs.testsuite.utils.AssertThrows.{assertThrows, _}
 
 class BigDecimalConstructorsTest {
 
@@ -34,7 +34,7 @@ class BigDecimalConstructorsTest {
     val aNumber = new BigDecimal(bA)
     assertTrue(aNumber.unscaledValue() == bA)
     assertEquals(0, aNumber.scale())
-    assertThrows(classOf[NullPointerException], new BigDecimal(null.asInstanceOf[BigInteger]))
+    assertThrowsNPEIfCompliant(new BigDecimal(null.asInstanceOf[BigInteger]))
   }
 
   @Test def testConstrBigIntegerMathContext(): Unit = {

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/math/MathContextTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/math/MathContextTest.scala
@@ -22,7 +22,7 @@ import java.math.{MathContext, RoundingMode}
 import org.junit.Test
 import org.junit.Assert._
 
-import org.scalajs.testsuite.utils.AssertThrows.assertThrows
+import org.scalajs.testsuite.utils.AssertThrows.{assertThrows, _}
 
 class MathContextTest {
 
@@ -65,7 +65,7 @@ class MathContextTest {
     assertThrows(classOf[IllegalArgumentException],
         new MathContext("precision=22roundingMode=UP"))
     assertThrows(classOf[IllegalArgumentException], new MathContext(""))
-    assertThrows(classOf[NullPointerException], new MathContext(null))
+    assertThrowsNPEIfCompliant(new MathContext(null))
   }
 
   @Test def testMathContextConstructorEquality(): Unit = {

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/ObjectsTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/ObjectsTest.scala
@@ -16,9 +16,13 @@ import java.{util => ju}
 
 import org.junit.Test
 import org.junit.Assert._
-import org.scalajs.testsuite.utils.AssertThrows.assertThrows
+
+import org.scalajs.testsuite.utils.AssertThrows.{assertThrows, _}
+import org.scalajs.testsuite.utils.Platform.hasCompliantNullPointers
 
 class ObjectsTest {
+
+  @noinline private def hide[T](x: T): T = x
 
   @Test def testEquals(): Unit = {
     val obj = new Object
@@ -87,11 +91,67 @@ class ObjectsTest {
     assertTrue(ju.Objects.compare(1, 2, cmp1) < 0)
   }
 
+  /* The overloads of requireNonNull are subject to intrinsic optimizations.
+   * Make sure to test them with arguments that are both known and not-known
+   * to be nullable or non-nullable.
+   */
+
   @Test def requireNonNull(): Unit = {
-    assertThrows(classOf[NullPointerException], ju.Objects.requireNonNull(null))
-    assertThrows(classOf[NullPointerException], ju.Objects.requireNonNull(null, "message"))
+    assertThrowsNPEIfCompliant(ju.Objects.requireNonNull(null))
+    assertThrowsNPEIfCompliant(ju.Objects.requireNonNull(hide[String](null)))
+
     assertEquals("abc", ju.Objects.requireNonNull("abc"))
-    assertEquals("abc", ju.Objects.requireNonNull("abc", ""))
+    assertEquals("abc", ju.Objects.requireNonNull(hide[String]("abc")))
+  }
+
+  @Test def requireNonNullWithMessage(): Unit = {
+    if (hasCompliantNullPointers) {
+      val e1 = assertThrows(classOf[NullPointerException],
+          ju.Objects.requireNonNull(null, "the message"))
+      assertEquals("the message", e1.getMessage())
+
+      val e2 = assertThrows(classOf[NullPointerException],
+          ju.Objects.requireNonNull(hide[String](null), "the message"))
+      assertEquals("the message", e2.getMessage())
+    }
+
+    assertEquals("abc", ju.Objects.requireNonNull("abc", "unexpected"))
+    assertEquals("abc", ju.Objects.requireNonNull(hide[String]("abc"), "unexpected"))
+
+    // The effects of computing the arguments are preserved, in order
+
+    locally {
+      var effects = 5
+
+      assertThrows(classOf[IllegalStateException], {
+        ju.Objects.requireNonNull({
+          effects *= 2
+          hide[String](null)
+        }, {
+          effects += 1
+          throw new IllegalStateException()
+          hide[String]("unexpected")
+        })
+      })
+
+      assertEquals(11, effects)
+    }
+
+    if (hasCompliantNullPointers) {
+      var effects = 5
+
+      assertThrows(classOf[NullPointerException], {
+        ju.Objects.requireNonNull({
+          effects *= 2
+          hide[String](null)
+        }, {
+          effects += 1
+          hide[String]("unexpected")
+        })
+      })
+
+      assertEquals(11, effects)
+    }
   }
 
   @Test def requireNonNullWithMsgSupplier(): Unit = {
@@ -101,6 +161,11 @@ class ObjectsTest {
       def get(): String = message
     }
 
+    // Hidden version; with a distinct instance so that successSupplier can still be inlined
+    val hiddenSuccessSupplier = hide(new ju.function.Supplier[String] {
+      def get(): String = message
+    })
+
     val failureSupplier = new ju.function.Supplier[String] {
       def get(): String = {
         throw new AssertionError(
@@ -108,11 +173,86 @@ class ObjectsTest {
       }
     }
 
-    val e = assertThrows(classOf[NullPointerException],
-        ju.Objects.requireNonNull(null, successSupplier))
-    assertEquals(message, e.getMessage())
+    if (hasCompliantNullPointers) {
+      val e1 = assertThrows(classOf[NullPointerException],
+          ju.Objects.requireNonNull(null, successSupplier))
+      assertEquals(message, e1.getMessage())
+      val e2 = assertThrows(classOf[NullPointerException],
+          ju.Objects.requireNonNull(hide[String](null), successSupplier))
+      assertEquals(message, e2.getMessage())
+
+      val e3 = assertThrows(classOf[NullPointerException],
+          ju.Objects.requireNonNull(null, hiddenSuccessSupplier))
+      assertEquals(message, e3.getMessage())
+      val e4 = assertThrows(classOf[NullPointerException],
+          ju.Objects.requireNonNull(hide[String](null), hiddenSuccessSupplier))
+      assertEquals(message, e4.getMessage())
+
+      // If the supplier returns a null message, we get a null message
+      val e5 = assertThrows(classOf[NullPointerException],
+          ju.Objects.requireNonNull(null, () => null))
+      assertNull(e5.getMessage())
+      val e6 = assertThrows(classOf[NullPointerException],
+          ju.Objects.requireNonNull(hide[String](null), () => null))
+      assertNull(e6.getMessage())
+
+      // If the supplier itself is null as well, we get an NPE with an unspecified message
+      assertThrows(classOf[NullPointerException],
+          ju.Objects.requireNonNull(null, null: ju.function.Supplier[String]))
+      assertThrows(classOf[NullPointerException],
+          ju.Objects.requireNonNull(hide[String](null), null: ju.function.Supplier[String]))
+      assertThrows(classOf[NullPointerException],
+          ju.Objects.requireNonNull(null, hide[ju.function.Supplier[String]](null)))
+      assertThrows(classOf[NullPointerException],
+          ju.Objects.requireNonNull(hide[String](null), hide[ju.function.Supplier[String]](null)))
+    }
 
     assertEquals("abc", ju.Objects.requireNonNull("abc", failureSupplier))
+    assertEquals("abc", ju.Objects.requireNonNull(hide[String]("abc"), failureSupplier))
+
+    assertEquals("abc",
+        ju.Objects.requireNonNull("abc", null: ju.function.Supplier[String]))
+    assertEquals("abc",
+        ju.Objects.requireNonNull(hide[String]("abc"), hide[ju.function.Supplier[String]](null)))
+
+    // The effects of computing the arguments are preserved, in order
+
+    locally {
+      var effects = 5
+
+      assertThrows(classOf[IllegalStateException], {
+        ju.Objects.requireNonNull({
+          effects *= 2
+          hide[String](null)
+        }, {
+          effects += 1
+          throw new IllegalStateException()
+          hide[ju.function.Supplier[String]](null)
+        })
+      })
+
+      assertEquals(11, effects)
+    }
+
+    if (hasCompliantNullPointers) {
+      var effects = 5
+
+      assertThrows(classOf[NullPointerException], {
+        ju.Objects.requireNonNull({
+          effects *= 2
+          hide[String](null)
+        }, {
+          effects += 1
+
+          { () =>
+            effects = -100 - effects
+            "the message"
+          }: ju.function.Supplier[String]
+        })
+      })
+
+      assertEquals(-111, effects)
+    }
   }
 
   @Test def isNull(): Unit = {

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/OptionalTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/OptionalTest.scala
@@ -18,14 +18,14 @@ import org.junit.Test
 import java.util.Optional
 import java.util.function._
 
-import org.scalajs.testsuite.utils.AssertThrows.assertThrows
+import org.scalajs.testsuite.utils.AssertThrows.{assertThrows, _}
 
 class OptionalTest {
 
   @Test def testCreation(): Unit = {
     Optional.empty[String]()
     Optional.of[String]("")
-    assertThrows(classOf[NullPointerException], Optional.of[String](null))
+    assertThrowsNPEIfCompliant(Optional.of[String](null))
     Optional.ofNullable[String]("")
     Optional.ofNullable[String](null)
   }

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/concurrent/ConcurrentHashMapTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/concurrent/ConcurrentHashMapTest.scala
@@ -22,7 +22,7 @@ import org.junit.Assert._
 import org.junit.Test
 
 import org.scalajs.testsuite.javalib.util.MapTest
-import org.scalajs.testsuite.utils.AssertThrows.assertThrows
+import org.scalajs.testsuite.utils.AssertThrows.{assertThrows, _}
 
 class ConcurrentHashMapTest extends MapTest {
 
@@ -197,7 +197,7 @@ class ConcurrentHashMapTest extends MapTest {
 
   @Test def keySetWithNullMappedValue(): Unit = {
     val map = factory.empty[String, String]
-    assertThrows(classOf[NullPointerException], map.keySet(null))
+    assertThrowsNPEIfCompliant(classOf[NullPointerException], map.keySet(null))
   }
 
   @Test def addOnKeySetView(): Unit = {


### PR DESCRIPTION
And use it for all explicit null checks in the javalib.

Unfortunately, it is unclear what to do about the two overloads of `ju.Objects.requireNonNull` with an explicit message. Either we keep the message and we have to throw an explicit NPE; or we trigger a UB NPE, but we ignore the message.

We choose to trigger the UB, but then we catch a genuine NPE to rethrow it with the correct message. The message will still be lost when the NPEs are Fatal, but at least they are used when NPEs are Compliant.

For the overload that takes a `messageSupplier`, additionally we choose to only call its `get()` method when we actually need the message, i.e., only in Compliant mode.

These changes allow for good optimization opportunities. We intrinsify the 3 overloads so we can get the best possible code for every checked behavior. For Unchecked mode, the tests completely disappear. For Compliant and Fatal, we don't need to throw a fake NPE that we immediately try to catch and re-throw.

---

Extracted the NPE-related stuff from #5329.