### PR TITLE
Allow to allocate direct byte buffers without typed arrays.

### DIFF
--- a/javalib/src/main/scala/java/nio/ByteBuffer.scala
+++ b/javalib/src/main/scala/java/nio/ByteBuffer.scala
@@ -12,7 +12,11 @@
 
 package java.nio
 
+import scala.scalajs.js
 import scala.scalajs.js.typedarray._
+
+import scala.scalajs.LinkingInfo
+import scala.scalajs.LinkingInfo.ESVersion
 
 object ByteBuffer {
   private final val HashSeed = -547316498 // "java.nio.ByteBuffer".##
@@ -24,7 +28,18 @@ object ByteBuffer {
 
   def allocateDirect(capacity: Int): ByteBuffer = {
     GenBuffer.validateAllocateCapacity(capacity)
-    TypedArrayByteBuffer.allocate(capacity)
+
+    if (LinkingInfo.esVersion >= ESVersion.ES2015 ||
+        js.typeOf(js.Dynamic.global.Int8Array) != "undefined") {
+      TypedArrayByteBuffer.allocate(capacity)
+    } else {
+      /* Create a direct ByteBuffer that is actually backed by a regular Array.
+       * We can do this because the JavaDoc explicitly leaves it unspecified
+       * whether direct buffers are actually backed by an array or not.
+       * They only need to return `true` from `isDirect()`.
+       */
+      HeapByteBuffer.allocateDirect(capacity)
+    }
   }
 
   def wrap(array: Array[Byte], offset: Int, length: Int): ByteBuffer =

--- a/javalib/src/main/scala/java/nio/GenHeapBuffer.scala
+++ b/javalib/src/main/scala/java/nio/GenHeapBuffer.scala
@@ -19,8 +19,15 @@ private[nio] object GenHeapBuffer {
     new GenHeapBuffer(self)
 
   trait NewHeapBuffer[BufferType <: Buffer, ElementType] {
+
+    /** Creates a new HeapBuffer with the given parameters.
+     *
+     *  `direct` is only supported if `BufferType <: ByteBuffer`. For other
+     *  buffer types, if `direct` is false, throws an `AssertionError`.
+     */
     def apply(capacity: Int, array: Array[ElementType], arrayOffset: Int,
-        initialPosition: Int, initialLimit: Int, readOnly: Boolean): BufferType
+        initialPosition: Int, initialLimit: Int, readOnly: Boolean,
+        direct: Boolean): BufferType
   }
 
   @inline
@@ -35,7 +42,7 @@ private[nio] object GenHeapBuffer {
     if (initialPosition < 0 || initialLength < 0 || initialLimit > capacity)
       throw new IndexOutOfBoundsException
     newHeapBuffer(capacity, array, arrayOffset,
-        initialPosition, initialLimit, isReadOnly)
+        initialPosition, initialLimit, isReadOnly, false)
   }
 }
 
@@ -54,14 +61,14 @@ private[nio] final class GenHeapBuffer[B <: Buffer] private (val self: B) extend
       implicit newHeapBuffer: NewThisHeapBuffer): BufferType = {
     val newCapacity = remaining()
     newHeapBuffer(newCapacity, _array, _arrayOffset + position(),
-        0, newCapacity, isReadOnly())
+        0, newCapacity, isReadOnly(), isDirect())
   }
 
   @inline
   def generic_duplicate()(
       implicit newHeapBuffer: NewThisHeapBuffer): BufferType = {
     val result = newHeapBuffer(capacity(), _array, _arrayOffset,
-        position(), limit(), isReadOnly())
+        position(), limit(), isReadOnly(), isDirect())
     result._mark = _mark
     result
   }
@@ -70,7 +77,7 @@ private[nio] final class GenHeapBuffer[B <: Buffer] private (val self: B) extend
   def generic_asReadOnlyBuffer()(
       implicit newHeapBuffer: NewThisHeapBuffer): BufferType = {
     val result = newHeapBuffer(capacity(), _array, _arrayOffset,
-        position(), limit(), true)
+        position(), limit(), true, isDirect())
     result._mark = _mark
     result
   }

--- a/javalib/src/main/scala/java/nio/GenHeapBufferView.scala
+++ b/javalib/src/main/scala/java/nio/GenHeapBufferView.scala
@@ -21,7 +21,7 @@ private[nio] object GenHeapBufferView {
 
     def apply(capacity: Int, byteArray: Array[Byte], byteArrayOffset: Int,
         initialPosition: Int, initialLimit: Int, readOnly: Boolean,
-        isBigEndian: Boolean): BufferType
+        isDirect: Boolean, isBigEndian: Boolean): BufferType
   }
 
   @inline
@@ -33,7 +33,8 @@ private[nio] object GenHeapBufferView {
       (byteBuffer.limit() - byteBufferPos) / newHeapBufferView.bytesPerElem
     newHeapBufferView(viewCapacity, byteBuffer._array,
         byteBuffer._arrayOffset + byteBufferPos,
-        0, viewCapacity, byteBuffer.isReadOnly(), byteBuffer.isBigEndian)
+        0, viewCapacity, byteBuffer.isReadOnly(), byteBuffer.isDirect(),
+        byteBuffer.isBigEndian)
   }
 }
 
@@ -53,14 +54,14 @@ private[nio] final class GenHeapBufferView[B <: Buffer] private (val self: B) ex
     val bytesPerElem = newHeapBufferView.bytesPerElem
     newHeapBufferView(newCapacity, _byteArray,
         _byteArrayOffset + bytesPerElem * position(),
-        0, newCapacity, isReadOnly(), isBigEndian)
+        0, newCapacity, isReadOnly(), isDirect(), isBigEndian)
   }
 
   @inline
   def generic_duplicate()(
       implicit newHeapBufferView: NewThisHeapBufferView): BufferType = {
     val result = newHeapBufferView(capacity(), _byteArray, _byteArrayOffset,
-        position(), limit(), isReadOnly(), isBigEndian)
+        position(), limit(), isReadOnly(), isDirect(), isBigEndian)
     result._mark = _mark
     result
   }
@@ -69,7 +70,7 @@ private[nio] final class GenHeapBufferView[B <: Buffer] private (val self: B) ex
   def generic_asReadOnlyBuffer()(
       implicit newHeapBufferView: NewThisHeapBufferView): BufferType = {
     val result = newHeapBufferView(capacity(), _byteArray, _byteArrayOffset,
-        position(), limit(), true, isBigEndian)
+        position(), limit(), true, isDirect(), isBigEndian)
     result._mark = _mark
     result
   }

--- a/javalib/src/main/scala/java/nio/HeapByteBuffer.scala
+++ b/javalib/src/main/scala/java/nio/HeapByteBuffer.scala
@@ -14,7 +14,8 @@ package java.nio
 
 private[nio] final class HeapByteBuffer private (
     _capacity: Int, _array0: Array[Byte], _arrayOffset0: Int,
-    _initialPosition: Int, _initialLimit: Int, _readOnly: Boolean)
+    _initialPosition: Int, _initialLimit: Int, _readOnly: Boolean,
+    _isDirect: Boolean)
     extends ByteBuffer(_capacity, _array0, _arrayOffset0) {
 
   position(_initialPosition)
@@ -24,7 +25,7 @@ private[nio] final class HeapByteBuffer private (
 
   def isReadOnly(): Boolean = _readOnly
 
-  def isDirect(): Boolean = false
+  def isDirect(): Boolean = _isDirect
 
   @noinline
   def slice(): ByteBuffer =
@@ -199,11 +200,12 @@ private[nio] final class HeapByteBuffer private (
 private[nio] object HeapByteBuffer {
   private[nio] implicit object NewHeapByteBuffer
       extends GenHeapBuffer.NewHeapBuffer[ByteBuffer, Byte] {
+    @inline
     def apply(capacity: Int, array: Array[Byte], arrayOffset: Int,
         initialPosition: Int, initialLimit: Int,
-        readOnly: Boolean): ByteBuffer = {
+        readOnly: Boolean, direct: Boolean): ByteBuffer = {
       new HeapByteBuffer(capacity, array, arrayOffset,
-          initialPosition, initialLimit, readOnly)
+          initialPosition, initialLimit, readOnly, direct)
     }
   }
 
@@ -214,5 +216,10 @@ private[nio] object HeapByteBuffer {
     GenHeapBuffer.generic_wrap(
         array, arrayOffset, capacity,
         initialPosition, initialLength, isReadOnly)
+  }
+
+  private[nio] def allocateDirect(capacity: Int): ByteBuffer = {
+    new HeapByteBuffer(capacity, new Array[Byte](capacity),
+        0, 0, capacity, false, true)
   }
 }

--- a/javalib/src/main/scala/java/nio/HeapByteBufferCharView.scala
+++ b/javalib/src/main/scala/java/nio/HeapByteBufferCharView.scala
@@ -17,7 +17,8 @@ private[nio] final class HeapByteBufferCharView private (
     override private[nio] val _byteArray: Array[Byte],
     override private[nio] val _byteArrayOffset: Int,
     _initialPosition: Int, _initialLimit: Int,
-    _readOnly: Boolean, override private[nio] val isBigEndian: Boolean)
+    _readOnly: Boolean, _isDirect: Boolean,
+    override private[nio] val isBigEndian: Boolean)
     extends CharBuffer(_capacity, null, -1) {
 
   position(_initialPosition)
@@ -28,7 +29,7 @@ private[nio] final class HeapByteBufferCharView private (
 
   def isReadOnly(): Boolean = _readOnly
 
-  def isDirect(): Boolean = false
+  def isDirect(): Boolean = _isDirect
 
   @noinline
   def slice(): CharBuffer =
@@ -46,7 +47,7 @@ private[nio] final class HeapByteBufferCharView private (
     if (start < 0 || end < start || end > remaining())
       throw new IndexOutOfBoundsException
     new HeapByteBufferCharView(capacity(), _byteArray, _byteArrayOffset,
-        position() + start, position() + end, isReadOnly(), isBigEndian)
+        position() + start, position() + end, isReadOnly(), isDirect(), isBigEndian)
   }
 
   @noinline
@@ -99,9 +100,9 @@ private[nio] object HeapByteBufferCharView {
 
     def apply(capacity: Int, byteArray: Array[Byte], byteArrayOffset: Int,
         initialPosition: Int, initialLimit: Int, readOnly: Boolean,
-        isBigEndian: Boolean): CharBuffer = {
+        isDirect: Boolean, isBigEndian: Boolean): CharBuffer = {
       new HeapByteBufferCharView(capacity, byteArray, byteArrayOffset,
-          initialPosition, initialLimit, readOnly, isBigEndian)
+          initialPosition, initialLimit, readOnly, isDirect, isBigEndian)
     }
   }
 

--- a/javalib/src/main/scala/java/nio/HeapByteBufferDoubleView.scala
+++ b/javalib/src/main/scala/java/nio/HeapByteBufferDoubleView.scala
@@ -17,7 +17,8 @@ private[nio] final class HeapByteBufferDoubleView private (
     override private[nio] val _byteArray: Array[Byte],
     override private[nio] val _byteArrayOffset: Int,
     _initialPosition: Int, _initialLimit: Int,
-    _readOnly: Boolean, override private[nio] val isBigEndian: Boolean)
+    _readOnly: Boolean, _isDirect: Boolean,
+    override private[nio] val isBigEndian: Boolean)
     extends DoubleBuffer(_capacity, null, -1) {
 
   position(_initialPosition)
@@ -28,7 +29,7 @@ private[nio] final class HeapByteBufferDoubleView private (
 
   def isReadOnly(): Boolean = _readOnly
 
-  def isDirect(): Boolean = false
+  def isDirect(): Boolean = _isDirect
 
   @noinline
   def slice(): DoubleBuffer =
@@ -92,9 +93,9 @@ private[nio] object HeapByteBufferDoubleView {
 
     def apply(capacity: Int, byteArray: Array[Byte], byteArrayOffset: Int,
         initialPosition: Int, initialLimit: Int, readOnly: Boolean,
-        isBigEndian: Boolean): DoubleBuffer = {
+        isDirect: Boolean, isBigEndian: Boolean): DoubleBuffer = {
       new HeapByteBufferDoubleView(capacity, byteArray, byteArrayOffset,
-          initialPosition, initialLimit, readOnly, isBigEndian)
+          initialPosition, initialLimit, readOnly, isDirect, isBigEndian)
     }
   }
 

--- a/javalib/src/main/scala/java/nio/HeapByteBufferFloatView.scala
+++ b/javalib/src/main/scala/java/nio/HeapByteBufferFloatView.scala
@@ -17,7 +17,8 @@ private[nio] final class HeapByteBufferFloatView private (
     override private[nio] val _byteArray: Array[Byte],
     override private[nio] val _byteArrayOffset: Int,
     _initialPosition: Int, _initialLimit: Int,
-    _readOnly: Boolean, override private[nio] val isBigEndian: Boolean)
+    _readOnly: Boolean, _isDirect: Boolean,
+    override private[nio] val isBigEndian: Boolean)
     extends FloatBuffer(_capacity, null, -1) {
 
   position(_initialPosition)
@@ -28,7 +29,7 @@ private[nio] final class HeapByteBufferFloatView private (
 
   def isReadOnly(): Boolean = _readOnly
 
-  def isDirect(): Boolean = false
+  def isDirect(): Boolean = _isDirect
 
   @noinline
   def slice(): FloatBuffer =
@@ -92,9 +93,9 @@ private[nio] object HeapByteBufferFloatView {
 
     def apply(capacity: Int, byteArray: Array[Byte], byteArrayOffset: Int,
         initialPosition: Int, initialLimit: Int, readOnly: Boolean,
-        isBigEndian: Boolean): FloatBuffer = {
+        isDirect: Boolean, isBigEndian: Boolean): FloatBuffer = {
       new HeapByteBufferFloatView(capacity, byteArray, byteArrayOffset,
-          initialPosition, initialLimit, readOnly, isBigEndian)
+          initialPosition, initialLimit, readOnly, isDirect, isBigEndian)
     }
   }
 

--- a/javalib/src/main/scala/java/nio/HeapByteBufferIntView.scala
+++ b/javalib/src/main/scala/java/nio/HeapByteBufferIntView.scala
@@ -17,7 +17,8 @@ private[nio] final class HeapByteBufferIntView private (
     override private[nio] val _byteArray: Array[Byte],
     override private[nio] val _byteArrayOffset: Int,
     _initialPosition: Int, _initialLimit: Int,
-    _readOnly: Boolean, override private[nio] val isBigEndian: Boolean)
+    _readOnly: Boolean, _isDirect: Boolean,
+    override private[nio] val isBigEndian: Boolean)
     extends IntBuffer(_capacity, null, -1) {
 
   position(_initialPosition)
@@ -28,7 +29,7 @@ private[nio] final class HeapByteBufferIntView private (
 
   def isReadOnly(): Boolean = _readOnly
 
-  def isDirect(): Boolean = false
+  def isDirect(): Boolean = _isDirect
 
   @noinline
   def slice(): IntBuffer =
@@ -92,9 +93,9 @@ private[nio] object HeapByteBufferIntView {
 
     def apply(capacity: Int, byteArray: Array[Byte], byteArrayOffset: Int,
         initialPosition: Int, initialLimit: Int, readOnly: Boolean,
-        isBigEndian: Boolean): IntBuffer = {
+        isDirect: Boolean, isBigEndian: Boolean): IntBuffer = {
       new HeapByteBufferIntView(capacity, byteArray, byteArrayOffset,
-          initialPosition, initialLimit, readOnly, isBigEndian)
+          initialPosition, initialLimit, readOnly, isDirect, isBigEndian)
     }
   }
 

--- a/javalib/src/main/scala/java/nio/HeapByteBufferLongView.scala
+++ b/javalib/src/main/scala/java/nio/HeapByteBufferLongView.scala
@@ -17,7 +17,8 @@ private[nio] final class HeapByteBufferLongView private (
     override private[nio] val _byteArray: Array[Byte],
     override private[nio] val _byteArrayOffset: Int,
     _initialPosition: Int, _initialLimit: Int,
-    _readOnly: Boolean, override private[nio] val isBigEndian: Boolean)
+    _readOnly: Boolean, _isDirect: Boolean,
+    override private[nio] val isBigEndian: Boolean)
     extends LongBuffer(_capacity, null, -1) {
 
   position(_initialPosition)
@@ -28,7 +29,7 @@ private[nio] final class HeapByteBufferLongView private (
 
   def isReadOnly(): Boolean = _readOnly
 
-  def isDirect(): Boolean = false
+  def isDirect(): Boolean = _isDirect
 
   @noinline
   def slice(): LongBuffer =
@@ -92,9 +93,9 @@ private[nio] object HeapByteBufferLongView {
 
     def apply(capacity: Int, byteArray: Array[Byte], byteArrayOffset: Int,
         initialPosition: Int, initialLimit: Int, readOnly: Boolean,
-        isBigEndian: Boolean): LongBuffer = {
+        isDirect: Boolean, isBigEndian: Boolean): LongBuffer = {
       new HeapByteBufferLongView(capacity, byteArray, byteArrayOffset,
-          initialPosition, initialLimit, readOnly, isBigEndian)
+          initialPosition, initialLimit, readOnly, isDirect, isBigEndian)
     }
   }
 

--- a/javalib/src/main/scala/java/nio/HeapByteBufferShortView.scala
+++ b/javalib/src/main/scala/java/nio/HeapByteBufferShortView.scala
@@ -17,7 +17,8 @@ private[nio] final class HeapByteBufferShortView private (
     override private[nio] val _byteArray: Array[Byte],
     override private[nio] val _byteArrayOffset: Int,
     _initialPosition: Int, _initialLimit: Int,
-    _readOnly: Boolean, override private[nio] val isBigEndian: Boolean)
+    _readOnly: Boolean, _isDirect: Boolean,
+    override private[nio] val isBigEndian: Boolean)
     extends ShortBuffer(_capacity, null, -1) {
 
   position(_initialPosition)
@@ -28,7 +29,7 @@ private[nio] final class HeapByteBufferShortView private (
 
   def isReadOnly(): Boolean = _readOnly
 
-  def isDirect(): Boolean = false
+  def isDirect(): Boolean = _isDirect
 
   @noinline
   def slice(): ShortBuffer =
@@ -92,9 +93,9 @@ private[nio] object HeapByteBufferShortView {
 
     def apply(capacity: Int, byteArray: Array[Byte], byteArrayOffset: Int,
         initialPosition: Int, initialLimit: Int, readOnly: Boolean,
-        isBigEndian: Boolean): ShortBuffer = {
+        isDirect: Boolean, isBigEndian: Boolean): ShortBuffer = {
       new HeapByteBufferShortView(capacity, byteArray, byteArrayOffset,
-          initialPosition, initialLimit, readOnly, isBigEndian)
+          initialPosition, initialLimit, readOnly, isDirect, isBigEndian)
     }
   }
 

--- a/javalib/src/main/scala/java/nio/HeapCharBuffer.scala
+++ b/javalib/src/main/scala/java/nio/HeapCharBuffer.scala
@@ -101,9 +101,12 @@ private[nio] final class HeapCharBuffer private (
 private[nio] object HeapCharBuffer {
   private[nio] implicit object NewHeapCharBuffer
       extends GenHeapBuffer.NewHeapBuffer[CharBuffer, Char] {
+    @inline
     def apply(capacity: Int, array: Array[Char], arrayOffset: Int,
         initialPosition: Int, initialLimit: Int,
-        readOnly: Boolean): CharBuffer = {
+        readOnly: Boolean, direct: Boolean): CharBuffer = {
+      if (direct)
+        throw new AssertionError("Cannot create a direct HeapCharBuffer")
       new HeapCharBuffer(capacity, array, arrayOffset,
           initialPosition, initialLimit, readOnly)
     }

--- a/javalib/src/main/scala/java/nio/HeapDoubleBuffer.scala
+++ b/javalib/src/main/scala/java/nio/HeapDoubleBuffer.scala
@@ -94,9 +94,12 @@ private[nio] final class HeapDoubleBuffer private (
 private[nio] object HeapDoubleBuffer {
   private[nio] implicit object NewHeapDoubleBuffer
       extends GenHeapBuffer.NewHeapBuffer[DoubleBuffer, Double] {
+    @inline
     def apply(capacity: Int, array: Array[Double], arrayOffset: Int,
         initialPosition: Int, initialLimit: Int,
-        readOnly: Boolean): DoubleBuffer = {
+        readOnly: Boolean, direct: Boolean): DoubleBuffer = {
+      if (direct)
+        throw new AssertionError("Cannot create a direct HeapDoubleBuffer")
       new HeapDoubleBuffer(capacity, array, arrayOffset,
           initialPosition, initialLimit, readOnly)
     }

--- a/javalib/src/main/scala/java/nio/HeapFloatBuffer.scala
+++ b/javalib/src/main/scala/java/nio/HeapFloatBuffer.scala
@@ -94,9 +94,12 @@ private[nio] final class HeapFloatBuffer private (
 private[nio] object HeapFloatBuffer {
   private[nio] implicit object NewHeapFloatBuffer
       extends GenHeapBuffer.NewHeapBuffer[FloatBuffer, Float] {
+    @inline
     def apply(capacity: Int, array: Array[Float], arrayOffset: Int,
         initialPosition: Int, initialLimit: Int,
-        readOnly: Boolean): FloatBuffer = {
+        readOnly: Boolean, direct: Boolean): FloatBuffer = {
+      if (direct)
+        throw new AssertionError("Cannot create a direct HeapFloatBuffer")
       new HeapFloatBuffer(capacity, array, arrayOffset,
           initialPosition, initialLimit, readOnly)
     }

--- a/javalib/src/main/scala/java/nio/HeapIntBuffer.scala
+++ b/javalib/src/main/scala/java/nio/HeapIntBuffer.scala
@@ -94,9 +94,12 @@ private[nio] final class HeapIntBuffer private (
 private[nio] object HeapIntBuffer {
   private[nio] implicit object NewHeapIntBuffer
       extends GenHeapBuffer.NewHeapBuffer[IntBuffer, Int] {
+    @inline
     def apply(capacity: Int, array: Array[Int], arrayOffset: Int,
         initialPosition: Int, initialLimit: Int,
-        readOnly: Boolean): IntBuffer = {
+        readOnly: Boolean, direct: Boolean): IntBuffer = {
+      if (direct)
+        throw new AssertionError("Cannot create a direct HeapIntBuffer")
       new HeapIntBuffer(capacity, array, arrayOffset,
           initialPosition, initialLimit, readOnly)
     }

--- a/javalib/src/main/scala/java/nio/HeapLongBuffer.scala
+++ b/javalib/src/main/scala/java/nio/HeapLongBuffer.scala
@@ -94,9 +94,12 @@ private[nio] final class HeapLongBuffer private (
 private[nio] object HeapLongBuffer {
   private[nio] implicit object NewHeapLongBuffer
       extends GenHeapBuffer.NewHeapBuffer[LongBuffer, Long] {
+    @inline
     def apply(capacity: Int, array: Array[Long], arrayOffset: Int,
         initialPosition: Int, initialLimit: Int,
-        readOnly: Boolean): LongBuffer = {
+        readOnly: Boolean, direct: Boolean): LongBuffer = {
+      if (direct)
+        throw new AssertionError("Cannot create a direct HeapLongBuffer")
       new HeapLongBuffer(capacity, array, arrayOffset,
           initialPosition, initialLimit, readOnly)
     }

--- a/javalib/src/main/scala/java/nio/HeapShortBuffer.scala
+++ b/javalib/src/main/scala/java/nio/HeapShortBuffer.scala
@@ -94,9 +94,12 @@ private[nio] final class HeapShortBuffer private (
 private[nio] object HeapShortBuffer {
   private[nio] implicit object NewHeapShortBuffer
       extends GenHeapBuffer.NewHeapBuffer[ShortBuffer, Short] {
+    @inline
     def apply(capacity: Int, array: Array[Short], arrayOffset: Int,
         initialPosition: Int, initialLimit: Int,
-        readOnly: Boolean): ShortBuffer = {
+        readOnly: Boolean, direct: Boolean): ShortBuffer = {
+      if (direct)
+        throw new AssertionError("Cannot create a direct HeapShortBuffer")
       new HeapShortBuffer(capacity, array, arrayOffset,
           initialPosition, initialLimit, readOnly)
     }

--- a/test-suite/js/src/main/scala/org/scalajs/testsuite/utils/Platform.scala
+++ b/test-suite/js/src/main/scala/org/scalajs/testsuite/utils/Platform.scala
@@ -86,8 +86,6 @@ object Platform {
 
   def hasCompliantModuleInit: Boolean = BuildInfo.compliantModuleInit
 
-  def hasDirectBuffers: Boolean = typedArrays
-
   def regexSupportsUnicodeCase: Boolean =
     assumedESVersion >= ESVersion.ES2015
 

--- a/test-suite/js/src/test/scala/org/scalajs/testsuite/niobuffer/ByteBufferJSTest.scala
+++ b/test-suite/js/src/test/scala/org/scalajs/testsuite/niobuffer/ByteBufferJSTest.scala
@@ -14,20 +14,6 @@ package org.scalajs.testsuite.niobuffer
 
 import org.scalajs.testsuite.niobuffer.BufferFactory.ByteBufferFactory
 
-object AllocDirectByteBufferJSTest extends SupportsTypedArrays
-
-class AllocDirectByteBufferJSTest extends ByteBufferTest {
-  val factory: ByteBufferFactory =
-    new ByteBufferFactories.AllocDirectByteBufferFactory
-}
-
-object SlicedAllocDirectByteBufferJSTest extends SupportsTypedArrays
-
-class SlicedAllocDirectByteBufferJSTest extends ByteBufferTest {
-  val factory: ByteBufferFactory =
-    new ByteBufferFactories.SlicedAllocDirectByteBufferFactory
-}
-
 object WrappedTypedArrayByteBufferJSTest extends SupportsTypedArrays
 
 class WrappedTypedArrayByteBufferJSTest extends ByteBufferTest {

--- a/test-suite/js/src/test/scala/org/scalajs/testsuite/niobuffer/CharBufferJSTest.scala
+++ b/test-suite/js/src/test/scala/org/scalajs/testsuite/niobuffer/CharBufferJSTest.scala
@@ -38,30 +38,10 @@ class WrappedTypedArrayCharBufferJSTest extends CharBufferTest {
 
 // Char views of byte buffers
 
-object CharViewOfAllocDirectByteBufferBigEndianJSTest extends SupportsTypedArrays
-
-class CharViewOfAllocDirectByteBufferBigEndianJSTest
-    extends CharViewOfByteBufferTest(new AllocDirectByteBufferFactory, ByteOrder.BIG_ENDIAN)
-
-object CharViewOfSlicedAllocDirectByteBufferBigEndianJSTest extends SupportsTypedArrays
-
-class CharViewOfSlicedAllocDirectByteBufferBigEndianJSTest
-    extends CharViewOfByteBufferTest(new SlicedAllocDirectByteBufferFactory, ByteOrder.BIG_ENDIAN)
-
 object CharViewOfWrappedTypedArrayByteBufferBigEndianJSTest extends SupportsTypedArrays
 
 class CharViewOfWrappedTypedArrayByteBufferBigEndianJSTest
     extends CharViewOfByteBufferTest(new WrappedTypedArrayByteBufferFactory, ByteOrder.BIG_ENDIAN)
-
-object CharViewOfAllocDirectByteBufferLittleEndianJSTest extends SupportsTypedArrays
-
-class CharViewOfAllocDirectByteBufferLittleEndianJSTest
-    extends CharViewOfByteBufferTest(new AllocDirectByteBufferFactory, ByteOrder.LITTLE_ENDIAN)
-
-object CharViewOfSlicedAllocDirectByteBufferLittleEndianJSTest extends SupportsTypedArrays
-
-class CharViewOfSlicedAllocDirectByteBufferLittleEndianJSTest
-    extends CharViewOfByteBufferTest(new SlicedAllocDirectByteBufferFactory, ByteOrder.LITTLE_ENDIAN)
 
 object CharViewOfWrappedTypedArrayByteBufferLittleEndianJSTest extends SupportsTypedArrays
 
@@ -70,34 +50,11 @@ class CharViewOfWrappedTypedArrayByteBufferLittleEndianJSTest
 
 // Read only Char views of byte buffers
 
-object ReadOnlyCharViewOfAllocDirectByteBufferBigEndianJSTest extends SupportsTypedArrays
-
-class ReadOnlyCharViewOfAllocDirectByteBufferBigEndianJSTest
-    extends ReadOnlyCharViewOfByteBufferTest(new AllocDirectByteBufferFactory, ByteOrder.BIG_ENDIAN)
-
-object ReadOnlyCharViewOfSlicedAllocDirectByteBufferBigEndianJSTest extends SupportsTypedArrays
-
-class ReadOnlyCharViewOfSlicedAllocDirectByteBufferBigEndianJSTest
-    extends ReadOnlyCharViewOfByteBufferTest(
-        new SlicedAllocDirectByteBufferFactory, ByteOrder.BIG_ENDIAN)
-
 object ReadOnlyCharViewOfWrappedTypedArrayByteBufferBigEndianJSTest extends SupportsTypedArrays
 
 class ReadOnlyCharViewOfWrappedTypedArrayByteBufferBigEndianJSTest
     extends ReadOnlyCharViewOfByteBufferTest(
         new WrappedTypedArrayByteBufferFactory, ByteOrder.BIG_ENDIAN)
-
-object ReadOnlyCharViewOfAllocDirectByteBufferLittleEndianJSTest extends SupportsTypedArrays
-
-class ReadOnlyCharViewOfAllocDirectByteBufferLittleEndianJSTest
-    extends ReadOnlyCharViewOfByteBufferTest(
-        new AllocDirectByteBufferFactory, ByteOrder.LITTLE_ENDIAN)
-
-object ReadOnlyCharViewOfSlicedAllocDirectByteBufferLittleEndianJSTest extends SupportsTypedArrays
-
-class ReadOnlyCharViewOfSlicedAllocDirectByteBufferLittleEndianJSTest
-    extends ReadOnlyCharViewOfByteBufferTest(
-        new SlicedAllocDirectByteBufferFactory, ByteOrder.LITTLE_ENDIAN)
 
 object ReadOnlyCharViewOfWrappedTypedArrayByteBufferLittleEndianJSTest extends SupportsTypedArrays
 

--- a/test-suite/js/src/test/scala/org/scalajs/testsuite/niobuffer/DoubleBufferJSTest.scala
+++ b/test-suite/js/src/test/scala/org/scalajs/testsuite/niobuffer/DoubleBufferJSTest.scala
@@ -38,30 +38,10 @@ class WrappedTypedArrayDoubleBufferJSTest extends DoubleBufferTest {
 
 // Double views of byte buffers
 
-object DoubleViewOfAllocDirectByteBufferBigEndianJSTest extends SupportsTypedArrays
-
-class DoubleViewOfAllocDirectByteBufferBigEndianJSTest
-    extends DoubleViewOfByteBufferTest(new AllocDirectByteBufferFactory, ByteOrder.BIG_ENDIAN)
-
-object DoubleViewOfSlicedAllocDirectByteBufferBigEndianJSTest extends SupportsTypedArrays
-
-class DoubleViewOfSlicedAllocDirectByteBufferBigEndianJSTest
-    extends DoubleViewOfByteBufferTest(new SlicedAllocDirectByteBufferFactory, ByteOrder.BIG_ENDIAN)
-
 object DoubleViewOfWrappedTypedArrayByteBufferBigEndianJSTest extends SupportsTypedArrays
 
 class DoubleViewOfWrappedTypedArrayByteBufferBigEndianJSTest
     extends DoubleViewOfByteBufferTest(new WrappedTypedArrayByteBufferFactory, ByteOrder.BIG_ENDIAN)
-
-object DoubleViewOfAllocDirectByteBufferLittleEndianJSTest extends SupportsTypedArrays
-
-class DoubleViewOfAllocDirectByteBufferLittleEndianJSTest
-    extends DoubleViewOfByteBufferTest(new AllocDirectByteBufferFactory, ByteOrder.LITTLE_ENDIAN)
-
-object DoubleViewOfSlicedAllocDirectByteBufferLittleEndianJSTest extends SupportsTypedArrays
-
-class DoubleViewOfSlicedAllocDirectByteBufferLittleEndianJSTest extends DoubleViewOfByteBufferTest(
-        new SlicedAllocDirectByteBufferFactory, ByteOrder.LITTLE_ENDIAN)
 
 object DoubleViewOfWrappedTypedArrayByteBufferLittleEndianJSTest extends SupportsTypedArrays
 
@@ -70,35 +50,11 @@ class DoubleViewOfWrappedTypedArrayByteBufferLittleEndianJSTest extends DoubleVi
 
 // Read only Double views of byte buffers
 
-object ReadOnlyDoubleViewOfAllocDirectByteBufferBigEndianJSTest extends SupportsTypedArrays
-
-class ReadOnlyDoubleViewOfAllocDirectByteBufferBigEndianJSTest
-    extends ReadOnlyDoubleViewOfByteBufferTest(
-        new AllocDirectByteBufferFactory, ByteOrder.BIG_ENDIAN)
-
-object ReadOnlyDoubleViewOfSlicedAllocDirectByteBufferBigEndianJSTest extends SupportsTypedArrays
-
-class ReadOnlyDoubleViewOfSlicedAllocDirectByteBufferBigEndianJSTest
-    extends ReadOnlyDoubleViewOfByteBufferTest(
-        new SlicedAllocDirectByteBufferFactory, ByteOrder.BIG_ENDIAN)
-
 object ReadOnlyDoubleViewOfWrappedTypedArrayByteBufferBigEndianJSTest extends SupportsTypedArrays
 
 class ReadOnlyDoubleViewOfWrappedTypedArrayByteBufferBigEndianJSTest
     extends ReadOnlyDoubleViewOfByteBufferTest(
         new WrappedTypedArrayByteBufferFactory, ByteOrder.BIG_ENDIAN)
-
-object ReadOnlyDoubleViewOfAllocDirectByteBufferLittleEndianJSTest extends SupportsTypedArrays
-
-class ReadOnlyDoubleViewOfAllocDirectByteBufferLittleEndianJSTest
-    extends ReadOnlyDoubleViewOfByteBufferTest(
-        new AllocDirectByteBufferFactory, ByteOrder.LITTLE_ENDIAN)
-
-object ReadOnlyDoubleViewOfSlicedAllocDirectByteBufferLittleEndianJSTest extends SupportsTypedArrays
-
-class ReadOnlyDoubleViewOfSlicedAllocDirectByteBufferLittleEndianJSTest
-    extends ReadOnlyDoubleViewOfByteBufferTest(
-        new SlicedAllocDirectByteBufferFactory, ByteOrder.LITTLE_ENDIAN)
 
 object ReadOnlyDoubleViewOfWrappedTypedArrayByteBufferLittleEndianJSTest extends SupportsTypedArrays
 

--- a/test-suite/js/src/test/scala/org/scalajs/testsuite/niobuffer/FloatBufferJSTest.scala
+++ b/test-suite/js/src/test/scala/org/scalajs/testsuite/niobuffer/FloatBufferJSTest.scala
@@ -38,30 +38,10 @@ class WrappedTypedArrayFloatBufferJSTest extends FloatBufferTest {
 
 // Float views of byte buffers
 
-object FloatViewOfAllocDirectByteBufferBigEndianJSTest extends SupportsTypedArrays
-
-class FloatViewOfAllocDirectByteBufferBigEndianJSTest
-    extends FloatViewOfByteBufferTest(new AllocDirectByteBufferFactory, ByteOrder.BIG_ENDIAN)
-
-object FloatViewOfSlicedAllocDirectByteBufferBigEndianJSTest extends SupportsTypedArrays
-
-class FloatViewOfSlicedAllocDirectByteBufferBigEndianJSTest
-    extends FloatViewOfByteBufferTest(new SlicedAllocDirectByteBufferFactory, ByteOrder.BIG_ENDIAN)
-
 object FloatViewOfWrappedTypedArrayByteBufferBigEndianJSTest extends SupportsTypedArrays
 
 class FloatViewOfWrappedTypedArrayByteBufferBigEndianJSTest
     extends FloatViewOfByteBufferTest(new WrappedTypedArrayByteBufferFactory, ByteOrder.BIG_ENDIAN)
-
-object FloatViewOfAllocDirectByteBufferLittleEndianJSTest extends SupportsTypedArrays
-
-class FloatViewOfAllocDirectByteBufferLittleEndianJSTest
-    extends FloatViewOfByteBufferTest(new AllocDirectByteBufferFactory, ByteOrder.LITTLE_ENDIAN)
-
-object FloatViewOfSlicedAllocDirectByteBufferLittleEndianJSTest extends SupportsTypedArrays
-
-class FloatViewOfSlicedAllocDirectByteBufferLittleEndianJSTest extends FloatViewOfByteBufferTest(
-        new SlicedAllocDirectByteBufferFactory, ByteOrder.LITTLE_ENDIAN)
 
 object FloatViewOfWrappedTypedArrayByteBufferLittleEndianJSTest extends SupportsTypedArrays
 
@@ -70,34 +50,11 @@ class FloatViewOfWrappedTypedArrayByteBufferLittleEndianJSTest extends FloatView
 
 // Read only Float views of byte buffers
 
-object ReadOnlyFloatViewOfAllocDirectByteBufferBigEndianJSTest extends SupportsTypedArrays
-
-class ReadOnlyFloatViewOfAllocDirectByteBufferBigEndianJSTest
-    extends ReadOnlyFloatViewOfByteBufferTest(new AllocDirectByteBufferFactory, ByteOrder.BIG_ENDIAN)
-
-object ReadOnlyFloatViewOfSlicedAllocDirectByteBufferBigEndianJSTest extends SupportsTypedArrays
-
-class ReadOnlyFloatViewOfSlicedAllocDirectByteBufferBigEndianJSTest
-    extends ReadOnlyFloatViewOfByteBufferTest(
-        new SlicedAllocDirectByteBufferFactory, ByteOrder.BIG_ENDIAN)
-
 object ReadOnlyFloatViewOfWrappedTypedArrayByteBufferBigEndianJSTest extends SupportsTypedArrays
 
 class ReadOnlyFloatViewOfWrappedTypedArrayByteBufferBigEndianJSTest
     extends ReadOnlyFloatViewOfByteBufferTest(
         new WrappedTypedArrayByteBufferFactory, ByteOrder.BIG_ENDIAN)
-
-object ReadOnlyFloatViewOfAllocDirectByteBufferLittleEndianJSTest extends SupportsTypedArrays
-
-class ReadOnlyFloatViewOfAllocDirectByteBufferLittleEndianJSTest
-    extends ReadOnlyFloatViewOfByteBufferTest(
-        new AllocDirectByteBufferFactory, ByteOrder.LITTLE_ENDIAN)
-
-object ReadOnlyFloatViewOfSlicedAllocDirectByteBufferLittleEndianJSTest extends SupportsTypedArrays
-
-class ReadOnlyFloatViewOfSlicedAllocDirectByteBufferLittleEndianJSTest
-    extends ReadOnlyFloatViewOfByteBufferTest(
-        new SlicedAllocDirectByteBufferFactory, ByteOrder.LITTLE_ENDIAN)
 
 object ReadOnlyFloatViewOfWrappedTypedArrayByteBufferLittleEndianJSTest extends SupportsTypedArrays
 

--- a/test-suite/js/src/test/scala/org/scalajs/testsuite/niobuffer/IntBufferJSTest.scala
+++ b/test-suite/js/src/test/scala/org/scalajs/testsuite/niobuffer/IntBufferJSTest.scala
@@ -38,30 +38,10 @@ class WrappedTypedArrayIntBufferJSTest extends IntBufferTest {
 
 // Int views of byte buffers
 
-object IntViewOfAllocDirectByteBufferBigEndianJSTest extends SupportsTypedArrays
-
-class IntViewOfAllocDirectByteBufferBigEndianJSTest
-    extends IntViewOfByteBufferTest(new AllocDirectByteBufferFactory, ByteOrder.BIG_ENDIAN)
-
-object IntViewOfSlicedAllocDirectByteBufferBigEndianJSTest extends SupportsTypedArrays
-
-class IntViewOfSlicedAllocDirectByteBufferBigEndianJSTest
-    extends IntViewOfByteBufferTest(new SlicedAllocDirectByteBufferFactory, ByteOrder.BIG_ENDIAN)
-
 object IntViewOfWrappedTypedArrayByteBufferBigEndianJSTest extends SupportsTypedArrays
 
 class IntViewOfWrappedTypedArrayByteBufferBigEndianJSTest
     extends IntViewOfByteBufferTest(new WrappedTypedArrayByteBufferFactory, ByteOrder.BIG_ENDIAN)
-
-object IntViewOfAllocDirectByteBufferLittleEndianJSTest extends SupportsTypedArrays
-
-class IntViewOfAllocDirectByteBufferLittleEndianJSTest
-    extends IntViewOfByteBufferTest(new AllocDirectByteBufferFactory, ByteOrder.LITTLE_ENDIAN)
-
-object IntViewOfSlicedAllocDirectByteBufferLittleEndianJSTest extends SupportsTypedArrays
-
-class IntViewOfSlicedAllocDirectByteBufferLittleEndianJSTest
-    extends IntViewOfByteBufferTest(new SlicedAllocDirectByteBufferFactory, ByteOrder.LITTLE_ENDIAN)
 
 object IntViewOfWrappedTypedArrayByteBufferLittleEndianJSTest extends SupportsTypedArrays
 
@@ -70,34 +50,11 @@ class IntViewOfWrappedTypedArrayByteBufferLittleEndianJSTest
 
 // Read only Int views of byte buffers
 
-object ReadOnlyIntViewOfAllocDirectByteBufferBigEndianJSTest extends SupportsTypedArrays
-
-class ReadOnlyIntViewOfAllocDirectByteBufferBigEndianJSTest
-    extends ReadOnlyIntViewOfByteBufferTest(new AllocDirectByteBufferFactory, ByteOrder.BIG_ENDIAN)
-
-object ReadOnlyIntViewOfSlicedAllocDirectByteBufferBigEndianJSTest extends SupportsTypedArrays
-
-class ReadOnlyIntViewOfSlicedAllocDirectByteBufferBigEndianJSTest
-    extends ReadOnlyIntViewOfByteBufferTest(
-        new SlicedAllocDirectByteBufferFactory, ByteOrder.BIG_ENDIAN)
-
 object ReadOnlyIntViewOfWrappedTypedArrayByteBufferBigEndianJSTest extends SupportsTypedArrays
 
 class ReadOnlyIntViewOfWrappedTypedArrayByteBufferBigEndianJSTest
     extends ReadOnlyIntViewOfByteBufferTest(
         new WrappedTypedArrayByteBufferFactory, ByteOrder.BIG_ENDIAN)
-
-object ReadOnlyIntViewOfAllocDirectByteBufferLittleEndianJSTest extends SupportsTypedArrays
-
-class ReadOnlyIntViewOfAllocDirectByteBufferLittleEndianJSTest
-    extends ReadOnlyIntViewOfByteBufferTest(
-        new AllocDirectByteBufferFactory, ByteOrder.LITTLE_ENDIAN)
-
-object ReadOnlyIntViewOfSlicedAllocDirectByteBufferLittleEndianJSTest extends SupportsTypedArrays
-
-class ReadOnlyIntViewOfSlicedAllocDirectByteBufferLittleEndianJSTest
-    extends ReadOnlyIntViewOfByteBufferTest(
-        new SlicedAllocDirectByteBufferFactory, ByteOrder.LITTLE_ENDIAN)
 
 object ReadOnlyIntViewOfWrappedTypedArrayByteBufferLittleEndianJSTest extends SupportsTypedArrays
 

--- a/test-suite/js/src/test/scala/org/scalajs/testsuite/niobuffer/LongBufferJSTest.scala
+++ b/test-suite/js/src/test/scala/org/scalajs/testsuite/niobuffer/LongBufferJSTest.scala
@@ -19,30 +19,10 @@ import org.scalajs.testsuite.niobuffer.ByteBufferJSFactories._
 
 // Long views of byte buffers
 
-object LongViewOfAllocDirectByteBufferBigEndianJSTest extends SupportsTypedArrays
-
-class LongViewOfAllocDirectByteBufferBigEndianJSTest
-    extends LongViewOfByteBufferTest(new AllocDirectByteBufferFactory, ByteOrder.BIG_ENDIAN)
-
-object LongViewOfSlicedAllocDirectByteBufferBigEndianJSTest extends SupportsTypedArrays
-
-class LongViewOfSlicedAllocDirectByteBufferBigEndianJSTest
-    extends LongViewOfByteBufferTest(new SlicedAllocDirectByteBufferFactory, ByteOrder.BIG_ENDIAN)
-
 object LongViewOfWrappedTypedArrayByteBufferBigEndianJSTest extends SupportsTypedArrays
 
 class LongViewOfWrappedTypedArrayByteBufferBigEndianJSTest
     extends LongViewOfByteBufferTest(new WrappedTypedArrayByteBufferFactory, ByteOrder.BIG_ENDIAN)
-
-object LongViewOfAllocDirectByteBufferLittleEndianJSTest extends SupportsTypedArrays
-
-class LongViewOfAllocDirectByteBufferLittleEndianJSTest
-    extends LongViewOfByteBufferTest(new AllocDirectByteBufferFactory, ByteOrder.LITTLE_ENDIAN)
-
-object LongViewOfSlicedAllocDirectByteBufferLittleEndianJSTest extends SupportsTypedArrays
-
-class LongViewOfSlicedAllocDirectByteBufferLittleEndianJSTest
-    extends LongViewOfByteBufferTest(new SlicedAllocDirectByteBufferFactory, ByteOrder.LITTLE_ENDIAN)
 
 object LongViewOfWrappedTypedArrayByteBufferLittleEndianJSTest extends SupportsTypedArrays
 
@@ -51,34 +31,11 @@ class LongViewOfWrappedTypedArrayByteBufferLittleEndianJSTest
 
 // Read only Long views of byte buffers
 
-object ReadOnlyLongViewOfAllocDirectByteBufferBigEndianJSTest extends SupportsTypedArrays
-
-class ReadOnlyLongViewOfAllocDirectByteBufferBigEndianJSTest
-    extends ReadOnlyLongViewOfByteBufferTest(new AllocDirectByteBufferFactory, ByteOrder.BIG_ENDIAN)
-
-object ReadOnlyLongViewOfSlicedAllocDirectByteBufferBigEndianJSTest extends SupportsTypedArrays
-
-class ReadOnlyLongViewOfSlicedAllocDirectByteBufferBigEndianJSTest
-    extends ReadOnlyLongViewOfByteBufferTest(
-        new SlicedAllocDirectByteBufferFactory, ByteOrder.BIG_ENDIAN)
-
 object ReadOnlyLongViewOfWrappedTypedArrayByteBufferBigEndianJSTest extends SupportsTypedArrays
 
 class ReadOnlyLongViewOfWrappedTypedArrayByteBufferBigEndianJSTest
     extends ReadOnlyLongViewOfByteBufferTest(
         new WrappedTypedArrayByteBufferFactory, ByteOrder.BIG_ENDIAN)
-
-object ReadOnlyLongViewOfAllocDirectByteBufferLittleEndianJSTest extends SupportsTypedArrays
-
-class ReadOnlyLongViewOfAllocDirectByteBufferLittleEndianJSTest
-    extends ReadOnlyLongViewOfByteBufferTest(
-        new AllocDirectByteBufferFactory, ByteOrder.LITTLE_ENDIAN)
-
-object ReadOnlyLongViewOfSlicedAllocDirectByteBufferLittleEndianJSTest extends SupportsTypedArrays
-
-class ReadOnlyLongViewOfSlicedAllocDirectByteBufferLittleEndianJSTest
-    extends ReadOnlyLongViewOfByteBufferTest(
-        new SlicedAllocDirectByteBufferFactory, ByteOrder.LITTLE_ENDIAN)
 
 object ReadOnlyLongViewOfWrappedTypedArrayByteBufferLittleEndianJSTest extends SupportsTypedArrays
 

--- a/test-suite/js/src/test/scala/org/scalajs/testsuite/niobuffer/ShortBufferJSTest.scala
+++ b/test-suite/js/src/test/scala/org/scalajs/testsuite/niobuffer/ShortBufferJSTest.scala
@@ -38,30 +38,10 @@ class WrappedTypedArrayShortBufferJSTest extends ShortBufferTest {
 
 // Short views of byte buffers
 
-object ShortViewOfAllocDirectByteBufferBigEndianJSTest extends SupportsTypedArrays
-
-class ShortViewOfAllocDirectByteBufferBigEndianJSTest
-    extends ShortViewOfByteBufferTest(new AllocDirectByteBufferFactory, ByteOrder.BIG_ENDIAN)
-
-object ShortViewOfSlicedAllocDirectByteBufferBigEndianJSTest extends SupportsTypedArrays
-
-class ShortViewOfSlicedAllocDirectByteBufferBigEndianJSTest
-    extends ShortViewOfByteBufferTest(new SlicedAllocDirectByteBufferFactory, ByteOrder.BIG_ENDIAN)
-
 object ShortViewOfWrappedTypedArrayByteBufferBigEndianJSTest extends SupportsTypedArrays
 
 class ShortViewOfWrappedTypedArrayByteBufferBigEndianJSTest
     extends ShortViewOfByteBufferTest(new WrappedTypedArrayByteBufferFactory, ByteOrder.BIG_ENDIAN)
-
-object ShortViewOfAllocDirectByteBufferLittleEndianJSTest extends SupportsTypedArrays
-
-class ShortViewOfAllocDirectByteBufferLittleEndianJSTest
-    extends ShortViewOfByteBufferTest(new AllocDirectByteBufferFactory, ByteOrder.LITTLE_ENDIAN)
-
-object ShortViewOfSlicedAllocDirectByteBufferLittleEndianJSTest extends SupportsTypedArrays
-
-class ShortViewOfSlicedAllocDirectByteBufferLittleEndianJSTest extends ShortViewOfByteBufferTest(
-        new SlicedAllocDirectByteBufferFactory, ByteOrder.LITTLE_ENDIAN)
 
 object ShortViewOfWrappedTypedArrayByteBufferLittleEndianJSTest extends SupportsTypedArrays
 
@@ -70,34 +50,11 @@ class ShortViewOfWrappedTypedArrayByteBufferLittleEndianJSTest extends ShortView
 
 // Read only Short views of byte buffers
 
-object ReadOnlyShortViewOfAllocDirectByteBufferBigEndianJSTest extends SupportsTypedArrays
-
-class ReadOnlyShortViewOfAllocDirectByteBufferBigEndianJSTest
-    extends ReadOnlyShortViewOfByteBufferTest(new AllocDirectByteBufferFactory, ByteOrder.BIG_ENDIAN)
-
-object ReadOnlyShortViewOfSlicedAllocDirectByteBufferBigEndianJSTest extends SupportsTypedArrays
-
-class ReadOnlyShortViewOfSlicedAllocDirectByteBufferBigEndianJSTest
-    extends ReadOnlyShortViewOfByteBufferTest(
-        new SlicedAllocDirectByteBufferFactory, ByteOrder.BIG_ENDIAN)
-
 object ReadOnlyShortViewOfWrappedTypedArrayByteBufferBigEndianJSTest extends SupportsTypedArrays
 
 class ReadOnlyShortViewOfWrappedTypedArrayByteBufferBigEndianJSTest
     extends ReadOnlyShortViewOfByteBufferTest(
         new WrappedTypedArrayByteBufferFactory, ByteOrder.BIG_ENDIAN)
-
-object ReadOnlyShortViewOfAllocDirectByteBufferLittleEndianJSTest extends SupportsTypedArrays
-
-class ReadOnlyShortViewOfAllocDirectByteBufferLittleEndianJSTest
-    extends ReadOnlyShortViewOfByteBufferTest(
-        new AllocDirectByteBufferFactory, ByteOrder.LITTLE_ENDIAN)
-
-object ReadOnlyShortViewOfSlicedAllocDirectByteBufferLittleEndianJSTest extends SupportsTypedArrays
-
-class ReadOnlyShortViewOfSlicedAllocDirectByteBufferLittleEndianJSTest
-    extends ReadOnlyShortViewOfByteBufferTest(
-        new SlicedAllocDirectByteBufferFactory, ByteOrder.LITTLE_ENDIAN)
 
 object ReadOnlyShortViewOfWrappedTypedArrayByteBufferLittleEndianJSTest extends SupportsTypedArrays
 

--- a/test-suite/jvm/src/main/scala/org/scalajs/testsuite/utils/Platform.scala
+++ b/test-suite/jvm/src/main/scala/org/scalajs/testsuite/utils/Platform.scala
@@ -45,7 +45,6 @@ object Platform {
   def hasCompliantNullPointers: Boolean = true
   def hasCompliantStringIndexOutOfBounds: Boolean = true
   def hasCompliantModule: Boolean = true
-  def hasDirectBuffers: Boolean = true
 
   def regexSupportsUnicodeCase: Boolean = true
   def regexSupportsUnicodeCharacterClasses: Boolean = true

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/BitSetTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/BitSetTest.scala
@@ -1493,9 +1493,7 @@ class BitSetTest {
     assertEquals(1, allocateByteBuffer.position())
   }
 
-  @Test def valueOf_ByteBuffer_typedArrays(): Unit = {
-    assumeTrue("requires support for direct Buffers", hasDirectBuffers)
-
+  @Test def valueOf_ByteBuffer_direct(): Unit = {
     val eightBS = makeEightBS()
     val eightBytes = eightBS.toByteArray()
 

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/niobuffer/BaseBufferTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/niobuffer/BaseBufferTest.scala
@@ -58,6 +58,11 @@ abstract class BaseBufferTest {
     assertEquals(9, buf2.capacity())
   }
 
+  @Test def isDirect(): Unit = {
+    val buf = allocBuffer(10)
+    assertEquals(createsDirect, buf.isDirect())
+  }
+
   @Test def isReadOnly()(): Unit = {
     val buf = allocBuffer(10)
     if (createsReadOnly)
@@ -345,6 +350,8 @@ abstract class BaseBufferTest {
     buf1.limit(7)
     buf1.mark()
     val buf2 = buf1.sliceChain()
+    assertEquals(buf1.isDirect(), buf2.isDirect())
+    assertEquals(buf1.isReadOnly(), buf2.isReadOnly())
     assertEquals(0, buf2.position())
     assertEquals(4, buf2.limit())
     assertEquals(4, buf2.capacity())
@@ -380,6 +387,8 @@ abstract class BaseBufferTest {
     buf1.limit(7)
     buf1.mark()
     val buf2 = buf1.duplicateChain()
+    assertEquals(buf1.isDirect(), buf2.isDirect())
+    assertEquals(buf1.isReadOnly(), buf2.isReadOnly())
     assertEquals(3, buf2.position())
     assertEquals(7, buf2.limit())
     assertEquals(10, buf2.capacity())

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/niobuffer/BufferFactory.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/niobuffer/BufferFactory.scala
@@ -36,6 +36,8 @@ sealed abstract class BufferFactory {
   def boxedElemsFromInt(elems: Int*): Array[AnyRef] =
     boxed(elems.map(elemFromInt).toArray)
 
+  val createsDirect: Boolean = false
+
   val createsReadOnly: Boolean = false
 
   protected[this] def explicitlyValidateCapacity(capacity: Int): Unit = {
@@ -208,6 +210,8 @@ object BufferFactory {
   }
 
   trait WrappedTypedArrayBufferFactory extends WrappedBufferFactory {
+    override val createsDirect: Boolean = true
+
     protected def baseWrap(array: Array[ElementType],
         offset: Int, length: Int): BufferType = {
       val buf = baseWrap(array)
@@ -258,6 +262,12 @@ object BufferFactory {
   }
 
   trait ByteBufferViewFactory extends BufferFactory {
+    protected val byteBufferFactory: ByteBufferFactory
+
+    require(!byteBufferFactory.createsReadOnly)
+
+    override val createsDirect: Boolean = byteBufferFactory.createsDirect
+
     def baseAllocBuffer(capacity: Int): BufferType
 
     def allocBuffer(capacity: Int): BufferType =

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/niobuffer/ByteBufferFactories.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/niobuffer/ByteBufferFactories.scala
@@ -31,6 +31,8 @@ object ByteBufferFactories {
   }
 
   class AllocDirectByteBufferFactory extends ByteBufferFactory {
+    override val createsDirect: Boolean = true
+
     def allocBuffer(capacity: Int): ByteBuffer =
       ByteBuffer.allocateDirect(capacity)
   }

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/niobuffer/ByteBufferTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/niobuffer/ByteBufferTest.scala
@@ -1146,3 +1146,13 @@ class SlicedAllocByteBufferTest extends ByteBufferTest {
   val factory: ByteBufferFactory =
     new ByteBufferFactories.SlicedAllocByteBufferFactory
 }
+
+class AllocDirectByteBufferTest extends ByteBufferTest {
+  val factory: ByteBufferFactory =
+    new ByteBufferFactories.AllocDirectByteBufferFactory
+}
+
+class SlicedAllocDirectByteBufferTest extends ByteBufferTest {
+  val factory: ByteBufferFactory =
+    new ByteBufferFactories.SlicedAllocDirectByteBufferFactory
+}

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/niobuffer/CharBufferTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/niobuffer/CharBufferTest.scala
@@ -37,10 +37,9 @@ abstract class CharBufferTest extends BaseBufferTest {
   }
 
   class ByteBufferCharViewFactory(
-      byteBufferFactory: BufferFactory.ByteBufferFactory,
+      protected val byteBufferFactory: BufferFactory.ByteBufferFactory,
       order: ByteOrder)
       extends Factory with BufferFactory.ByteBufferViewFactory {
-    require(!byteBufferFactory.createsReadOnly)
 
     def baseAllocBuffer(capacity: Int): CharBuffer =
       byteBufferFactory.allocBuffer(capacity * 2).order(order).asCharBuffer()
@@ -181,3 +180,34 @@ class ReadOnlyCharViewOfWrappedByteBufferLittleEndianTest
 class ReadOnlyCharViewOfSlicedAllocByteBufferLittleEndianTest
     extends ReadOnlyCharViewOfByteBufferTest(
         new SlicedAllocByteBufferFactory, ByteOrder.LITTLE_ENDIAN)
+
+// Char views of direct byte buffers
+
+class CharViewOfAllocDirectByteBufferBigEndianTest
+    extends CharViewOfByteBufferTest(new AllocDirectByteBufferFactory, ByteOrder.BIG_ENDIAN)
+
+class CharViewOfSlicedAllocDirectByteBufferBigEndianTest
+    extends CharViewOfByteBufferTest(new SlicedAllocDirectByteBufferFactory, ByteOrder.BIG_ENDIAN)
+
+class CharViewOfAllocDirectByteBufferLittleEndianTest
+    extends CharViewOfByteBufferTest(new AllocDirectByteBufferFactory, ByteOrder.LITTLE_ENDIAN)
+
+class CharViewOfSlicedAllocDirectByteBufferLittleEndianTest
+    extends CharViewOfByteBufferTest(new SlicedAllocDirectByteBufferFactory, ByteOrder.LITTLE_ENDIAN)
+
+// Read only Char views of direct byte buffers
+
+class ReadOnlyCharViewOfAllocDirectByteBufferBigEndianTest
+    extends ReadOnlyCharViewOfByteBufferTest(new AllocDirectByteBufferFactory, ByteOrder.BIG_ENDIAN)
+
+class ReadOnlyCharViewOfSlicedAllocDirectByteBufferBigEndianTest
+    extends ReadOnlyCharViewOfByteBufferTest(
+        new SlicedAllocDirectByteBufferFactory, ByteOrder.BIG_ENDIAN)
+
+class ReadOnlyCharViewOfAllocDirectByteBufferLittleEndianTest
+    extends ReadOnlyCharViewOfByteBufferTest(
+        new AllocDirectByteBufferFactory, ByteOrder.LITTLE_ENDIAN)
+
+class ReadOnlyCharViewOfSlicedAllocDirectByteBufferLittleEndianTest
+    extends ReadOnlyCharViewOfByteBufferTest(
+        new SlicedAllocDirectByteBufferFactory, ByteOrder.LITTLE_ENDIAN)

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/niobuffer/DoubleBufferTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/niobuffer/DoubleBufferTest.scala
@@ -33,10 +33,9 @@ abstract class DoubleBufferTest extends BaseBufferTest {
   }
 
   class ByteBufferDoubleViewFactory(
-      byteBufferFactory: BufferFactory.ByteBufferFactory,
+      protected val byteBufferFactory: BufferFactory.ByteBufferFactory,
       order: ByteOrder)
       extends Factory with BufferFactory.ByteBufferViewFactory {
-    require(!byteBufferFactory.createsReadOnly)
 
     def baseAllocBuffer(capacity: Int): DoubleBuffer =
       byteBufferFactory.allocBuffer(capacity * 8).order(order).asDoubleBuffer()
@@ -121,3 +120,35 @@ class ReadOnlyDoubleViewOfWrappedByteBufferLittleEndianTest
 class ReadOnlyDoubleViewOfSlicedAllocByteBufferLittleEndianTest
     extends ReadOnlyDoubleViewOfByteBufferTest(
         new SlicedAllocByteBufferFactory, ByteOrder.LITTLE_ENDIAN)
+
+// Double views of direct byte buffers
+
+class DoubleViewOfAllocDirectByteBufferBigEndianTest
+    extends DoubleViewOfByteBufferTest(new AllocDirectByteBufferFactory, ByteOrder.BIG_ENDIAN)
+
+class DoubleViewOfSlicedAllocDirectByteBufferBigEndianTest
+    extends DoubleViewOfByteBufferTest(new SlicedAllocDirectByteBufferFactory, ByteOrder.BIG_ENDIAN)
+
+class DoubleViewOfAllocDirectByteBufferLittleEndianTest
+    extends DoubleViewOfByteBufferTest(new AllocDirectByteBufferFactory, ByteOrder.LITTLE_ENDIAN)
+
+class DoubleViewOfSlicedAllocDirectByteBufferLittleEndianTest extends DoubleViewOfByteBufferTest(
+        new SlicedAllocDirectByteBufferFactory, ByteOrder.LITTLE_ENDIAN)
+
+// Read only Double views of direct byte buffers
+
+class ReadOnlyDoubleViewOfAllocDirectByteBufferBigEndianTest
+    extends ReadOnlyDoubleViewOfByteBufferTest(
+        new AllocDirectByteBufferFactory, ByteOrder.BIG_ENDIAN)
+
+class ReadOnlyDoubleViewOfSlicedAllocDirectByteBufferBigEndianTest
+    extends ReadOnlyDoubleViewOfByteBufferTest(
+        new SlicedAllocDirectByteBufferFactory, ByteOrder.BIG_ENDIAN)
+
+class ReadOnlyDoubleViewOfAllocDirectByteBufferLittleEndianTest
+    extends ReadOnlyDoubleViewOfByteBufferTest(
+        new AllocDirectByteBufferFactory, ByteOrder.LITTLE_ENDIAN)
+
+class ReadOnlyDoubleViewOfSlicedAllocDirectByteBufferLittleEndianTest
+    extends ReadOnlyDoubleViewOfByteBufferTest(
+        new SlicedAllocDirectByteBufferFactory, ByteOrder.LITTLE_ENDIAN)

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/niobuffer/FloatBufferTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/niobuffer/FloatBufferTest.scala
@@ -33,10 +33,9 @@ abstract class FloatBufferTest extends BaseBufferTest {
   }
 
   class ByteBufferFloatViewFactory(
-      byteBufferFactory: BufferFactory.ByteBufferFactory,
+      protected val byteBufferFactory: BufferFactory.ByteBufferFactory,
       order: ByteOrder)
       extends Factory with BufferFactory.ByteBufferViewFactory {
-    require(!byteBufferFactory.createsReadOnly)
 
     def baseAllocBuffer(capacity: Int): FloatBuffer =
       byteBufferFactory.allocBuffer(capacity * 4).order(order).asFloatBuffer()
@@ -120,3 +119,34 @@ class ReadOnlyFloatViewOfWrappedByteBufferLittleEndianTest
 class ReadOnlyFloatViewOfSlicedAllocByteBufferLittleEndianTest
     extends ReadOnlyFloatViewOfByteBufferTest(
         new SlicedAllocByteBufferFactory, ByteOrder.LITTLE_ENDIAN)
+
+// Float views of direct byte buffers
+
+class FloatViewOfAllocDirectByteBufferBigEndianTest
+    extends FloatViewOfByteBufferTest(new AllocDirectByteBufferFactory, ByteOrder.BIG_ENDIAN)
+
+class FloatViewOfSlicedAllocDirectByteBufferBigEndianTest
+    extends FloatViewOfByteBufferTest(new SlicedAllocDirectByteBufferFactory, ByteOrder.BIG_ENDIAN)
+
+class FloatViewOfAllocDirectByteBufferLittleEndianTest
+    extends FloatViewOfByteBufferTest(new AllocDirectByteBufferFactory, ByteOrder.LITTLE_ENDIAN)
+
+class FloatViewOfSlicedAllocDirectByteBufferLittleEndianTest extends FloatViewOfByteBufferTest(
+        new SlicedAllocDirectByteBufferFactory, ByteOrder.LITTLE_ENDIAN)
+
+// Read only Float views of direct byte buffers
+
+class ReadOnlyFloatViewOfAllocDirectByteBufferBigEndianTest
+    extends ReadOnlyFloatViewOfByteBufferTest(new AllocDirectByteBufferFactory, ByteOrder.BIG_ENDIAN)
+
+class ReadOnlyFloatViewOfSlicedAllocDirectByteBufferBigEndianTest
+    extends ReadOnlyFloatViewOfByteBufferTest(
+        new SlicedAllocDirectByteBufferFactory, ByteOrder.BIG_ENDIAN)
+
+class ReadOnlyFloatViewOfAllocDirectByteBufferLittleEndianTest
+    extends ReadOnlyFloatViewOfByteBufferTest(
+        new AllocDirectByteBufferFactory, ByteOrder.LITTLE_ENDIAN)
+
+class ReadOnlyFloatViewOfSlicedAllocDirectByteBufferLittleEndianTest
+    extends ReadOnlyFloatViewOfByteBufferTest(
+        new SlicedAllocDirectByteBufferFactory, ByteOrder.LITTLE_ENDIAN)

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/niobuffer/IntBufferTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/niobuffer/IntBufferTest.scala
@@ -33,10 +33,9 @@ abstract class IntBufferTest extends BaseBufferTest {
   }
 
   class ByteBufferIntViewFactory(
-      byteBufferFactory: BufferFactory.ByteBufferFactory,
+      protected val byteBufferFactory: BufferFactory.ByteBufferFactory,
       order: ByteOrder)
       extends Factory with BufferFactory.ByteBufferViewFactory {
-    require(!byteBufferFactory.createsReadOnly)
 
     def baseAllocBuffer(capacity: Int): IntBuffer =
       byteBufferFactory.allocBuffer(capacity * 4).order(order).asIntBuffer()
@@ -117,3 +116,33 @@ class ReadOnlyIntViewOfWrappedByteBufferLittleEndianTest
 
 class ReadOnlyIntViewOfSlicedAllocByteBufferLittleEndianTest extends ReadOnlyIntViewOfByteBufferTest(
         new SlicedAllocByteBufferFactory, ByteOrder.LITTLE_ENDIAN)
+
+// Int views of direct byte buffers
+
+class IntViewOfAllocDirectByteBufferBigEndianTest
+    extends IntViewOfByteBufferTest(new AllocDirectByteBufferFactory, ByteOrder.BIG_ENDIAN)
+
+class IntViewOfSlicedAllocDirectByteBufferBigEndianTest
+    extends IntViewOfByteBufferTest(new SlicedAllocDirectByteBufferFactory, ByteOrder.BIG_ENDIAN)
+
+class IntViewOfAllocDirectByteBufferLittleEndianTest
+    extends IntViewOfByteBufferTest(new AllocDirectByteBufferFactory, ByteOrder.LITTLE_ENDIAN)
+
+class IntViewOfSlicedAllocDirectByteBufferLittleEndianTest
+    extends IntViewOfByteBufferTest(new SlicedAllocDirectByteBufferFactory, ByteOrder.LITTLE_ENDIAN)
+
+// Read only Int views of direct byte buffers
+
+class ReadOnlyIntViewOfAllocDirectByteBufferBigEndianTest
+    extends ReadOnlyIntViewOfByteBufferTest(new AllocDirectByteBufferFactory, ByteOrder.BIG_ENDIAN)
+
+class ReadOnlyIntViewOfSlicedAllocDirectByteBufferBigEndianTest
+    extends ReadOnlyIntViewOfByteBufferTest(
+        new SlicedAllocDirectByteBufferFactory, ByteOrder.BIG_ENDIAN)
+
+class ReadOnlyIntViewOfAllocDirectByteBufferLittleEndianTest extends ReadOnlyIntViewOfByteBufferTest(
+        new AllocDirectByteBufferFactory, ByteOrder.LITTLE_ENDIAN)
+
+class ReadOnlyIntViewOfSlicedAllocDirectByteBufferLittleEndianTest
+    extends ReadOnlyIntViewOfByteBufferTest(
+        new SlicedAllocDirectByteBufferFactory, ByteOrder.LITTLE_ENDIAN)

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/niobuffer/LongBufferTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/niobuffer/LongBufferTest.scala
@@ -33,10 +33,9 @@ abstract class LongBufferTest extends BaseBufferTest {
   }
 
   class ByteBufferLongViewFactory(
-      byteBufferFactory: BufferFactory.ByteBufferFactory,
+      protected val byteBufferFactory: BufferFactory.ByteBufferFactory,
       order: ByteOrder)
       extends Factory with BufferFactory.ByteBufferViewFactory {
-    require(!byteBufferFactory.createsReadOnly)
 
     def baseAllocBuffer(capacity: Int): LongBuffer =
       byteBufferFactory.allocBuffer(capacity * 8).order(order).asLongBuffer()
@@ -118,3 +117,34 @@ class ReadOnlyLongViewOfWrappedByteBufferLittleEndianTest
 class ReadOnlyLongViewOfSlicedAllocByteBufferLittleEndianTest
     extends ReadOnlyLongViewOfByteBufferTest(
         new SlicedAllocByteBufferFactory, ByteOrder.LITTLE_ENDIAN)
+
+// Long views of direct byte buffers
+
+class LongViewOfAllocDirectByteBufferBigEndianTest
+    extends LongViewOfByteBufferTest(new AllocDirectByteBufferFactory, ByteOrder.BIG_ENDIAN)
+
+class LongViewOfSlicedAllocDirectByteBufferBigEndianTest
+    extends LongViewOfByteBufferTest(new SlicedAllocDirectByteBufferFactory, ByteOrder.BIG_ENDIAN)
+
+class LongViewOfAllocDirectByteBufferLittleEndianTest
+    extends LongViewOfByteBufferTest(new AllocDirectByteBufferFactory, ByteOrder.LITTLE_ENDIAN)
+
+class LongViewOfSlicedAllocDirectByteBufferLittleEndianTest
+    extends LongViewOfByteBufferTest(new SlicedAllocDirectByteBufferFactory, ByteOrder.LITTLE_ENDIAN)
+
+// Read only Long views of direct byte buffers
+
+class ReadOnlyLongViewOfAllocDirectByteBufferBigEndianTest
+    extends ReadOnlyLongViewOfByteBufferTest(new AllocDirectByteBufferFactory, ByteOrder.BIG_ENDIAN)
+
+class ReadOnlyLongViewOfSlicedAllocDirectByteBufferBigEndianTest
+    extends ReadOnlyLongViewOfByteBufferTest(
+        new SlicedAllocDirectByteBufferFactory, ByteOrder.BIG_ENDIAN)
+
+class ReadOnlyLongViewOfAllocDirectByteBufferLittleEndianTest
+    extends ReadOnlyLongViewOfByteBufferTest(
+        new AllocDirectByteBufferFactory, ByteOrder.LITTLE_ENDIAN)
+
+class ReadOnlyLongViewOfSlicedAllocDirectByteBufferLittleEndianTest
+    extends ReadOnlyLongViewOfByteBufferTest(
+        new SlicedAllocDirectByteBufferFactory, ByteOrder.LITTLE_ENDIAN)

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/niobuffer/ShortBufferTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/niobuffer/ShortBufferTest.scala
@@ -33,10 +33,9 @@ abstract class ShortBufferTest extends BaseBufferTest {
   }
 
   class ByteBufferShortViewFactory(
-      byteBufferFactory: BufferFactory.ByteBufferFactory,
+      protected val byteBufferFactory: BufferFactory.ByteBufferFactory,
       order: ByteOrder)
       extends Factory with BufferFactory.ByteBufferViewFactory {
-    require(!byteBufferFactory.createsReadOnly)
 
     def baseAllocBuffer(capacity: Int): ShortBuffer =
       byteBufferFactory.allocBuffer(capacity * 2).order(order).asShortBuffer()
@@ -120,3 +119,34 @@ class ReadOnlyShortViewOfWrappedByteBufferLittleEndianTest
 class ReadOnlyShortViewOfSlicedAllocByteBufferLittleEndianTest
     extends ReadOnlyShortViewOfByteBufferTest(
         new SlicedAllocByteBufferFactory, ByteOrder.LITTLE_ENDIAN)
+
+// Short views of direct byte buffers
+
+class ShortViewOfAllocDirectByteBufferBigEndianTest
+    extends ShortViewOfByteBufferTest(new AllocDirectByteBufferFactory, ByteOrder.BIG_ENDIAN)
+
+class ShortViewOfSlicedAllocDirectByteBufferBigEndianTest
+    extends ShortViewOfByteBufferTest(new SlicedAllocDirectByteBufferFactory, ByteOrder.BIG_ENDIAN)
+
+class ShortViewOfAllocDirectByteBufferLittleEndianTest
+    extends ShortViewOfByteBufferTest(new AllocDirectByteBufferFactory, ByteOrder.LITTLE_ENDIAN)
+
+class ShortViewOfSlicedAllocDirectByteBufferLittleEndianTest extends ShortViewOfByteBufferTest(
+        new SlicedAllocDirectByteBufferFactory, ByteOrder.LITTLE_ENDIAN)
+
+// Read only Short views of direct byte buffers
+
+class ReadOnlyShortViewOfAllocDirectByteBufferBigEndianTest
+    extends ReadOnlyShortViewOfByteBufferTest(new AllocDirectByteBufferFactory, ByteOrder.BIG_ENDIAN)
+
+class ReadOnlyShortViewOfSlicedAllocDirectByteBufferBigEndianTest
+    extends ReadOnlyShortViewOfByteBufferTest(
+        new SlicedAllocDirectByteBufferFactory, ByteOrder.BIG_ENDIAN)
+
+class ReadOnlyShortViewOfAllocDirectByteBufferLittleEndianTest
+    extends ReadOnlyShortViewOfByteBufferTest(
+        new AllocDirectByteBufferFactory, ByteOrder.LITTLE_ENDIAN)
+
+class ReadOnlyShortViewOfSlicedAllocDirectByteBufferLittleEndianTest
+    extends ReadOnlyShortViewOfByteBufferTest(
+        new SlicedAllocDirectByteBufferFactory, ByteOrder.LITTLE_ENDIAN)


### PR DESCRIPTION
They are backed by arrays, which is allowed by the spec.

The motivation is not so much about ES 5.1 (which is deprecated anyway), but about future support of Wasm without a JS host. In Wasm without JS host, we should be able to allocate a direct `ByteBuffer` even if there are no JS typed arrays.

/cc @tanishiking When this PR reaches scala-wasm/scala-wasm, you'll have to amend `ByteBuffer.allocateDirect` to use a `linkTimeIf` for Wasm-only targets to also take the code path with `HeapByteBuffer.allocateDirect(capacity)`.