### PR TITLE
Overhaul ju.Date: always use the GMT time zone, and implement it without JS interop.

### DIFF
--- a/javalib/src/main/scala/java/util/Date.scala
+++ b/javalib/src/main/scala/java/util/Date.scala
@@ -20,6 +20,10 @@ import java.util.function._
 
 import scalajs.js
 
+/* Note that the default timezone is always Etc/GMT (= UTC, without any
+ * daylight saving time).
+ */
+
 class Date(private var millis: Long)
     extends Object with Serializable with Cloneable with Comparable[Date] {
 
@@ -29,7 +33,7 @@ class Date(private var millis: Long)
 
   @Deprecated
   def this(year: Int, month: Int, date: Int, hrs: Int, min: Int, sec: Int) =
-    this(Date.safeGetTime(new js.Date(1900 + year, month, date, hrs, min, sec, 0)))
+    this(Date.UTC(year, month, date, hrs, min, sec))
 
   @Deprecated
   def this(year: Int, month: Int, date: Int, hrs: Int, min: Int) =
@@ -74,53 +78,54 @@ class Date(private var millis: Long)
   }
 
   @Deprecated
-  def getDate(): Int = asDate().getDate().toInt
+  def getDate(): Int = asDate().getUTCDate().toInt
 
   @Deprecated
-  def getDay(): Int = asDate().getDay().toInt
+  def getDay(): Int = asDate().getUTCDay().toInt
 
   @Deprecated
-  def getHours(): Int = asDate().getHours().toInt
+  def getHours(): Int = asDate().getUTCHours().toInt
 
   @Deprecated
-  def getMinutes(): Int = asDate().getMinutes().toInt
+  def getMinutes(): Int = asDate().getUTCMinutes().toInt
 
   @Deprecated
-  def getMonth(): Int = asDate().getMonth().toInt
+  def getMonth(): Int = asDate().getUTCMonth().toInt
 
   @Deprecated
-  def getSeconds(): Int = asDate().getSeconds().toInt
+  def getSeconds(): Int = asDate().getUTCSeconds().toInt
 
   def getTime(): Long = millis
 
   @Deprecated
-  def getTimezoneOffset(): Int = new js.Date().getTimezoneOffset().toInt
+  def getTimezoneOffset(): Int = 0
 
   @Deprecated
-  def getYear(): Int = asDate().getFullYear().toInt - 1900
+  def getYear(): Int = asDate().getUTCFullYear().toInt - 1900
 
   @Deprecated
-  def setDate(date: Int): Unit = mutDate(_.setDate(date))
+  def setDate(date: Int): Unit = mutDate(_.setUTCDate(date))
 
   @Deprecated
-  def setHours(hours: Int): Unit = mutDate(_.setHours(hours))
+  def setHours(hours: Int): Unit = mutDate(_.setUTCHours(hours))
 
   @Deprecated
-  def setMinutes(minutes: Int): Unit = mutDate(_.setMinutes(minutes))
+  def setMinutes(minutes: Int): Unit = mutDate(_.setUTCMinutes(minutes))
 
   @Deprecated
-  def setMonth(month: Int): Unit = mutDate(_.setMonth(month))
+  def setMonth(month: Int): Unit = mutDate(_.setUTCMonth(month))
 
   @Deprecated
-  def setSeconds(seconds: Int): Unit = mutDate(_.setSeconds(seconds))
+  def setSeconds(seconds: Int): Unit = mutDate(_.setUTCSeconds(seconds))
 
   def setTime(time: Long): Unit = millis = time
 
   @Deprecated
-  def setYear(year: Int): Unit = mutDate(_.setFullYear(1900 + year))
+  def setYear(year: Int): Unit = mutDate(_.setUTCFullYear(1900 + year))
 
   @Deprecated
   def toGMTString(): String = {
+    // Specified format: "d mon yyyy hh:mm:ss GMT".
     val date = asDate()
     "" + date.getUTCDate().toInt + " " + Months(date.getUTCMonth().toInt) + " " +
       date.getUTCFullYear().toInt + " " + pad0(date.getUTCHours().toInt) + ":" +
@@ -132,23 +137,23 @@ class Date(private var millis: Long)
 
   @Deprecated
   def toLocaleString(): String = {
+    /* Use the format "yyyy mon d hh:mm:ss", which appears to be what the JVM
+     * uses for the timezone Etc/GMT and the ROOT locale.
+     */
     val date = asDate()
-    "" + date.getDate().toInt + "-" + Months(date.getMonth().toInt) + "-" +
-      date.getFullYear().toInt + "-" + pad0(date.getHours().toInt) + ":" +
-      pad0(date.getMinutes().toInt) + ":" + pad0(date.getSeconds().toInt)
+    "" + date.getUTCFullYear().toInt + " " + Months(date.getUTCMonth().toInt) + " " +
+      date.getDate().toInt + " " + pad0(date.getUTCHours().toInt) + ":" +
+      pad0(date.getUTCMinutes().toInt) + ":" + pad0(date.getUTCSeconds().toInt)
   }
 
   override def toString(): String = {
+    // Specified format: "dow mon dd hh:mm:ss zzz yyyy". zzz is always "GMT".
     if (isSafeJSDate()) {
       val date = asDate()
-      val offset = -date.getTimezoneOffset().toInt
-      val sign = if (offset < 0) "-" else "+"
-      val hours = pad0(Math.abs(offset) / 60)
-      val mins = pad0(Math.abs(offset) % 60)
-      Days(date.getDay().toInt) + " " + Months(date.getMonth().toInt) + " " +
-        pad0(date.getDate().toInt) + " " + pad0(date.getHours().toInt) + ":" +
-        pad0(date.getMinutes().toInt) + ":" + pad0(date.getSeconds().toInt) +
-        " GMT" + " " + date.getFullYear().toInt
+      Days(date.getUTCDay().toInt) + " " + Months(date.getUTCMonth().toInt) + " " +
+        pad0(date.getUTCDate().toInt) + " " + pad0(date.getUTCHours().toInt) + ":" +
+        pad0(date.getUTCMinutes().toInt) + ":" + pad0(date.getUTCSeconds().toInt) +
+        " GMT " + date.getUTCFullYear().toInt
     } else {
       s"java.util.Date($millis)"
     }
@@ -214,7 +219,7 @@ object Date {
   @Deprecated
   def UTC(year: Int, month: Int, date: Int,
       hrs: Int, min: Int, sec: Int): Long = {
-    js.Date.UTC(year + 1900, month, date, hrs, min, sec).toLong
+    safeGetTime(js.Date.UTC(year + 1900, month, date, hrs, min, sec))
   }
 
   @Deprecated
@@ -234,10 +239,11 @@ object Date {
     var minute = -1
     var second = -1
 
-    /* The timezone offset (in minutes) can be negative, but is parsed from a
-     * positive int and therefore cannot be Int.MinValue.
+    /* If we do not find any timezone, we will default to GMT. We don't need a
+     * separate encoding of "not there". All the code paths behave the same for
+     * "last parsed is GMT" and "no timezone parsed so far".
      */
-    var timezoneOffset = Int.MinValue
+    var timezoneOffset = 0
 
     @inline def isASCIIDigit(c: Char): Boolean =
       c >= '0' && c <= '9'
@@ -288,7 +294,7 @@ object Date {
           /* > If a number is preceded by + or - and a year has already been
            * > recognized, then the number is a time-zone offset.
            */
-          if (timezoneOffset != Int.MinValue && timezoneOffset != 0)
+          if (timezoneOffset != 0)
             fail() // out of spec
           val signedNumber = if (prev == '-') -number else number
           if (number < 24) {
@@ -426,24 +432,24 @@ object Date {
     if (second == -1)
       second = 0
 
-    if (timezoneOffset != Int.MinValue) {
-      /* > If a time zone or time-zone offset has been recognized, then the year,
-       * > month, day of month, hour, minute, and second are interpreted in UTC
-       * > and then the time-zone offset is applied.
-       */
-      val utc = UTC(year - 1900, month, dayOfMonth, hour, minute, second)
-      utc - (timezoneOffset * MSPerMinute).toLong
-    } else {
-      /* > Otherwise, the year, month, day of month, hour, minute, and second
-       * > are interpreted in the local time zone.
-       */
-      safeGetTime(new js.Date(year, month, dayOfMonth, hour, minute, second, 0))
-    }
+    /* > If a time zone or time-zone offset has been recognized, then the year,
+     * > month, day of month, hour, minute, and second are interpreted in UTC
+     * > and then the time-zone offset is applied.
+     * > Otherwise, the year, month, day of month, hour, minute, and second
+     * > are interpreted in the local time zone.
+     *
+     * Since the local time zone is always GMT=UTC, we have a unique code path.
+     */
+    val utc = UTC(year - 1900, month, dayOfMonth, hour, minute, second)
+    utc - (timezoneOffset * MSPerMinute).toLong
   }
 
   @inline
-  private def safeGetTime(date: js.Date): Long = {
-    val time = date.getTime()
+  private def safeGetTime(date: js.Date): Long =
+    safeGetTime(date.getTime())
+
+  @inline
+  private def safeGetTime(time: Double): Long = {
     if (java.lang.Double.isNaN(time))
       throw new IllegalArgumentException
     time.toLong

--- a/javalib/src/main/scala/java/util/Date.scala
+++ b/javalib/src/main/scala/java/util/Date.scala
@@ -16,15 +16,12 @@ import scala.annotation.switch
 
 import java.lang.Cloneable
 import java.time.Instant
-import java.util.function._
-
-import scalajs.js
 
 /* Note that the default timezone is always Etc/GMT (= UTC, without any
  * daylight saving time).
  */
 
-class Date(private var millis: Long)
+class Date(private var time: Long)
     extends Object with Serializable with Cloneable with Comparable[Date] {
 
   import Date._
@@ -46,91 +43,238 @@ class Date(private var millis: Long)
   @Deprecated
   def this(date: String) = this(Date.parse(date))
 
-  def after(when: Date): Boolean = millis > when.millis
+  /** The cached decoded year.
+   *
+   *  Valid iff `cachedRest` is valid.
+   */
+  private var cachedYear: Int = 0
 
-  def before(when: Date): Boolean = millis < when.millis
+  /** Cached data for every else.
+   *
+   *  Bit field with dayOfWeek, month, day, hour, minute, second.
+   *
+   *  Valid iff `cachedRest != 0` (because `day` is 1-based).
+   */
+  private var cachedRest: Int = 0
 
-  override def clone(): Object = new Date(millis)
+  // API that only uses the timestamp (no decoding/encoding)
+
+  def after(when: Date): Boolean = time > when.time
+
+  def before(when: Date): Boolean = time < when.time
+
+  override def clone(): Object = new Date(time)
 
   override def compareTo(anotherDate: Date): Int =
-    java.lang.Long.compare(millis, anotherDate.millis)
+    java.lang.Long.compare(time, anotherDate.time)
 
   override def equals(obj: Any): Boolean = obj match {
-    case d: Date => d.millis == millis
+    case d: Date => d.time == time
     case _       => false
   }
 
-  override def hashCode(): Int = millis.hashCode()
+  override def hashCode(): Int =
+    java.lang.Long.hashCode(time)
 
-  private def asDate(): js.Date = {
-    if (!isSafeJSDate()) {
-      throw new IllegalArgumentException(
-          s"cannot convert this java.util.Date ($millis millis) to a js.Date")
-    }
-    new js.Date(millis.toDouble)
-  }
+  // API that requires decoding and encoding into calendar fields
 
   @inline
-  private def mutDate(mutator: Consumer[js.Date]): Unit = {
-    val date = asDate()
-    mutator.accept(date)
-    millis = safeGetTime(date)
+  private def decode(): Decoded = {
+    if (cachedRest == 0)
+      doDecodeAndCache()
+    Decoded.fromBits(cachedYear, cachedRest)
+  }
+
+  @noinline
+  private def doDecodeAndCache(): Unit = {
+    // Decompose into day and time-in-day
+    val (daysSinceEpoch, millisInDay) = floorDivMod(this.time, MSPerDay)
+
+    // Decompose time-in-day into hour, minute, second (ignore millis)
+    val (hour, millisInHour) = unsignedDivMod(millisInDay, MSPerHour)
+    val (minute, millisInMinute) = unsignedDivMod(millisInHour, MSPerMinute)
+    val second = Integer.divideUnsigned(millisInMinute, MSPerSecond)
+
+    // Find the year and day-in-year
+    val isGregorian = daysSinceEpoch >= FirstGregorianDaySinceEpoch
+    val (year, dayInYear, isLeapYear) =
+      if (isGregorian) decodeGregorianYearAndDayInYear(daysSinceEpoch)
+      else decodeJulianYearAndDayInYear(daysSinceEpoch)
+
+    // Compute the month-in-year and day-in-month
+    val (month, day) = if (dayInYear < 31 + 28 + isLeapYear) {
+      if (dayInYear < 31)
+        (0, dayInYear)
+      else
+        (1, dayInYear - 31)
+    } else {
+      val dayInYearAsIfNonLeap = dayInYear - isLeapYear
+      val cumulDaysInMonths = CumulativeDaysInMonthsNonLeap // local copy
+      var m = 2
+      while (dayInYearAsIfNonLeap >= cumulDaysInMonths(m))
+        m += 1
+      (m, dayInYearAsIfNonLeap - cumulDaysInMonths(m - 1))
+    }
+
+    /* The Julian/Gregorian transition did not interrupt the day-of-week cycle.
+     * Therefore, we directly compute it from `daysSinceEpoch`.
+     * The epoch was a Wednesday, so we add 4 and take the remainder by 7.
+     */
+    val dayOfWeek = Math.floorMod(daysSinceEpoch + 4L, 7)
+
+    val decoded = new Decoded(year, month, day + 1, hour, minute, second, dayOfWeek)
+    this.cachedYear = decoded.year
+    this.cachedRest = decoded.toRestBits
+  }
+
+  /** Decodes the year and day-in-year of a day that falls in the Gregorian calendar.
+   *
+   *  @return
+   *    `(year, dayInYear, isLeapYear)` where `isLeapYear` is 1 if yes and 0 otherwise.
+   */
+  @inline // exactly 1 call site
+  private def decodeGregorianYearAndDayInYear(daysSinceEpoch: Long): (Int, Int, Int) = {
+    // Decompose the day into a 400-year-cycle and days-in-cycle
+    val daysSinceYear0 = DaysFromGregorianYear0ToEpoch + daysSinceEpoch
+    val (cycleLong, daysIn400YearCycle) = floorDivMod(daysSinceYear0, DaysInGregorian400Years)
+    val cycle = cycleLong.toInt // we have divided enough now that we must fit in an int
+
+    /* Compute the year in the cycle and the day in the year.
+     *
+     * estimatedYearInCycle is either the correct year, or 1 too low.
+     *
+     * This assumption can be checked with
+     *   for (d <- 0 until 146097) { // days in the 400 cycle
+     *     val estimatedYear = 1600 + d/366 // start at 1600 for the Gregorian calendar
+     *     val correctYear = new Date(1600 - 1900, 0, 1 + d).getYear() + 1900
+     *     assert(estimatedYear == correctYear || estimatedYear == correctYear-1)
+     *   }
+     */
+    val (yearInCycle, dayInYear, isLeapYear) = {
+      val estimatedYearInCycle = Integer.divideUnsigned(daysIn400YearCycle, 366)
+      val estimatedDayInYear = daysIn400YearCycle - daysToYearInGregorianCycle(estimatedYearInCycle)
+      val estimatedIsLeap = if (isGregorianLeapYearInCycle(estimatedYearInCycle)) 1 else 0
+      val estimatedNumDays = 365 + estimatedIsLeap
+      if (estimatedDayInYear < estimatedNumDays) {
+        // The estimated day falls into the estimated year, so the estimation is correct
+        (estimatedYearInCycle, estimatedDayInYear, estimatedIsLeap)
+      } else {
+        // Adjust the estimation
+        val correctedYear = estimatedYearInCycle + 1
+        val correctedDayInYear = estimatedDayInYear - estimatedNumDays
+        val correctedYearIsLeap = if (isGregorianLeapYearInCycle(correctedYear)) 1 else 0
+        (correctedYear, correctedDayInYear, correctedYearIsLeap)
+      }
+    }
+    val year = cycle * 400 + yearInCycle
+
+    (year, dayInYear, isLeapYear)
+  }
+
+  /** Decodes the year and day-in-year of a day that falls in the Julian calendar.
+   *
+   *  @return
+   *    `(year, dayInYear, isLeapYear)` where `isLeapYear` is 1 if yes and 0 otherwise.
+   */
+  @inline // exactly 1 call site
+  private def decodeJulianYearAndDayInYear(daysSinceEpoch: Long): (Int, Int, Int) = {
+    // Decompose the day into a 4-year-cycle and days-in-cycle
+    val daysSinceYear0 = DaysFromJulianYear0ToEpoch + daysSinceEpoch
+    val (cycleLong, daysIn4YearCycle) = floorDivMod(daysSinceYear0, DaysInJulian4Years)
+    val cycle = cycleLong.toInt // we have divided enough now that we must fit in an int
+
+    val cycleYears = cycle * 4
+
+    if (daysIn4YearCycle < 366) {
+      // First year, which is the leap year
+      (cycleYears + 0, daysIn4YearCycle, 1)
+    } else {
+      // One of the other 3 years, which are not leap years
+      val (yearInCycle, dayInYear) = unsignedDivMod(daysIn4YearCycle - 1, 365)
+      (cycleYears + yearInCycle, dayInYear, 0)
+    }
   }
 
   @Deprecated
-  def getDate(): Int = asDate().getUTCDate().toInt
+  def getYear(): Int = decode().apiYear
 
   @Deprecated
-  def getDay(): Int = asDate().getUTCDay().toInt
+  def getMonth(): Int = decode().month
 
   @Deprecated
-  def getHours(): Int = asDate().getUTCHours().toInt
+  def getDate(): Int = decode().day
 
   @Deprecated
-  def getMinutes(): Int = asDate().getUTCMinutes().toInt
+  def getDay(): Int = decode().dayOfWeek
 
   @Deprecated
-  def getMonth(): Int = asDate().getUTCMonth().toInt
+  def getHours(): Int = decode().hour
 
   @Deprecated
-  def getSeconds(): Int = asDate().getUTCSeconds().toInt
+  def getMinutes(): Int = decode().minute
 
-  def getTime(): Long = millis
+  @Deprecated
+  def getSeconds(): Int = decode().second
+
+  def getTime(): Long = time
 
   @Deprecated
   def getTimezoneOffset(): Int = 0
 
-  @Deprecated
-  def getYear(): Int = asDate().getUTCFullYear().toInt - 1900
+  /** Resets the year and month.
+   *
+   *  This requires a full re-encoding.
+   */
+  private def setYearMonth(d: Decoded, newYear: Int, newMonth: Int): Unit = {
+    val timeInDay = Math.floorMod(time, MSPerDay.toLong)
+    setTime(encode(newYear, newMonth, d.day, timeInDay))
+  }
+
+  /** Sets a field whose difference translate directly into a number of milliseconds.
+   *
+   *  This is the case for every field except `year` and  `month`.
+   */
+  private def setCalendarIndependentField(prevValue: Int, newValue: Int, msPerField: Long): Unit =
+    setTime(time + (newValue.toLong - prevValue.toLong) * msPerField)
 
   @Deprecated
-  def setDate(date: Int): Unit = mutDate(_.setUTCDate(date))
+  def setYear(year: Int): Unit = {
+    val d = decode()
+    setYearMonth(d, year + 1900, d.month)
+  }
 
   @Deprecated
-  def setHours(hours: Int): Unit = mutDate(_.setUTCHours(hours))
+  def setMonth(month: Int): Unit = {
+    val d = decode()
+    setYearMonth(d, d.year, month)
+  }
 
   @Deprecated
-  def setMinutes(minutes: Int): Unit = mutDate(_.setUTCMinutes(minutes))
+  def setDate(date: Int): Unit =
+    setCalendarIndependentField(decode().day, date, MSPerDay)
 
   @Deprecated
-  def setMonth(month: Int): Unit = mutDate(_.setUTCMonth(month))
+  def setHours(hours: Int): Unit =
+    setCalendarIndependentField(decode().hour, hours, MSPerHour)
 
   @Deprecated
-  def setSeconds(seconds: Int): Unit = mutDate(_.setUTCSeconds(seconds))
-
-  def setTime(time: Long): Unit = millis = time
+  def setMinutes(minutes: Int): Unit =
+    setCalendarIndependentField(decode().minute, minutes, MSPerMinute)
 
   @Deprecated
-  def setYear(year: Int): Unit = mutDate(_.setUTCFullYear(1900 + year))
+  def setSeconds(seconds: Int): Unit =
+    setCalendarIndependentField(decode().second, seconds, MSPerSecond)
+
+  def setTime(time: Long): Unit = {
+    cachedRest = 0 // invalidate cache
+    this.time = time
+  }
 
   @Deprecated
   def toGMTString(): String = {
     // Specified format: "d mon yyyy hh:mm:ss GMT".
-    val date = asDate()
-    "" + date.getUTCDate().toInt + " " + Months(date.getUTCMonth().toInt) + " " +
-      date.getUTCFullYear().toInt + " " + pad0(date.getUTCHours().toInt) + ":" +
-      pad0(date.getUTCMinutes().toInt) + ":" +
-      pad0(date.getUTCSeconds().toInt) + " GMT"
+    val d = decode()
+    s"${d.day} ${Months(d.month)} ${d.eraYear} ${d.formattedTimeInDay} GMT"
   }
 
   def toInstant(): Instant = Instant.ofEpochMilli(getTime())
@@ -140,37 +284,57 @@ class Date(private var millis: Long)
     /* Use the format "yyyy mon d hh:mm:ss", which appears to be what the JVM
      * uses for the timezone Etc/GMT and the ROOT locale.
      */
-    val date = asDate()
-    "" + date.getUTCFullYear().toInt + " " + Months(date.getUTCMonth().toInt) + " " +
-      date.getDate().toInt + " " + pad0(date.getUTCHours().toInt) + ":" +
-      pad0(date.getUTCMinutes().toInt) + ":" + pad0(date.getUTCSeconds().toInt)
+    val d = decode()
+    s"${d.eraYear} ${Months(d.month)} ${d.day} ${d.formattedTimeInDay}"
   }
 
   override def toString(): String = {
     // Specified format: "dow mon dd hh:mm:ss zzz yyyy". zzz is always "GMT".
-    if (isSafeJSDate()) {
-      val date = asDate()
-      Days(date.getUTCDay().toInt) + " " + Months(date.getUTCMonth().toInt) + " " +
-        pad0(date.getUTCDate().toInt) + " " + pad0(date.getUTCHours().toInt) + ":" +
-        pad0(date.getUTCMinutes().toInt) + ":" + pad0(date.getUTCSeconds().toInt) +
-        " GMT " + date.getUTCFullYear().toInt
-    } else {
-      s"java.util.Date($millis)"
-    }
+    val d = decode()
+    s"${Days(d.dayOfWeek)} ${Months(d.month)} ${pad0(d.day)} ${d.formattedTimeInDay} GMT ${d.eraYear}"
   }
-
-  @inline
-  private def isSafeJSDate(): Boolean =
-    -MaxMillis <= millis && millis <= MaxMillis
 }
 
 object Date {
-  /* Maximum amount of milliseconds supported in a js.Date.
-   * See https://www.ecma-international.org/ecma-262/5.1/#sec-15.9.1.14
-   */
-  private final val MaxMillis = 8640000000000000L
-
+  private final val MSPerSecond = 1000
   private final val MSPerMinute = 60000
+  private final val MSPerHour = 3600000
+  private final val MSPerDay = 86400000
+
+  /** The number of days "since" the epoch to the first day using the Gregorian calendar.
+   *
+   *  That is Friday, 15 October 1582 in the Gregorian calendar. It would have
+   *  corresponded to Friday, 5 October 1582 in the Julian calendar.
+   *
+   *  It is before the epoch, so it is negative.
+   */
+  private final val FirstGregorianDaySinceEpoch = -141427L
+
+  /** The number of days in a 400-year cycle in the Gregorian calendar.
+   *
+   *  This can be computed from `365*400+97`, where `97` is the number of leap
+   *  years in the cycle (`400/4 - 3`).
+   */
+  private final val DaysInGregorian400Years = 146097
+
+  /** The number of days in a 4-year cycle in the Julian calendar.
+   *
+   *  This can be computed from `365*4+1`.
+   */
+  private final val DaysInJulian4Years = 1461
+
+  /** The number of days between Gregorian 1st Jan of year 0 (1 BC) and the Epoch.
+   *
+   *  Note that this particular date is a reference point for calculations, but
+   *  it does not exist, since at that time the active calendar is Julian.
+   */
+  private final val DaysFromGregorianYear0ToEpoch = 719528
+
+  /** The number of days between Julian 1st Jan of year 0 (1 BC) and the Epoch. */
+  private final val DaysFromJulianYear0ToEpoch = 719530
+
+  private val CumulativeDaysInMonthsNonLeap: Array[Int] =
+    Array(31, 59, 90, 120, 151, 181, 212, 243, 273, 304, 334, 365)
 
   /** Marker for end-of-string in parsing; distinct from every `Char`. */
   private final val EOF = -1
@@ -200,7 +364,104 @@ object Date {
    *  lifetime of the application.
    */
   private lazy val currentYear: Int =
-    new js.Date().getFullYear().toInt
+    new Date().getYear() + 1900
+
+  @inline
+  private def floorDivMod(x: Long, y: Int): (Long, Int) = {
+    val div = Math.floorDiv(x, y)
+    (div, x.toInt - div.toInt * y)
+  }
+
+  @inline
+  private def floorDivMod(x: Int, y: Int): (Int, Int) = {
+    val div = Math.floorDiv(x, y)
+    (div, x - div * y)
+  }
+
+  @inline
+  private def unsignedDivMod(x: Int, y: Int): (Int, Int) = {
+    val div = Integer.divideUnsigned(x, y)
+    (div, x - div * y)
+  }
+
+  @inline
+  private final class Decoded(
+      val year: Int,
+      val month: Int,
+      val day: Int,
+      val hour: Int,
+      val minute: Int,
+      val second: Int,
+      val dayOfWeek: Int
+  ) {
+    import Decoded._
+
+    @inline
+    def toRestBits: Int = {
+      (dayOfWeek << DayOfWeekShift) |
+      (month << MonthShift) |
+      (day << DayShift) |
+      (hour << HourShift) |
+      (minute << MinuteShift) |
+      (second << SecondShift)
+    }
+
+    /** The year as presented in the API (1900-based). */
+    @inline
+    def apiYear: Int = year - 1900
+
+    /** The year in the AD/BC era, as presented in strings. */
+    @inline
+    def eraYear: Int =
+      if (year > 0) year
+      else -year + 1 // 0 is 1 BC, -1 is 2 BC, etc.
+
+    /** The time in day formatted as `hh:mm:ss`, shared by the 3 string methods. */
+    @inline
+    def formattedTimeInDay: String =
+      s"${pad0(hour)}:${pad0(minute)}:${pad0(second)}"
+  }
+
+  private object Decoded {
+    // Total bits used: 29
+    private final val SecondBits = 6 // [0, 59] (we don't track leap seconds)
+    private final val MinuteBits = 6 // [0, 59]
+    private final val HourBits = 5 // [0, 23]
+    private final val DayBits = 5 // [1, 31]
+    private final val MonthBits = 4 // [0, 11]
+    private final val DayOfWeekBits = 3 // [0, 6]
+
+    private final val SecondShift = 0
+    private final val SecondMask = (1 << SecondBits) - 1
+
+    private final val MinuteShift = SecondShift + SecondBits
+    private final val MinuteMask = (1 << MinuteBits) - 1
+
+    private final val HourShift = MinuteShift + MinuteBits
+    private final val HourMask = (1 << HourBits) - 1
+
+    private final val DayShift = HourShift + HourBits
+    private final val DayMask = (1 << DayBits) - 1
+
+    private final val MonthShift = DayShift + DayBits
+    private final val MonthMask = (1 << MonthBits) - 1
+
+    private final val DayOfWeekShift = MonthShift + MonthBits
+    private final val DayOfWeekMask = (1 << DayOfWeekBits) - 1
+
+    @inline
+    def fromBits(year: Int, bits: Int): Decoded = {
+      new Decoded(
+        year,
+        (bits >>> MonthShift) & MonthMask,
+        (bits >>> DayShift) & DayMask,
+        (bits >>> HourShift) & HourMask,
+        (bits >>> MinuteShift) & MinuteMask,
+        (bits >>> SecondShift) & SecondMask,
+        (bits >>> DayOfWeekShift) & DayOfWeekMask
+      )
+    }
+  }
 
   private def pad0(i: Int): String = {
     val str = "" + i
@@ -216,10 +477,80 @@ object Date {
     }
   }
 
+  /** The number of days from the start of a 400-year-cycle to the given year-in-cycle. */
+  private def daysToYearInGregorianCycle(yearInCycle: Int): Int = {
+    val divBy4ToSkip = Integer.divideUnsigned(yearInCycle + 3, 4)
+    val divBy100ToSkip = Integer.divideUnsigned(yearInCycle + 99, 100)
+    val divBy400ToSkip = if (yearInCycle == 0) 0 else 1
+    val leapYearsToSkip = divBy4ToSkip - divBy100ToSkip + divBy400ToSkip
+    365 * yearInCycle + leapYearsToSkip
+  }
+
+  @inline
+  private def isGregorianLeapYearInCycle(yearMod400: Int): Boolean =
+    (yearMod400 & 3) == 0 && yearMod400 != 100 && yearMod400 != 200 && yearMod400 != 300
+
   @Deprecated
   def UTC(year: Int, month: Int, date: Int,
       hrs: Int, min: Int, sec: Int): Long = {
-    safeGetTime(js.Date.UTC(year + 1900, month, date, hrs, min, sec))
+    encode(year + 1900, month, date, hrs, min, sec, 0)
+  }
+
+  private def encode(year: Int, month: Int, day: Int,
+      hour: Int, minute: Int, second: Int, millisecond: Int): Long = {
+    val timeInDay = encodeTimeInDay(hour, minute, second, millisecond)
+    encode(year, month, day, timeInDay)
+  }
+
+  private def encode(year: Int, month: Int, day: Int, timeInDay: Long): Long = {
+    val daysSinceEpoch = encodeDaysSinceEpoch(year, month, day)
+    daysSinceEpoch * MSPerDay + timeInDay
+  }
+
+  @inline
+  private def encodeTimeInDay(hour: Int, min: Int, sec: Int, ms: Int): Long =
+    hour.toLong * MSPerHour + min.toLong * MSPerMinute + sec.toLong * MSPerSecond + ms.toLong
+
+  private def encodeDaysSinceEpoch(year: Int, month: Int, day: Int): Long = {
+    // First transfer any excess months to the year
+    val (additionalYearsFromMonth, actualMonth) = floorDivMod(month, 12)
+    val actualYear = year + additionalYearsFromMonth
+
+    // Determine in which calendar we are; Gregorian starts on Oct 15, 1582
+    val isGregorian = {
+      actualYear > 1582 ||
+      (actualYear == 1582 && (actualMonth > 9 || (actualMonth == 9 && day >= 15)))
+    }
+
+    // Compute the number of days until the start of the year
+    val (daysToYear, isLeapYear) = if (isGregorian) {
+      val (cycle, yearInCycle) = floorDivMod(actualYear, 400)
+      val daysToYearInCycle = daysToYearInGregorianCycle(yearInCycle)
+      val daysToYear = cycle * DaysInGregorian400Years + daysToYearInCycle
+      val isLeapYear = isGregorianLeapYearInCycle(yearInCycle)
+      (daysToYear, isLeapYear)
+    } else {
+      val (cycle, yearInCycle) = floorDivMod(actualYear, 4)
+      val isLeapYear = yearInCycle == 0
+      val daysToYearInCycle = if (isLeapYear) 0 else 1 + 365 * yearInCycle
+      val daysToYear = cycle * DaysInJulian4Years + daysToYearInCycle
+      (daysToYear, isLeapYear)
+    }
+
+    // Compute the number of days in the year until the start of the month
+    val daysInYearToMonth1st = actualMonth match {
+      case 0 => 0
+      case 1 => 31
+      case _ => CumulativeDaysInMonthsNonLeap(actualMonth - 1) + (if (isLeapYear) 1 else 0)
+    }
+
+    // Add up all the days since the epoch
+    val daysSinceYear0 =
+      daysToYear.toLong + Integer.toUnsignedLong(daysInYearToMonth1st) + (day - 1).toLong
+    if (isGregorian)
+      daysSinceYear0 - DaysFromGregorianYear0ToEpoch
+    else
+      daysSinceYear0 - DaysFromJulianYear0ToEpoch
   }
 
   @Deprecated
@@ -440,18 +771,7 @@ object Date {
      *
      * Since the local time zone is always GMT=UTC, we have a unique code path.
      */
-    val utc = UTC(year - 1900, month, dayOfMonth, hour, minute, second)
+    val utc = encode(year, month, dayOfMonth, hour, minute, second, 0)
     utc - (timezoneOffset * MSPerMinute).toLong
-  }
-
-  @inline
-  private def safeGetTime(date: js.Date): Long =
-    safeGetTime(date.getTime())
-
-  @inline
-  private def safeGetTime(time: Double): Long = {
-    if (java.lang.Double.isNaN(time))
-      throw new IllegalArgumentException
-    time.toLong
   }
 }

--- a/javalib/src/main/scala/java/util/Date.scala
+++ b/javalib/src/main/scala/java/util/Date.scala
@@ -12,6 +12,8 @@
 
 package java.util
 
+import scala.annotation.switch
+
 import java.lang.Cloneable
 import java.time.Instant
 import java.util.function._
@@ -163,12 +165,37 @@ object Date {
    */
   private final val MaxMillis = 8640000000000000L
 
+  private final val MSPerMinute = 60000
+
+  /** Marker for end-of-string in parsing; distinct from every `Char`. */
+  private final val EOF = -1
+
   private val Days = Array(
       "Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat")
 
   private val Months = Array(
       "Jan", "Feb", "Mar", "Apr", "May", "Jun",
       "Jul", "Aug", "Sep", "Oct", "Nov", "Dec")
+
+  /** All the "words" for which `parse` tries a prefix, in order of precedence. */
+  private val ParsePrefixWords: Array[String] = Array(
+      "SUNDAY", "MONDAY", "TUESDAY", "WEDNESDAY", "THURSDAY", "FRIDAY", "SATURDAY",
+      "JANUARY", "FEBRUARY", "MARCH", "APRIL", "MAY", "JUNE",
+      "JULY", "AUGUST", "SEPTEMBER", "OCTOBER", "NOVEMBER", "DECEMBER"
+  )
+
+  /** The current year, used to interpret small years in `parse`.
+   *
+   *  It is explicitly stored, rather than recomputed, because the JavaDoc
+   *  says the computation is relative to
+   *  > the time when the Date class is initialized
+   *
+   *  We don't follow the exact initialization time, but at least this way we
+   *  preserve the fact that only one `currentYear` is observed through the
+   *  lifetime of the application.
+   */
+  private lazy val currentYear: Int =
+    new js.Date().getFullYear().toInt
 
   private def pad0(i: Int): String = {
     val str = "" + i
@@ -191,8 +218,230 @@ object Date {
   }
 
   @Deprecated
-  def parse(string: String): Long = safeGetTime(new js.Date(string))
+  def parse(string: String): Long = {
+    /* Parse the string according to
+     * https://docs.oracle.com/en/java/javase/25/docs/api/java.base/java/util/Date.html#parse(java.lang.String)
+     * Comments starting with '>' are quoted from the JavaDoc.
+     */
 
+    /* We can use -1 as absent value for these fields because they cannot
+     * be parsed as negative values.
+     */
+    var year = -1
+    var month = -1
+    var dayOfMonth = -1
+    var hour = -1
+    var minute = -1
+    var second = -1
+
+    /* The timezone offset (in minutes) can be negative, but is parsed from a
+     * positive int and therefore cannot be Int.MinValue.
+     */
+    var timezoneOffset = Int.MinValue
+
+    @inline def isASCIIDigit(c: Char): Boolean =
+      c >= '0' && c <= '9'
+
+    @inline def isASCIILetter(c: Char): Boolean =
+      (c >= 'A' && c <= 'Z') || (c >= 'a' && c <= 'z')
+
+    def fail(): Nothing =
+      throw new IllegalArgumentException(string)
+
+    val len = string.length()
+    var i = 0
+    while (i != len) {
+      val start = i
+      val c = string.charAt(start)
+      i += 1
+
+      if (isASCIIDigit(c)) {
+        // Parse the whole number
+        while (i != len && isASCIIDigit(string.charAt(i))) {
+          i += 1
+        }
+        val number = Integer.parseInt(string.substring(start, i))
+
+        // Look behind and ahead
+        val prev = if (start == 0) EOF else string.charAt(start - 1).toInt
+        val next = if (i == len) EOF else string.charAt(i).toInt
+
+        // > The number is regarded as a year number if one of the following conditions is true:
+        @inline def isYear: Boolean = {
+          (year == -1) && { // out of spec, but otherwise nothing works
+            if (number >= 70) {
+              /* > The number is equal to or greater than 70 and followed by a
+               * > space, comma, slash, or end of string.
+               */
+              next == ' ' || next == ',' || next == '/' || next == EOF
+            } else {
+              /* > The number is less than 70, and both a month and a day of the
+               * > month have already been recognized.
+               */
+              month != -1 && dayOfMonth != -1
+            }
+          }
+        }
+
+        // Decide what to do with the number
+        if ((prev == '+' || prev == '-') && year != -1) {
+          /* > If a number is preceded by + or - and a year has already been
+           * > recognized, then the number is a time-zone offset.
+           */
+          if (timezoneOffset != Int.MinValue && timezoneOffset != 0)
+            fail() // out of spec
+          val signedNumber = if (prev == '-') -number else number
+          if (number < 24) {
+            timezoneOffset = 60 * signedNumber
+          } else {
+            // convert HHmm (= 100*HH + mm) to 60*HH + mm
+            val tzHours = signedNumber / 100 // for once, actually use truncating signed division
+            val tzMinutes = signedNumber - 100 * tzHours
+            timezoneOffset = (60 * tzHours) + tzMinutes
+          }
+        } else if (isYear) {
+          /* > If the recognized year number is less than 100, it is interpreted as an
+           * > abbreviated year relative to a century of which dates are within 80 years
+           * > before and 19 years after the time when the Date class is initialized.
+           */
+          year = if (number >= 100) {
+            number
+          } else {
+            val relCenturyStart = currentYear - 80
+            val absCenturyStart = relCenturyStart - Integer.remainderUnsigned(relCenturyStart, 100)
+            val candidate = absCenturyStart + number
+            if (candidate >= relCenturyStart)
+              candidate
+            else
+              candidate + 100
+          }
+        } else {
+          (next: @switch) match {
+            case ':' =>
+              /* > If the number is followed by a colon, it is regarded as an hour,
+               * > unless an hour has already been recognized, in which case it is
+               * > regarded as a minute.
+               */
+              if (hour == -1)
+                hour = number
+              else
+                minute = number
+
+            case '/' =>
+              /* > If the number is followed by a slash, it is regarded as a month
+               * > (it is decreased by 1 to produce a number in the range 0 to 11),
+               * > unless a month has already been recognized, in which case it is
+               * > regarded as a day of the month.
+               */
+              if (month == -1)
+                month = number - 1
+              else
+                dayOfMonth = number
+
+            case '\t' | '\n' | '\f' | '\r' | ' ' | ',' | '-' | EOF =>
+              /* > If the number is followed by whitespace, a comma, a hyphen, or
+               * > end of string, then if an hour has been recognized but not a
+               * > minute, it is regarded as a minute; otherwise, if a minute has
+               * > been recognized but not a second, it is regarded as a second;
+               * > otherwise, it is regarded as a day of the month.
+               */
+              if (hour != -1 && minute == -1)
+                minute = number
+              else if (minute != -1 && second == -1)
+                second = number
+              else
+                dayOfMonth = number
+
+            case _ =>
+              // Otherwise fail (not clearly specified)
+              fail()
+          }
+        }
+      } else if (isASCIILetter(c)) {
+        // Parse the whole ASCII word
+        while (i != len && isASCIILetter(string.charAt(i))) {
+          i += 1
+        }
+        if (i == start + 1)
+          fail() // out of spec, but apparently the JVM wants at least 2 letters here
+        val word = string.substring(start, i).toUpperCase()
+
+        // Decide what to do with it
+
+        val prefixWords = ParsePrefixWords // local copy
+        val prefixWordsLen = prefixWords.length
+        var prefixIndex = 0
+        while (prefixIndex != prefixWordsLen && !prefixWords(prefixIndex).startsWith(word)) {
+          prefixIndex += 1
+        }
+
+        if (prefixIndex < 7) {
+          // day of week, ignore
+        } else if (prefixIndex < prefixWordsLen) {
+          // named month
+          month = prefixIndex - 7
+        } else {
+          // one of the explicitly known timezones, otherwise fail
+          timezoneOffset = word match {
+            case "GMT" | "UT" | "UTC" => 0
+            case "EDT"                => -4 * 60
+            case "EST" | "CDT"        => -5 * 60
+            case "CST" | "MDT"        => -6 * 60
+            case "MST" | "PDT"        => -7 * 60
+            case "PST"                => -8 * 60
+            case _                    => fail()
+          }
+        }
+      } else {
+        (c: @switch) match {
+          case '\t' | '\n' | '\f' | '\r' | ' ' | ',' | '+' | '-' | ':' | '/' =>
+            // ignore
+            ()
+          case '(' =>
+            // Ignore all characters until a matching ')'
+            var nesting = 1
+            while (i != len && nesting > 0) {
+              string.charAt(i) match {
+                case '(' => nesting += 1
+                case ')' => nesting -= 1
+                case _   => ()
+              }
+              i += 1
+            }
+          case _ =>
+            fail()
+        }
+      }
+    }
+
+    // We need all the components of a date, otherwise fail
+    if (year == -1 || month == -1 || dayOfMonth == -1)
+      fail()
+
+    // However, time components are optional and default to 0
+    if (hour == -1)
+      hour = 0
+    if (minute == -1)
+      minute = 0
+    if (second == -1)
+      second = 0
+
+    if (timezoneOffset != Int.MinValue) {
+      /* > If a time zone or time-zone offset has been recognized, then the year,
+       * > month, day of month, hour, minute, and second are interpreted in UTC
+       * > and then the time-zone offset is applied.
+       */
+      val utc = UTC(year - 1900, month, dayOfMonth, hour, minute, second)
+      utc - (timezoneOffset * MSPerMinute).toLong
+    } else {
+      /* > Otherwise, the year, month, day of month, hour, minute, and second
+       * > are interpreted in the local time zone.
+       */
+      safeGetTime(new js.Date(year, month, dayOfMonth, hour, minute, second, 0))
+    }
+  }
+
+  @inline
   private def safeGetTime(date: js.Date): Long = {
     val time = date.getTime()
     if (java.lang.Double.isNaN(time))

--- a/javalib/src/main/scala/java/util/Date.scala
+++ b/javalib/src/main/scala/java/util/Date.scala
@@ -16,15 +16,12 @@ import scala.annotation.switch
 
 import java.lang.Cloneable
 import java.time.Instant
-import java.util.function._
-
-import scalajs.js
 
 /* Note that the default timezone is always Etc/GMT (= UTC, without any
  * daylight saving time).
  */
 
-class Date(private var millis: Long)
+class Date(private var time: Long)
     extends Object with Serializable with Cloneable with Comparable[Date] {
 
   import Date._
@@ -46,131 +43,312 @@ class Date(private var millis: Long)
   @Deprecated
   def this(date: String) = this(Date.parse(date))
 
-  def after(when: Date): Boolean = millis > when.millis
+  /** The cached decoded year.
+   *
+   *  Valid iff `cachedRest` is valid.
+   */
+  private var cachedYear: Int = 0
 
-  def before(when: Date): Boolean = millis < when.millis
+  /** Cached data for every else.
+   *
+   *  Bit field with dayOfWeek, month, day, hour, minute, second.
+   *
+   *  Valid iff `cachedRest != 0` (because `day` is 1-based).
+   */
+  private var cachedRest: Int = 0
 
-  override def clone(): Object = new Date(millis)
+  // API that only uses the timestamp (no decoding/encoding)
+
+  def getTime(): Long = time
+
+  def setTime(time: Long): Unit = {
+    cachedRest = 0 // invalidate cache
+    this.time = time
+  }
+
+  def after(when: Date): Boolean = time > when.time
+
+  def before(when: Date): Boolean = time < when.time
+
+  override def clone(): Object = new Date(time)
 
   override def compareTo(anotherDate: Date): Int =
-    java.lang.Long.compare(millis, anotherDate.millis)
+    java.lang.Long.compare(time, anotherDate.time)
 
   override def equals(obj: Any): Boolean = obj match {
-    case d: Date => d.millis == millis
+    case d: Date => d.time == time
     case _       => false
   }
 
-  override def hashCode(): Int = millis.hashCode()
+  override def hashCode(): Int =
+    java.lang.Long.hashCode(time)
 
-  private def asDate(): js.Date = {
-    if (!isSafeJSDate()) {
-      throw new IllegalArgumentException(
-          s"cannot convert this java.util.Date ($millis millis) to a js.Date")
-    }
-    new js.Date(millis.toDouble)
-  }
+  // API that requires decoding and encoding into calendar fields
 
   @inline
-  private def mutDate(mutator: Consumer[js.Date]): Unit = {
-    val date = asDate()
-    mutator.accept(date)
-    millis = safeGetTime(date)
+  private def decode(): Decoded = {
+    if (cachedRest == 0)
+      doDecodeAndCache()
+    Decoded.fromBits(cachedYear, cachedRest)
   }
 
-  @Deprecated
-  def getDate(): Int = asDate().getUTCDate().toInt
+  @noinline
+  private def doDecodeAndCache(): Unit = {
+    // Decompose into day and time-in-day
+    val (daysSinceEpoch, millisInDay) = floorDivMod(this.time, MSPerDay)
 
-  @Deprecated
-  def getDay(): Int = asDate().getUTCDay().toInt
+    // Decompose time-in-day into hour, minute, second (ignore millis)
+    val (hour, millisInHour) = unsignedDivMod(millisInDay, MSPerHour)
+    val (minute, millisInMinute) = unsignedDivMod(millisInHour, MSPerMinute)
+    val second = Integer.divideUnsigned(millisInMinute, MSPerSecond)
 
-  @Deprecated
-  def getHours(): Int = asDate().getUTCHours().toInt
+    // Find the year and day-in-year
+    val isGregorian = daysSinceEpoch >= FirstGregorianDaySinceEpoch
+    val (year, dayInYear, isLeapYear) =
+      if (isGregorian) decodeGregorianYearAndDayInYear(daysSinceEpoch)
+      else decodeJulianYearAndDayInYear(daysSinceEpoch)
 
-  @Deprecated
-  def getMinutes(): Int = asDate().getUTCMinutes().toInt
+    // Compute the month-in-year and day-in-month
+    val (month, day) = if (dayInYear < 31) {
+      (0, dayInYear)
+    } else if (dayInYear < 31 + 28 + isLeapYear) {
+      (1, dayInYear - 31)
+    } else {
+      val dayInYearAsIfNonLeap = dayInYear - isLeapYear
+      val cumulDaysInMonths = CumulativeDaysInMonthsNonLeap // local copy
+      var m = 2
+      while (dayInYearAsIfNonLeap >= cumulDaysInMonths(m))
+        m += 1
+      (m, dayInYearAsIfNonLeap - cumulDaysInMonths(m - 1))
+    }
 
-  @Deprecated
-  def getMonth(): Int = asDate().getUTCMonth().toInt
+    /* The Julian/Gregorian transition did not interrupt the day-of-week cycle.
+     * Therefore, we directly compute it from `daysSinceEpoch`.
+     * The epoch was a Wednesday, so we add 4 and take the remainder by 7.
+     *
+     * We add an additional offset of 106751991171L, which is a multiple of 7
+     * and such that `daysSinceEpoch + offset` is positive and does not overflow.
+     * This way, we can use an unsigned remainder rather than floorMod.
+     */
+    val dayOfWeek =
+      java.lang.Long.remainderUnsigned(daysSinceEpoch + (4L + 106751991171L), 7L).toInt
 
-  @Deprecated
-  def getSeconds(): Int = asDate().getUTCSeconds().toInt
+    val decoded = new Decoded(year, month, day + 1, hour, minute, second, dayOfWeek)
+    this.cachedYear = decoded.year
+    this.cachedRest = decoded.toRestBits
+  }
 
-  def getTime(): Long = millis
+  /** Decodes the year and day-in-year of a day that falls in the Gregorian calendar.
+   *
+   *  @return
+   *    `(year, dayInYear, isLeapYear)` where `isLeapYear` is 1 if yes and 0 otherwise.
+   */
+  @inline // exactly 1 call site
+  private def decodeGregorianYearAndDayInYear(daysSinceEpoch: Long): (Int, Int, Int) = {
+    /* Decompose the day into a 400-year-cycle and days-in-cycle.
+     * We can use an unsigned division because daysSinceYear0 is positive.
+     */
+    val daysSinceYear0 = DaysFromGregorianYear0ToEpoch + daysSinceEpoch
+    val (cycleLong, daysIn400YearCycle) = unsignedDivMod(daysSinceYear0, DaysInGregorian400Years)
+    val cycle = cycleLong.toInt // we have divided enough now that we must fit in an int
+
+    /* Compute the year in the cycle and the day in the year.
+     *
+     * estimatedYearInCycle is either the correct year, or 1 too low.
+     *
+     * This assumption can be checked with
+     *   for (d <- 0 until 146097) { // days in the 400 cycle
+     *     val estimatedYear = 1600 + d/366 // start at 1600 for the Gregorian calendar
+     *     val correctYear = new Date(1600 - 1900, 0, 1 + d).getYear() + 1900
+     *     assert(estimatedYear == correctYear || estimatedYear == correctYear-1)
+     *   }
+     */
+    val (yearInCycle, dayInYear, isLeapYear) = {
+      val estimatedYearInCycle = Integer.divideUnsigned(daysIn400YearCycle, 366)
+      val estimatedDayInYear = daysIn400YearCycle - daysToYearInGregorianCycle(estimatedYearInCycle)
+      val estimatedIsLeap = if (isGregorianLeapYearInCycle(estimatedYearInCycle)) 1 else 0
+      val estimatedNumDays = 365 + estimatedIsLeap
+      if (estimatedDayInYear < estimatedNumDays) {
+        // The estimated day falls into the estimated year, so the estimation is correct
+        (estimatedYearInCycle, estimatedDayInYear, estimatedIsLeap)
+      } else {
+        // Adjust the estimation
+        val correctedYear = estimatedYearInCycle + 1
+        val correctedDayInYear = estimatedDayInYear - estimatedNumDays
+        val correctedYearIsLeap = if (isGregorianLeapYearInCycle(correctedYear)) 1 else 0
+        (correctedYear, correctedDayInYear, correctedYearIsLeap)
+      }
+    }
+    val year = cycle * 400 + yearInCycle
+
+    (year, dayInYear, isLeapYear)
+  }
+
+  /** Decodes the year and day-in-year of a day that falls in the Julian calendar.
+   *
+   *  @return
+   *    `(year, dayInYear, isLeapYear)` where `isLeapYear` is 1 if yes and 0 otherwise.
+   */
+  @inline // exactly 1 call site
+  private def decodeJulianYearAndDayInYear(daysSinceEpoch: Long): (Int, Int, Int) = {
+    // Decompose the day into a 4-year-cycle and days-in-cycle
+    val daysSinceYear0 = DaysFromJulianYear0ToEpoch + daysSinceEpoch
+    val (cycleLong, daysIn4YearCycle) = floorDivMod(daysSinceYear0, DaysInJulian4Years)
+    val cycle = cycleLong.toInt // we have divided enough now that we must fit in an int
+
+    val cycleYears = cycle * 4
+
+    if (daysIn4YearCycle < 366) {
+      // First year, which is the leap year
+      (cycleYears + 0, daysIn4YearCycle, 1)
+    } else {
+      // One of the other 3 years, which are not leap years
+      val (yearInCycle, dayInYear) = unsignedDivMod(daysIn4YearCycle - 1, 365)
+      (cycleYears + yearInCycle, dayInYear, 0)
+    }
+  }
+
+  @Deprecated @noinline
+  def getYear(): Int = {
+    /* By spec, the result is 1900-based. What's not in the spec is that is
+     * computed from the eraYear. That of course makes no sense once we go to
+     * the BC era, but that's what it is.
+     */
+    decode().eraYear - 1900
+  }
+
+  @Deprecated @noinline
+  def getMonth(): Int = decode().month
+
+  @Deprecated @noinline
+  def getDate(): Int = decode().day
+
+  @Deprecated @noinline
+  def getDay(): Int = decode().dayOfWeek
+
+  @Deprecated @noinline
+  def getHours(): Int = decode().hour
+
+  @Deprecated @noinline
+  def getMinutes(): Int = decode().minute
+
+  @Deprecated @noinline
+  def getSeconds(): Int = decode().second
 
   @Deprecated
   def getTimezoneOffset(): Int = 0
 
-  @Deprecated
-  def getYear(): Int = asDate().getUTCFullYear().toInt - 1900
+  /** Resets the year and month.
+   *
+   *  This requires a full re-encoding.
+   */
+  @inline
+  private def setYearMonth(d: Decoded, newYear: Int, newMonth: Int): Unit = {
+    val timeInDay = Math.floorMod(time, MSPerDay.toLong)
+    setTime(encode(newYear, newMonth, d.day, timeInDay))
+  }
 
-  @Deprecated
-  def setDate(date: Int): Unit = mutDate(_.setUTCDate(date))
+  /** Sets a field whose difference translates directly into a number of milliseconds.
+   *
+   *  This is the case for every field except `year` and  `month`.
+   */
+  private def setCalendarIndependentField(prevValue: Int, newValue: Int, msPerField: Long): Unit =
+    setTime(time + (newValue.toLong - prevValue.toLong) * msPerField)
 
-  @Deprecated
-  def setHours(hours: Int): Unit = mutDate(_.setUTCHours(hours))
+  @Deprecated @noinline
+  def setYear(year: Int): Unit = {
+    val d = decode()
+    setYearMonth(d, year + 1900, d.month)
+  }
 
-  @Deprecated
-  def setMinutes(minutes: Int): Unit = mutDate(_.setUTCMinutes(minutes))
+  @Deprecated @noinline
+  def setMonth(month: Int): Unit = {
+    val d = decode()
+    setYearMonth(d, d.year, month)
+  }
 
-  @Deprecated
-  def setMonth(month: Int): Unit = mutDate(_.setUTCMonth(month))
+  @Deprecated @noinline
+  def setDate(date: Int): Unit =
+    setCalendarIndependentField(decode().day, date, MSPerDay)
 
-  @Deprecated
-  def setSeconds(seconds: Int): Unit = mutDate(_.setUTCSeconds(seconds))
+  @Deprecated @noinline
+  def setHours(hours: Int): Unit =
+    setCalendarIndependentField(decode().hour, hours, MSPerHour)
 
-  def setTime(time: Long): Unit = millis = time
+  @Deprecated @noinline
+  def setMinutes(minutes: Int): Unit =
+    setCalendarIndependentField(decode().minute, minutes, MSPerMinute)
 
-  @Deprecated
-  def setYear(year: Int): Unit = mutDate(_.setUTCFullYear(1900 + year))
+  @Deprecated @noinline
+  def setSeconds(seconds: Int): Unit =
+    setCalendarIndependentField(decode().second, seconds, MSPerSecond)
 
-  @Deprecated
+  @Deprecated @noinline
   def toGMTString(): String = {
     // Specified format: "d mon yyyy hh:mm:ss GMT".
-    val date = asDate()
-    "" + date.getUTCDate().toInt + " " + Months(date.getUTCMonth().toInt) + " " +
-      date.getUTCFullYear().toInt + " " + pad0(date.getUTCHours().toInt) + ":" +
-      pad0(date.getUTCMinutes().toInt) + ":" +
-      pad0(date.getUTCSeconds().toInt) + " GMT"
+    val d = decode()
+    s"${d.day} ${Months(d.month)} ${d.eraYear} ${d.formattedTimeInDay} GMT"
   }
 
   def toInstant(): Instant = Instant.ofEpochMilli(getTime())
 
-  @Deprecated
+  @Deprecated @noinline
   def toLocaleString(): String = {
     /* Use the format "yyyy mon d hh:mm:ss", which appears to be what the JVM
      * uses for the timezone Etc/GMT and the ROOT locale.
      */
-    val date = asDate()
-    "" + date.getUTCFullYear().toInt + " " + Months(date.getUTCMonth().toInt) + " " +
-      date.getDate().toInt + " " + pad0(date.getUTCHours().toInt) + ":" +
-      pad0(date.getUTCMinutes().toInt) + ":" + pad0(date.getUTCSeconds().toInt)
+    val d = decode()
+    s"${d.eraYear} ${Months(d.month)} ${d.day} ${d.formattedTimeInDay}"
   }
 
+  @noinline
   override def toString(): String = {
     // Specified format: "dow mon dd hh:mm:ss zzz yyyy". zzz is always "GMT".
-    if (isSafeJSDate()) {
-      val date = asDate()
-      Days(date.getUTCDay().toInt) + " " + Months(date.getUTCMonth().toInt) + " " +
-        pad0(date.getUTCDate().toInt) + " " + pad0(date.getUTCHours().toInt) + ":" +
-        pad0(date.getUTCMinutes().toInt) + ":" + pad0(date.getUTCSeconds().toInt) +
-        " GMT " + date.getUTCFullYear().toInt
-    } else {
-      s"java.util.Date($millis)"
-    }
+    val d = decode()
+    s"${Days(d.dayOfWeek)} ${Months(d.month)} ${pad0(d.day)} ${d.formattedTimeInDay} GMT ${d.eraYear}"
   }
-
-  @inline
-  private def isSafeJSDate(): Boolean =
-    -MaxMillis <= millis && millis <= MaxMillis
 }
 
 object Date {
-  /* Maximum amount of milliseconds supported in a js.Date.
-   * See https://www.ecma-international.org/ecma-262/5.1/#sec-15.9.1.14
-   */
-  private final val MaxMillis = 8640000000000000L
-
+  private final val MSPerSecond = 1000
   private final val MSPerMinute = 60000
+  private final val MSPerHour = 3600000
+  private final val MSPerDay = 86400000
+
+  /** The number of days "since" the epoch to the first day using the Gregorian calendar.
+   *
+   *  That is Friday, 15 October 1582 in the Gregorian calendar. It would have
+   *  corresponded to Friday, 5 October 1582 in the Julian calendar.
+   *
+   *  It is before the epoch, so it is negative.
+   */
+  private final val FirstGregorianDaySinceEpoch = -141427L
+
+  /** The number of days in a 400-year cycle in the Gregorian calendar.
+   *
+   *  This can be computed from `365*400+97`, where `97` is the number of leap
+   *  years in the cycle (`400/4 - 3`).
+   */
+  private final val DaysInGregorian400Years = 146097
+
+  /** The number of days in a 4-year cycle in the Julian calendar.
+   *
+   *  This can be computed from `365*4+1`.
+   */
+  private final val DaysInJulian4Years = 1461
+
+  /** The number of days between Gregorian 1st Jan of year 0 (1 BC) and the Epoch.
+   *
+   *  Note that this particular date is a reference point for calculations, but
+   *  it does not exist, since at that time the active calendar is Julian.
+   */
+  private final val DaysFromGregorianYear0ToEpoch = 719528
+
+  /** The number of days between Julian 1st Jan of year 0 (1 BC) and the Epoch. */
+  private final val DaysFromJulianYear0ToEpoch = 719530
+
+  private val CumulativeDaysInMonthsNonLeap: Array[Int] =
+    Array(31, 59, 90, 120, 151, 181, 212, 243, 273, 304, 334, 365)
 
   /** Marker for end-of-string in parsing; distinct from every `Char`. */
   private final val EOF = -1
@@ -206,7 +384,7 @@ object Date {
    *  it if it's a `val`.
    */
   private lazy val currentYear: Int =
-    new js.Date().getFullYear().toInt
+    new Date().getYear() + 1900
 
   private def resolveYear(number: Int): Int = {
     /* > If the recognized year number is less than 100, it is interpreted as an
@@ -226,6 +404,105 @@ object Date {
     }
   }
 
+  @inline
+  private def floorDivMod(x: Long, y: Int): (Long, Int) = {
+    val div = Math.floorDiv(x, y)
+    (div, x.toInt - div.toInt * y)
+  }
+
+  @inline
+  private def floorDivMod(x: Int, y: Int): (Int, Int) = {
+    val div = Math.floorDiv(x, y)
+    (div, x - div * y)
+  }
+
+  @inline
+  private def unsignedDivMod(x: Long, y: Int): (Long, Int) = {
+    val div = java.lang.Long.divideUnsigned(x, Integer.toUnsignedLong(y))
+    (div, x.toInt - div.toInt * y)
+  }
+
+  @inline
+  private def unsignedDivMod(x: Int, y: Int): (Int, Int) = {
+    val div = Integer.divideUnsigned(x, y)
+    (div, x - div * y)
+  }
+
+  @inline
+  private final class Decoded(
+      val year: Int,
+      val month: Int,
+      val day: Int,
+      val hour: Int,
+      val minute: Int,
+      val second: Int,
+      val dayOfWeek: Int
+  ) {
+    import Decoded._
+
+    @inline
+    def toRestBits: Int = {
+      (dayOfWeek << DayOfWeekShift) |
+      (month << MonthShift) |
+      (day << DayShift) |
+      (hour << HourShift) |
+      (minute << MinuteShift) |
+      (second << SecondShift)
+    }
+
+    /** The year in the AD/BC era, as presented in strings. */
+    @inline
+    def eraYear: Int =
+      if (year > 0) year
+      else -year + 1 // 0 is 1 BC, -1 is 2 BC, etc.
+
+    /** The time in day formatted as `hh:mm:ss`, shared by the 3 string methods. */
+    @inline
+    def formattedTimeInDay: String =
+      s"${pad0(hour)}:${pad0(minute)}:${pad0(second)}"
+  }
+
+  private object Decoded {
+    // Total bits used: 29
+    private final val SecondBits = 6 // [0, 59] (we don't track leap seconds)
+    private final val MinuteBits = 6 // [0, 59]
+    private final val HourBits = 5 // [0, 23]
+    private final val DayBits = 5 // [1, 31]
+    private final val MonthBits = 4 // [0, 11]
+    private final val DayOfWeekBits = 3 // [0, 6]
+
+    private final val SecondShift = 0
+    private final val SecondMask = (1 << SecondBits) - 1
+
+    private final val MinuteShift = SecondShift + SecondBits
+    private final val MinuteMask = (1 << MinuteBits) - 1
+
+    private final val HourShift = MinuteShift + MinuteBits
+    private final val HourMask = (1 << HourBits) - 1
+
+    private final val DayShift = HourShift + HourBits
+    private final val DayMask = (1 << DayBits) - 1
+
+    private final val MonthShift = DayShift + DayBits
+    private final val MonthMask = (1 << MonthBits) - 1
+
+    private final val DayOfWeekShift = MonthShift + MonthBits
+    private final val DayOfWeekMask = (1 << DayOfWeekBits) - 1
+
+    @inline
+    def fromBits(year: Int, bits: Int): Decoded = {
+      new Decoded(
+        year,
+        (bits >>> MonthShift) & MonthMask,
+        (bits >>> DayShift) & DayMask,
+        (bits >>> HourShift) & HourMask,
+        (bits >>> MinuteShift) & MinuteMask,
+        (bits >>> SecondShift) & SecondMask,
+        (bits >>> DayOfWeekShift) & DayOfWeekMask
+      )
+    }
+  }
+
   private def pad0(i: Int): String = {
     val str = "" + i
     if (str.length < 2) "0" + str else str
@@ -240,10 +517,80 @@ object Date {
     }
   }
 
+  /** The number of days from the start of a 400-year-cycle to the given year-in-cycle. */
+  private def daysToYearInGregorianCycle(yearInCycle: Int): Int = {
+    val divBy4ToSkip = Integer.divideUnsigned(yearInCycle + 3, 4)
+    val divBy100ToSkip = Integer.divideUnsigned(yearInCycle + 99, 100)
+    val divBy400ToSkip = if (yearInCycle == 0) 0 else 1
+    val leapYearsToSkip = divBy4ToSkip - divBy100ToSkip + divBy400ToSkip
+    365 * yearInCycle + leapYearsToSkip
+  }
+
+  @inline
+  private def isGregorianLeapYearInCycle(yearMod400: Int): Boolean =
+    (yearMod400 & 3) == 0 && yearMod400 != 100 && yearMod400 != 200 && yearMod400 != 300
+
   @Deprecated
   def UTC(year: Int, month: Int, date: Int,
       hrs: Int, min: Int, sec: Int): Long = {
-    safeGetTime(js.Date.UTC(year + 1900, month, date, hrs, min, sec))
+    encode(year + 1900, month, date, hrs, min, sec)
+  }
+
+  private def encode(year: Int, month: Int, day: Int,
+      hour: Int, minute: Int, second: Int): Long = {
+    val timeInDay = encodeTimeInDay(hour, minute, second)
+    encode(year, month, day, timeInDay)
+  }
+
+  private def encode(year: Int, month: Int, day: Int, timeInDay: Long): Long = {
+    val daysSinceEpoch = encodeDaysSinceEpoch(year, month, day)
+    daysSinceEpoch * MSPerDay + timeInDay
+  }
+
+  @inline
+  private def encodeTimeInDay(hour: Int, min: Int, sec: Int): Long =
+    hour.toLong * MSPerHour + min.toLong * MSPerMinute + sec.toLong * MSPerSecond
+
+  private def encodeDaysSinceEpoch(year: Int, month: Int, day: Int): Long = {
+    // First transfer any excess months to the year
+    val (additionalYearsFromMonth, actualMonth) = floorDivMod(month, 12)
+    val actualYear = year + additionalYearsFromMonth
+
+    // Determine in which calendar we are; Gregorian starts on Oct 15, 1582
+    val isGregorian = {
+      actualYear > 1582 ||
+      (actualYear == 1582 && (actualMonth > 9 || (actualMonth == 9 && day >= 15)))
+    }
+
+    // Compute the number of days until the start of the year
+    val (daysToYear, isLeapYear) = if (isGregorian) {
+      val (cycle, yearInCycle) = floorDivMod(actualYear, 400)
+      val daysToYearInCycle = daysToYearInGregorianCycle(yearInCycle)
+      val daysToYear = cycle.toLong * DaysInGregorian400Years.toLong + daysToYearInCycle.toLong
+      val isLeapYear = isGregorianLeapYearInCycle(yearInCycle)
+      (daysToYear, isLeapYear)
+    } else {
+      val (cycle, yearInCycle) = floorDivMod(actualYear, 4)
+      val isLeapYear = yearInCycle == 0
+      val daysToYearInCycle = if (isLeapYear) 0 else 1 + 365 * yearInCycle
+      val daysToYear = cycle.toLong * DaysInJulian4Years.toLong + daysToYearInCycle.toLong
+      (daysToYear, isLeapYear)
+    }
+
+    // Compute the number of days in the year until the start of the month
+    val daysInYearToMonth1st = actualMonth match {
+      case 0 => 0
+      case 1 => 31
+      case _ => CumulativeDaysInMonthsNonLeap(actualMonth - 1) + (if (isLeapYear) 1 else 0)
+    }
+
+    // Add up all the days since the epoch
+    val daysSinceYear0 =
+      daysToYear + Integer.toUnsignedLong(daysInYearToMonth1st) + (day - 1).toLong
+    if (isGregorian)
+      daysSinceYear0 - DaysFromGregorianYear0ToEpoch
+    else
+      daysSinceYear0 - DaysFromJulianYear0ToEpoch
   }
 
   @Deprecated
@@ -481,16 +828,7 @@ object Date {
      *
      * Since the local time zone is always GMT=UTC, we have a unique code path.
      */
-    val utc = UTC(year - 1900, month, dayOfMonth, hour, minute, second)
+    val utc = encode(year, month, dayOfMonth, hour, minute, second)
     utc - (timezoneOffset * MSPerMinute).toLong
-  }
-
-  private def safeGetTime(date: js.Date): Long =
-    safeGetTime(date.getTime())
-
-  private def safeGetTime(time: Double): Long = {
-    if (java.lang.Double.isNaN(time))
-      throw new IllegalArgumentException
-    time.toLong
   }
 }

--- a/javalib/src/main/scala/java/util/Date.scala
+++ b/javalib/src/main/scala/java/util/Date.scala
@@ -20,6 +20,10 @@ import java.util.function._
 
 import scalajs.js
 
+/* Note that the default timezone is always Etc/GMT (= UTC, without any
+ * daylight saving time).
+ */
+
 class Date(private var millis: Long)
     extends Object with Serializable with Cloneable with Comparable[Date] {
 
@@ -29,7 +33,7 @@ class Date(private var millis: Long)
 
   @Deprecated
   def this(year: Int, month: Int, date: Int, hrs: Int, min: Int, sec: Int) =
-    this(Date.safeGetTime(new js.Date(1900 + year, month, date, hrs, min, sec, 0)))
+    this(Date.UTC(year, month, date, hrs, min, sec))
 
   @Deprecated
   def this(year: Int, month: Int, date: Int, hrs: Int, min: Int) =
@@ -74,53 +78,54 @@ class Date(private var millis: Long)
   }
 
   @Deprecated
-  def getDate(): Int = asDate().getDate().toInt
+  def getDate(): Int = asDate().getUTCDate().toInt
 
   @Deprecated
-  def getDay(): Int = asDate().getDay().toInt
+  def getDay(): Int = asDate().getUTCDay().toInt
 
   @Deprecated
-  def getHours(): Int = asDate().getHours().toInt
+  def getHours(): Int = asDate().getUTCHours().toInt
 
   @Deprecated
-  def getMinutes(): Int = asDate().getMinutes().toInt
+  def getMinutes(): Int = asDate().getUTCMinutes().toInt
 
   @Deprecated
-  def getMonth(): Int = asDate().getMonth().toInt
+  def getMonth(): Int = asDate().getUTCMonth().toInt
 
   @Deprecated
-  def getSeconds(): Int = asDate().getSeconds().toInt
+  def getSeconds(): Int = asDate().getUTCSeconds().toInt
 
   def getTime(): Long = millis
 
   @Deprecated
-  def getTimezoneOffset(): Int = new js.Date().getTimezoneOffset().toInt
+  def getTimezoneOffset(): Int = 0
 
   @Deprecated
-  def getYear(): Int = asDate().getFullYear().toInt - 1900
+  def getYear(): Int = asDate().getUTCFullYear().toInt - 1900
 
   @Deprecated
-  def setDate(date: Int): Unit = mutDate(_.setDate(date))
+  def setDate(date: Int): Unit = mutDate(_.setUTCDate(date))
 
   @Deprecated
-  def setHours(hours: Int): Unit = mutDate(_.setHours(hours))
+  def setHours(hours: Int): Unit = mutDate(_.setUTCHours(hours))
 
   @Deprecated
-  def setMinutes(minutes: Int): Unit = mutDate(_.setMinutes(minutes))
+  def setMinutes(minutes: Int): Unit = mutDate(_.setUTCMinutes(minutes))
 
   @Deprecated
-  def setMonth(month: Int): Unit = mutDate(_.setMonth(month))
+  def setMonth(month: Int): Unit = mutDate(_.setUTCMonth(month))
 
   @Deprecated
-  def setSeconds(seconds: Int): Unit = mutDate(_.setSeconds(seconds))
+  def setSeconds(seconds: Int): Unit = mutDate(_.setUTCSeconds(seconds))
 
   def setTime(time: Long): Unit = millis = time
 
   @Deprecated
-  def setYear(year: Int): Unit = mutDate(_.setFullYear(1900 + year))
+  def setYear(year: Int): Unit = mutDate(_.setUTCFullYear(1900 + year))
 
   @Deprecated
   def toGMTString(): String = {
+    // Specified format: "d mon yyyy hh:mm:ss GMT".
     val date = asDate()
     "" + date.getUTCDate().toInt + " " + Months(date.getUTCMonth().toInt) + " " +
       date.getUTCFullYear().toInt + " " + pad0(date.getUTCHours().toInt) + ":" +
@@ -132,23 +137,23 @@ class Date(private var millis: Long)
 
   @Deprecated
   def toLocaleString(): String = {
+    /* Use the format "yyyy mon d hh:mm:ss", which appears to be what the JVM
+     * uses for the timezone Etc/GMT and the ROOT locale.
+     */
     val date = asDate()
-    "" + date.getDate().toInt + "-" + Months(date.getMonth().toInt) + "-" +
-      date.getFullYear().toInt + "-" + pad0(date.getHours().toInt) + ":" +
-      pad0(date.getMinutes().toInt) + ":" + pad0(date.getSeconds().toInt)
+    "" + date.getUTCFullYear().toInt + " " + Months(date.getUTCMonth().toInt) + " " +
+      date.getDate().toInt + " " + pad0(date.getUTCHours().toInt) + ":" +
+      pad0(date.getUTCMinutes().toInt) + ":" + pad0(date.getUTCSeconds().toInt)
   }
 
   override def toString(): String = {
+    // Specified format: "dow mon dd hh:mm:ss zzz yyyy". zzz is always "GMT".
     if (isSafeJSDate()) {
       val date = asDate()
-      val offset = -date.getTimezoneOffset().toInt
-      val sign = if (offset < 0) "-" else "+"
-      val hours = pad0(Math.abs(offset) / 60)
-      val mins = pad0(Math.abs(offset) % 60)
-      Days(date.getDay().toInt) + " " + Months(date.getMonth().toInt) + " " +
-        pad0(date.getDate().toInt) + " " + pad0(date.getHours().toInt) + ":" +
-        pad0(date.getMinutes().toInt) + ":" + pad0(date.getSeconds().toInt) +
-        " GMT" + " " + date.getFullYear().toInt
+      Days(date.getUTCDay().toInt) + " " + Months(date.getUTCMonth().toInt) + " " +
+        pad0(date.getUTCDate().toInt) + " " + pad0(date.getUTCHours().toInt) + ":" +
+        pad0(date.getUTCMinutes().toInt) + ":" + pad0(date.getUTCSeconds().toInt) +
+        " GMT " + date.getUTCFullYear().toInt
     } else {
       s"java.util.Date($millis)"
     }
@@ -258,10 +263,11 @@ object Date {
     var minute = -1
     var second = -1
 
-    /* The timezone offset (in minutes) can be negative, but is parsed from a
-     * positive int and therefore cannot be Int.MinValue.
+    /* If we do not find any timezone, we will default to GMT. We don't need a
+     * separate encoding of "not there". All the code paths behave the same for
+     * "last parsed is GMT" and "no timezone parsed so far".
      */
-    var timezoneOffset = Int.MinValue
+    var timezoneOffset = 0
 
     @inline def isASCIIDigit(c: Char): Boolean =
       c >= '0' && c <= '9'
@@ -295,7 +301,7 @@ object Date {
           /* > If a number is preceded by + or - and a year has already been
            * > recognized, then the number is a time-zone offset.
            */
-          if (timezoneOffset != Int.MinValue && timezoneOffset != 0)
+          if (timezoneOffset != 0)
             fail() // out of spec
           val signedNumber = if (prev == '-') -number else number
           if (number < 24) {
@@ -467,19 +473,16 @@ object Date {
     if (second == -1)
       second = 0
 
-    if (timezoneOffset != Int.MinValue) {
-      /* > If a time zone or time-zone offset has been recognized, then the year,
-       * > month, day of month, hour, minute, and second are interpreted in UTC
-       * > and then the time-zone offset is applied.
-       */
-      val utc = UTC(year - 1900, month, dayOfMonth, hour, minute, second)
-      utc - (timezoneOffset * MSPerMinute).toLong
-    } else {
-      /* > Otherwise, the year, month, day of month, hour, minute, and second
-       * > are interpreted in the local time zone.
-       */
-      safeGetTime(new js.Date(year, month, dayOfMonth, hour, minute, second, 0))
-    }
+    /* > If a time zone or time-zone offset has been recognized, then the year,
+     * > month, day of month, hour, minute, and second are interpreted in UTC
+     * > and then the time-zone offset is applied.
+     * > Otherwise, the year, month, day of month, hour, minute, and second
+     * > are interpreted in the local time zone.
+     *
+     * Since the local time zone is always GMT=UTC, we have a unique code path.
+     */
+    val utc = UTC(year - 1900, month, dayOfMonth, hour, minute, second)
+    utc - (timezoneOffset * MSPerMinute).toLong
   }
 
   private def safeGetTime(date: js.Date): Long =

--- a/javalib/src/main/scala/java/util/Date.scala
+++ b/javalib/src/main/scala/java/util/Date.scala
@@ -12,6 +12,8 @@
 
 package java.util
 
+import scala.annotation.switch
+
 import java.lang.Cloneable
 import java.time.Instant
 import java.util.function._
@@ -163,12 +165,61 @@ object Date {
    */
   private final val MaxMillis = 8640000000000000L
 
+  private final val MSPerMinute = 60000
+
+  /** Marker for end-of-string in parsing; distinct from every `Char`. */
+  private final val EOF = -1
+
   private val Days = Array(
       "Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat")
 
   private val Months = Array(
       "Jan", "Feb", "Mar", "Apr", "May", "Jun",
       "Jul", "Aug", "Sep", "Oct", "Nov", "Dec")
+
+  /** All the "words" for which `parse` tries a prefix, in order of precedence. */
+  private val ParsePrefixWords: Array[String] = Array(
+      "SUNDAY", "MONDAY", "TUESDAY", "WEDNESDAY", "THURSDAY", "FRIDAY", "SATURDAY",
+      "AM", "PM",
+      "JANUARY", "FEBRUARY", "MARCH", "APRIL", "MAY", "JUNE",
+      "JULY", "AUGUST", "SEPTEMBER", "OCTOBER", "NOVEMBER", "DECEMBER"
+  )
+
+  /** The current year, used to interpret small years in `parse`.
+   *
+   *  It is explicitly stored, rather than recomputed, because the JavaDoc
+   *  says the computation is relative to
+   *  > the time when the Date class is initialized
+   *
+   *  We don't follow the exact initialization time, but at least this way we
+   *  preserve the fact that only one `currentYear` is observed through the
+   *  lifetime of the application.
+   *
+   *  We make it a `lazy val` for DCE purposes. If a codebase does not use
+   *  `parse` (and it shouldn't), then we can DCE `currentYear` away. It uses
+   *  JS interop and therefore has side effects, so the optimizer cannot remove
+   *  it if it's a `val`.
+   */
+  private lazy val currentYear: Int =
+    new js.Date().getFullYear().toInt
+
+  private def resolveYear(number: Int): Int = {
+    /* > If the recognized year number is less than 100, it is interpreted as an
+     * > abbreviated year relative to a century of which dates are within 80 years
+     * > before and 19 years after the time when the Date class is initialized.
+     */
+    if (number >= 100) {
+      number
+    } else {
+      val relCenturyStart = currentYear - 80
+      val absCenturyStart = relCenturyStart - Integer.remainderUnsigned(relCenturyStart, 100)
+      val candidate = absCenturyStart + number
+      if (candidate >= relCenturyStart)
+        candidate
+      else
+        candidate + 100
+    }
+  }
 
   private def pad0(i: Int): String = {
     val str = "" + i
@@ -191,7 +242,245 @@ object Date {
   }
 
   @Deprecated
-  def parse(string: String): Long = safeGetTime(new js.Date(string))
+  def parse(string: String): Long = {
+    /* Parse the string according to
+     * https://docs.oracle.com/en/java/javase/25/docs/api/java.base/java/util/Date.html#parse(java.lang.String)
+     * Comments starting with '>' are quoted from the JavaDoc.
+     */
+
+    /* We can use -1 as absent value for these fields because they cannot
+     * be parsed as negative values.
+     */
+    var year = -1 // full year (not 1900-based)
+    var month = -1
+    var dayOfMonth = -1
+    var hour = -1
+    var minute = -1
+    var second = -1
+
+    /* The timezone offset (in minutes) can be negative, but is parsed from a
+     * positive int and therefore cannot be Int.MinValue.
+     */
+    var timezoneOffset = Int.MinValue
+
+    @inline def isASCIIDigit(c: Char): Boolean =
+      c >= '0' && c <= '9'
+
+    @inline def isASCIILetter(c: Char): Boolean =
+      (c >= 'A' && c <= 'Z') || (c >= 'a' && c <= 'z')
+
+    def fail(): Nothing =
+      throw new IllegalArgumentException(string)
+
+    val len = string.length()
+    var i = 0
+    while (i != len) {
+      val start = i
+      val c = string.charAt(start)
+      i += 1
+
+      if (isASCIIDigit(c)) {
+        // Parse the whole number
+        while (i != len && isASCIIDigit(string.charAt(i))) {
+          i += 1
+        }
+        val number = Integer.parseInt(string.substring(start, i))
+
+        // Look behind and ahead
+        val prev = if (start == 0) EOF else string.charAt(start - 1).toInt
+        val next = if (i == len) EOF else string.charAt(i).toInt
+
+        // Decide what to do with the number
+        if ((prev == '+' || prev == '-') && year != -1) {
+          /* > If a number is preceded by + or - and a year has already been
+           * > recognized, then the number is a time-zone offset.
+           */
+          if (timezoneOffset != Int.MinValue && timezoneOffset != 0)
+            fail() // out of spec
+          val signedNumber = if (prev == '-') -number else number
+          if (number < 24) {
+            timezoneOffset = 60 * signedNumber
+          } else {
+            // convert HHmm (= 100*HH + mm) to 60*HH + mm
+            val tzHours = signedNumber / 100 // for once, actually use truncating signed division
+            val tzMinutes = signedNumber - 100 * tzHours
+            timezoneOffset = (60 * tzHours) + tzMinutes
+          }
+        } else {
+          /* For non-timezone fields, we refuse to recognize the same field twice.
+           * This is not clearly specified, but it's the "smallest deviation"
+           * from the spec that makes all tests pass.
+           */
+
+          /* > The number is regarded as a year number if one of the following conditions is true:
+           * > - The number is equal to or greater than 70 and followed by a
+           * >   space, comma, slash, or end of string.
+           * > - The number is less than 70, and both a month and a day of the
+           * >   month have already been recognized.
+           *
+           * These conditions are identified in a few places below, and sent into
+           * this function.
+           */
+          @inline def interpretAsYear(): Unit = {
+            // inlined to keep `year` as a (non-captured) local var
+            if (year == -1)
+              year = resolveYear(number) // but outlined not to duplicate code
+            else
+              fail()
+          }
+
+          (next: @switch) match {
+            case ':' =>
+              /* > If the number is followed by a colon, it is regarded as an hour,
+               * > unless an hour has already been recognized, in which case it is
+               * > regarded as a minute.
+               */
+              if (hour == -1)
+                hour = number
+              else if (minute == -1)
+                minute = number
+              else
+                fail()
+
+            case '/' =>
+              /* > If the number is followed by a slash, it is regarded as a month
+               * > (it is decreased by 1 to produce a number in the range 0 to 11),
+               * > unless a month has already been recognized, in which case it is
+               * > regarded as a day of the month.
+               */
+              if (number >= 70)
+                interpretAsYear()
+              else if (month == -1)
+                month = number - 1
+              else if (dayOfMonth == -1)
+                dayOfMonth = number
+              else
+                fail()
+
+            case '\t' | '\n' | '\f' | '\r' | ' ' | ',' | '-' | EOF =>
+              /* > If the number is followed by whitespace, a comma, a hyphen, or
+               * > end of string, then if an hour has been recognized but not a
+               * > minute, it is regarded as a minute; otherwise, if a minute has
+               * > been recognized but not a second, it is regarded as a second;
+               * > otherwise, it is regarded as a day of the month.
+               */
+              if (number >= 70 && (next == ' ' || next == ',' || next == EOF))
+                interpretAsYear()
+              else if (hour != -1 && minute == -1)
+                minute = number
+              else if (minute != -1 && second == -1)
+                second = number
+              else if (dayOfMonth == -1)
+                dayOfMonth = number
+              else if (month != -1 && number < 70)
+                interpretAsYear()
+              else
+                fail()
+
+            case _ =>
+              // Otherwise fail (not clearly specified)
+              fail()
+          }
+        }
+      } else if (isASCIILetter(c)) {
+        // Parse the whole ASCII word
+        while (i != len && isASCIILetter(string.charAt(i))) {
+          i += 1
+        }
+        if (i == start + 1)
+          fail() // out of spec, but apparently the JVM wants at least 2 letters here
+        val word = string.substring(start, i).toUpperCase()
+
+        // Decide what to do with it
+
+        val prefixWords = ParsePrefixWords // local copy
+        val prefixWordsLen = prefixWords.length
+        var prefixIndex = 0
+        while (prefixIndex != prefixWordsLen && !prefixWords(prefixIndex).startsWith(word)) {
+          prefixIndex += 1
+        }
+
+        if (prefixIndex < 7) {
+          // day of week, ignore
+        } else if (prefixIndex < 9) {
+          /* AM (7) or PM (8)
+           * > A word that matches AM, ignoring case, is ignored.
+           * > A word that matches PM, ignoring case, adds 12 to the hour .
+           * > [for both:] (but the parse fails if an hour has not been
+           * > recognized or is less than 1 or greater than 12).
+           */
+          if (hour < 1 || hour > 12) // hour < 1 includes not recognized
+            fail()
+          if (prefixIndex == 8)
+            hour += 12
+        } else if (prefixIndex < prefixWordsLen) {
+          // named month
+          month = prefixIndex - 9
+        } else {
+          // one of the explicitly known timezones, otherwise fail
+          timezoneOffset = word match {
+            case "GMT" | "UT" | "UTC" => 0
+            case "EDT"                => -4 * 60
+            case "EST" | "CDT"        => -5 * 60
+            case "CST" | "MDT"        => -6 * 60
+            case "MST" | "PDT"        => -7 * 60
+            case "PST"                => -8 * 60
+            case _                    => fail()
+          }
+        }
+      } else {
+        (c: @switch) match {
+          case '\t' | '\n' | '\f' | '\r' | ' ' | ',' | '+' | '-' | ':' | '/' =>
+            // ignore
+            ()
+          case '(' =>
+            // Ignore all characters until a matching ')'
+            var nesting = 1
+            while (i != len && nesting > 0) {
+              string.charAt(i) match {
+                case '(' => nesting += 1
+                case ')' => nesting -= 1
+                case _   => ()
+              }
+              i += 1
+            }
+          case _ =>
+            fail()
+        }
+      }
+    }
+
+    // We need all the components of a date, otherwise fail
+    if (year == -1 || month == -1 || dayOfMonth == -1)
+      fail()
+
+    /* However, time components are optional and default to 0.
+     * With our algorithm above, hour-not-set implies minute-not-set and
+     * minute-not-set implies second-not-set.
+     * It's not straightforward from the spec, though, so we process them
+     * separately anyway.
+     */
+    if (hour == -1)
+      hour = 0
+    if (minute == -1)
+      minute = 0
+    if (second == -1)
+      second = 0
+
+    if (timezoneOffset != Int.MinValue) {
+      /* > If a time zone or time-zone offset has been recognized, then the year,
+       * > month, day of month, hour, minute, and second are interpreted in UTC
+       * > and then the time-zone offset is applied.
+       */
+      val utc = UTC(year - 1900, month, dayOfMonth, hour, minute, second)
+      utc - (timezoneOffset * MSPerMinute).toLong
+    } else {
+      /* > Otherwise, the year, month, day of month, hour, minute, and second
+       * > are interpreted in the local time zone.
+       */
+      safeGetTime(new js.Date(year, month, dayOfMonth, hour, minute, second, 0))
+    }
+  }
 
   private def safeGetTime(date: js.Date): Long =
     safeGetTime(date.getTime())

--- a/javalib/src/main/scala/java/util/Date.scala
+++ b/javalib/src/main/scala/java/util/Date.scala
@@ -187,14 +187,16 @@ object Date {
   @Deprecated
   def UTC(year: Int, month: Int, date: Int,
       hrs: Int, min: Int, sec: Int): Long = {
-    js.Date.UTC(year + 1900, month, date, hrs, min, sec).toLong
+    safeGetTime(js.Date.UTC(year + 1900, month, date, hrs, min, sec))
   }
 
   @Deprecated
   def parse(string: String): Long = safeGetTime(new js.Date(string))
 
-  private def safeGetTime(date: js.Date): Long = {
-    val time = date.getTime()
+  private def safeGetTime(date: js.Date): Long =
+    safeGetTime(date.getTime())
+
+  private def safeGetTime(time: Double): Long = {
     if (java.lang.Double.isNaN(time))
       throw new IllegalArgumentException
     time.toLong

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -2488,6 +2488,7 @@ object Build {
       Test / javaOptions ++= Seq(
           "-Dfile.encoding=UTF-8",
           "-Duser.country=", "-Duser.language=",
+          "-Duser.timezone=Etc/GMT",
           "-Dline.separator=\n"
       ),
 

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -2581,6 +2581,7 @@ object Build {
       Test / javaOptions ++= Seq(
           "-Dfile.encoding=UTF-8",
           "-Duser.country=", "-Duser.language=",
+          "-Duser.timezone=Etc/GMT",
           "-Dline.separator=\n"
       ),
 

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/DateTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/DateTest.scala
@@ -19,7 +19,7 @@ import org.junit.Assume._
 import org.junit.Test
 
 import org.scalajs.testsuite.utils.AssertThrows.assertThrows
-import org.scalajs.testsuite.utils.Platform.executingInJVM
+import org.scalajs.testsuite.utils.Platform._
 
 /** tests the implementation of the java standard library Date */
 class DateTest {
@@ -34,15 +34,11 @@ class DateTest {
   }
 
   @Test def fromLocalFields(): Unit = {
-    def test(expectedUTC: Long, date: Date): Unit = {
-      // Whatever the local timezone, we should not be more than 1 day away from UTC
-      assertTrue(Math.abs(date.getTime() - expectedUTC) <= MSPerDay)
-    }
-
-    test(-2209075200000L, new Date(1899 - 1900, 11, 31))
-    test(878534580000L, new Date(97, 10, 3, 5, 23))
-    test(-2145542331000L, new Date(2, 0, 5, 8, 1, 9))
-    test(29348715784000L, new Date(2900 - 1900, 0, 9, 5, 3, 4))
+    // The locale timezone is always GMT
+    assertEquals(-2209075200000L, new Date(1899 - 1900, 11, 31).getTime())
+    assertEquals(878534580000L, new Date(97, 10, 3, 5, 23).getTime())
+    assertEquals(-2145542331000L, new Date(2, 0, 5, 8, 1, 9).getTime())
+    assertEquals(29348715784000L, new Date(2900 - 1900, 0, 9, 5, 3, 4).getTime())
   }
 
   @Test def comparisons(): Unit = {
@@ -158,10 +154,10 @@ class DateTest {
     test(1194240207000L, "noVemb 5/7 5:23:27 GMT") // 2007
     test(2298777807000L, "11/5/42 5:23:27 GMT") // 2042
 
-    // Implicit time zone -> local time zone
-    test(new Date(97, 10, 5, 5, 23, 27).getTime(), "Nov 5 1997 5:23:27")
-    test(new Date(97, 10, 1).getTime(), "Nov 1 1997")
-    test(new Date(70, 0, 1, 18, 11, 1).getTime(), "Jan 1 1970 18:11:01")
+    // Implicit time zone -> always GMT for us
+    test(878707407000L, "Nov 5 1997 5:23:27")
+    test(878342400000L, "Nov 1 1997")
+    test(65461000L, "Jan 1 1970 18:11:01")
 
     // Some time zone abbreviations are explicitly supported (mix of cases)
     val supportedTimeZones = List(
@@ -214,15 +210,13 @@ class DateTest {
 
   // #2392
   @Test def getTimezoneOffset(): Unit =
-    new Date().getTimezoneOffset // Test that it links.
+    assertEquals(0, new Date().getTimezoneOffset())
 
   @Test def toStringTest(): Unit = {
-    def test(expectedRegex: String, actual: String): Unit =
-      assertTrue(s"expected:<$expectedRegex> to match:<$actual>", actual.matches(expectedRegex))
-    test("Mon Nov 03 05:23:27 .+ 1997", new Date(97, 10, 3, 5, 23, 27).toString)
-    test("Sun Dec 31 00:00:00 .+ 1899", new Date(0, 0, 0, 0, 0, 0).toString)
-    test("Sun Jan 05 08:01:09 .+ 1902", new Date(1, 12, 5, 8, 1, 9).toString)
-    test("Sat Jan 09 05:03:04 .+ 2900", new Date(1000, 0, 9, 5, 3, 4).toString)
+    assertEquals("Mon Nov 03 05:23:27 GMT 1997", new Date(878534607567L).toString())
+    assertEquals("Sun Dec 31 00:00:00 GMT 1899", new Date(-2209075200000L).toString())
+    assertEquals("Sun Jan 05 08:01:09 GMT 1902", new Date(-2145542330500L).toString())
+    assertEquals("Sat Jan 09 05:03:04 GMT 2900", new Date(29348715784999L).toString())
   }
 
   @Test def toGMTString(): Unit = {
@@ -230,6 +224,25 @@ class DateTest {
     assertEquals("31 Dec 1899 00:00:00 GMT", new Date(-2209075200000L).toGMTString())
     assertEquals("5 Jan 1902 08:01:09 GMT", new Date(-2145542330500L).toGMTString())
     assertEquals("9 Jan 2900 05:03:04 GMT", new Date(29348715784999L).toGMTString())
+  }
+
+  @Test def toLocaleString(): Unit = {
+    /* On JDK 8, the results are of the form "Nov 3, 1997 5:23:27 AM". That
+     * corresponds to the pattern of a DateFormat string obtained with
+     *   DateFormat.getDateTimeInstance(DateFormat.MEDIUM, DateFormat.MEDIUM, Locale.ENGLISH)
+     *
+     * On JDK 11+, and in our implementation, we get the format below, which
+     * corresponds to the pattern "y MMM d HH:mm:ss", which we get with
+     *   DateFormat.getDateTimeInstance(DateFormat.MEDIUM, DateFormat.MEDIUM, Locale.ROOT)
+     */
+    assumeFalse(
+        "JDK 8 did not abide by the default Locale rules yet",
+        executingInJVMOnLowerThanJDK(11))
+
+    assertEquals("1997 Nov 3 05:23:27", new Date(878534607567L).toLocaleString())
+    assertEquals("1899 Dec 31 00:00:00", new Date(-2209075200000L).toLocaleString())
+    assertEquals("1902 Jan 5 08:01:09", new Date(-2145542330500L).toLocaleString())
+    assertEquals("2900 Jan 9 05:03:04", new Date(29348715784999L).toLocaleString())
   }
 
   // #4131
@@ -263,5 +276,6 @@ class DateTest {
   @Test def preventsUnsafeConstruct(): Unit = {
     assumeFalse(executingInJVM)
     assertThrows(classOf[IllegalArgumentException], new Date(3000000, 1, 1))
+    assertThrows(classOf[IllegalArgumentException], Date.UTC(3000000, 1, 1, 0, 0, 0))
   }
 }

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/DateTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/DateTest.scala
@@ -31,6 +31,16 @@ class DateTest {
     assertEquals(878534607000L, Date.UTC(97, 10, 3, 5, 23, 27))
     assertEquals(-2145542331000L, Date.UTC(2, 0, 5, 8, 1, 9))
     assertEquals(29348715784000L, Date.UTC(2900 - 1900, 0, 9, 5, 3, 4))
+
+    // First Gregorian second and last Julian second
+    assertEquals(-12219292800000L, Date.UTC(1582 - 1900, 9, 15, 0, 0, 0))
+    assertEquals(-12219292801000L, Date.UTC(1582 - 1900, 9, 4, 23, 59, 59))
+
+    // The last second interpreted as Julian (but wrapping into the Gregorian calendar)
+    assertEquals(-12218428801000L, Date.UTC(1582 - 1900, 9, 14, 23, 59, 59))
+
+    assertEquals(94668649689600000L, Date.UTC(3000000, 1, 1, 0, 0, 0))
+    assertEquals(-94675005273600000L, Date.UTC(-3000000, 1, 1, 0, 0, 0))
   }
 
   @Test def fromLocalFields(): Unit = {
@@ -39,6 +49,9 @@ class DateTest {
     assertEquals(878534580000L, new Date(97, 10, 3, 5, 23).getTime())
     assertEquals(-2145542331000L, new Date(2, 0, 5, 8, 1, 9).getTime())
     assertEquals(29348715784000L, new Date(2900 - 1900, 0, 9, 5, 3, 4).getTime())
+
+    assertEquals(94668649689600000L, new Date(3000000, 1, 1).getTime())
+    assertEquals(-94675005273600000L, new Date(-3000000, 1, 1).getTime())
   }
 
   @Test def comparisons(): Unit = {
@@ -208,6 +221,19 @@ class DateTest {
     testYear(2030)
   }
 
+  @Test def setYear(): Unit = {
+    val date = new Date(0L)
+    date.setYear(300000)
+    assertEquals(9464876611200000L, date.getTime())
+    date.setYear(-300000)
+    assertEquals(-9469487952000000L, date.getTime())
+  }
+
+  @Test def getDate(): Unit = {
+    assertEquals(13, new Date(8640000000000001L).getDate())
+    assertEquals(19, new Date(-8640000000000001L).getDate())
+  }
+
   // #2392
   @Test def getTimezoneOffset(): Unit =
     assertEquals(0, new Date().getTimezoneOffset())
@@ -217,6 +243,10 @@ class DateTest {
     assertEquals("Sun Dec 31 00:00:00 GMT 1899", new Date(-2209075200000L).toString())
     assertEquals("Sun Jan 05 08:01:09 GMT 1902", new Date(-2145542330500L).toString())
     assertEquals("Sat Jan 09 05:03:04 GMT 2900", new Date(29348715784999L).toString())
+
+    assertEquals("Sat Sep 13 00:00:00 GMT 275760", new Date(8640000000000001L).toString())
+    assertEquals("Sun Aug 17 07:12:55 GMT 292278994", new Date(Long.MaxValue).toString())
+    assertEquals("Sun Dec 02 16:47:04 GMT 292269055", new Date(Long.MinValue).toString())
   }
 
   @Test def toGMTString(): Unit = {
@@ -224,6 +254,10 @@ class DateTest {
     assertEquals("31 Dec 1899 00:00:00 GMT", new Date(-2209075200000L).toGMTString())
     assertEquals("5 Jan 1902 08:01:09 GMT", new Date(-2145542330500L).toGMTString())
     assertEquals("9 Jan 2900 05:03:04 GMT", new Date(29348715784999L).toGMTString())
+
+    assertEquals("13 Sep 275760 00:00:00 GMT", new Date(8640000000000001L).toGMTString())
+    assertEquals("17 Aug 292278994 07:12:55 GMT", new Date(Long.MaxValue).toGMTString())
+    assertEquals("2 Dec 292269055 16:47:04 GMT", new Date(Long.MinValue).toGMTString())
   }
 
   @Test def toLocaleString(): Unit = {
@@ -243,6 +277,10 @@ class DateTest {
     assertEquals("1899 Dec 31 00:00:00", new Date(-2209075200000L).toLocaleString())
     assertEquals("1902 Jan 5 08:01:09", new Date(-2145542330500L).toLocaleString())
     assertEquals("2900 Jan 9 05:03:04", new Date(29348715784999L).toLocaleString())
+
+    assertEquals("275760 Sep 13 00:00:00", new Date(8640000000000001L).toLocaleString())
+    assertEquals("292278994 Aug 17 07:12:55", new Date(Long.MaxValue).toLocaleString())
+    assertEquals("292269055 Dec 2 16:47:04", new Date(Long.MinValue).toLocaleString())
   }
 
   // #4131
@@ -252,30 +290,5 @@ class DateTest {
 
     val lo = new Date(-8640000000000001L)
     assertEquals(-8640000000000001L, lo.getTime())
-  }
-
-  @Test def largeToString(): Unit = {
-    assumeFalse(executingInJVM)
-    assertEquals("java.util.Date(8640000000000001)", new Date(8640000000000001L).toString())
-  }
-
-  @Test def preventsUnsafeRead(): Unit = {
-    assumeFalse(executingInJVM)
-    assertThrows(classOf[IllegalArgumentException], new Date(8640000000000001L).getDate())
-    assertThrows(classOf[IllegalArgumentException], new Date(-8640000000000001L).getDate())
-  }
-
-  @Test def preventsUnsafeWrite(): Unit = {
-    assumeFalse(executingInJVM)
-    val date = new Date(0L)
-    assertThrows(classOf[IllegalArgumentException], date.setYear(300000))
-    assertEquals(0L, date.getTime())
-    assertThrows(classOf[IllegalArgumentException], date.setYear(-300000))
-  }
-
-  @Test def preventsUnsafeConstruct(): Unit = {
-    assumeFalse(executingInJVM)
-    assertThrows(classOf[IllegalArgumentException], new Date(3000000, 1, 1))
-    assertThrows(classOf[IllegalArgumentException], Date.UTC(3000000, 1, 1, 0, 0, 0))
   }
 }

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/DateTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/DateTest.scala
@@ -23,7 +23,8 @@ import org.scalajs.testsuite.utils.Platform.executingInJVM
 
 /** tests the implementation of the java standard library Date */
 class DateTest {
-  private final val MSPerDay = 24 * 60 * 60 * 1000
+  private final val MSPerHour = 60L * 60L * 1000L
+  private final val MSPerDay = 24L * MSPerHour
 
   @Test def fromUTC(): Unit = {
     assertEquals(-2209075200000L, Date.UTC(1899 - 1900, 11, 31, 0, 0, 0))
@@ -84,10 +85,105 @@ class DateTest {
     test(65461000L, "Jan 1 1970 18:11:01 GMT")
     test(878707407000L, "Nov 5 1997 (ig(no)ré) 5:23:27 GMT")
 
+    // Explicit time zone offsets
+    test(878689407000L, "Nov 5 1997 5:23:27 +5")
+    test(878414400000L, "Nov 1 1997 utc-20")
+    test(-11939000L, "Jan 1 1970 18:11:01 +2130")
+    test(878711907000L, "Nov 5 1997 (ig(no)ré) 5:23:27 GMT-0115")
+
+    /* If there are several time zones, the last one wins
+     * (which is why GMT-0115 works without dedicated code paths, btw).
+     */
+    test(878711907000L, "Nov 5 1997 GMT 5:23:27 -0115")
+    test(878725407000L, "Nov 5 1997 +0 GMT -0115 EST 5:23:27")
+    test(878725407000L, "Nov 5 1997 +0 GMT EST 5:23:27")
+    test(878707407000L, "Nov 5 1997 +0 -0115 EST GMT 5:23:27")
+    test(878689407000L, "Nov 5 1997 +0 EST GMT 5:23:27 +5")
+
+    // But a time zone offset is rejected if the last time zone so far is non-UTC (not specified)
+    testFailure("Nov 5 1997 +0 -0115 +5 5:23:27")
+    testFailure("Nov 5 1997 +0 EST -0115 GMT 5:23:27")
+
+    // Some other formats
+    test(878707407000L, "5 Nov 1997 5:23:27 GMT")
+    test(878707407000L, "11/5/1997 5:23:27 GMT")
+    test(878707407000L, "Nov 5 Thu 1997 5:  23:  27 GMT") // It was a Wednesday, actually
+    test(878707407000L, "Nov 5 1997 5:23:27 GMT")
+
+    // Other separators
+    test(878707407000L, "5\tNov\n1997 5:23:27 GMT")
+    test(878707407000L, "1997, 5\rNov 5:23:27 GMT")
+    test(878707407000L, "5\tNov\n1997 5:23,27 GMT")
+
+    // Various prefixes
+    test(878707407000L, "No 5 1997 5:23:27 GMT")
+    test(876029007000L, "October 5 1997 sunday 5:23:27 GMT")
+    test(876029007000L, "Oct5 1997 sunday5:23:27 GMT")
+
+    // 1-letter prefix is not allowed (out of spec)
+    testFailure("J 5 1997 5:23:27 GMT")
+
+    /* The JavaDoc specifically calls out
+     * > So is Ma, which is recognized as MARCH, not MAY.
+     * but the JDK answers May ...
+     */
+    if (executingInJVM)
+      test(862809807000L, "ma 5 1997 5:23:27 GMT") // oops, that's May
+    else
+      test(857539407000L, "ma 5 1997 5:23:27 GMT") // March, not May
+
+    // We can omit time components
+    test(878707380000L, "Nov 5 1997 5:23 GMT")
+    test(878706000000L, "Nov 5 1997 5: GMT")
+    test(878688000000L, "Nov 5 1997 GMT")
+
+    // But not date components
+    testFailure("Nov 5 GMT") // no year
+    testFailure("5 1997 5:23:27 GMT") // no month
+    testFailure("10/ 1997 5:23:27 GMT") // no day
+
+    /* Also apparently the JVM rejects the following, but I don't know why.
+     * For us, the '5:' gets interpreted as a year. If we disallow that
+     * interpretation because it's followed by ':', then '27' gets interpreted
+     * as a year anyway.
+     */
+    if (executingInJVM)
+      testFailure("Nov 5 5:23:27 GMT")
+    else
+      test(1131233220000L, "Nov 5 5:23:27 GMT") // parsed as 5 Nov 2005 23:27:00
+
+    // Year smaller than 100, time-dependent
+    // These tests will start failing in 2078 (since 2078 - 80 > 1997)
+    test(878707407000L, "5 Nov 97 5:23:27 GMT") // 1997
+    test(1194240207000L, "noVemb 5/7 5:23:27 GMT") // 2007
+    test(2298777807000L, "11/5/42 5:23:27 GMT") // 2042
+
     // Implicit time zone -> local time zone
     test(new Date(97, 10, 5, 5, 23, 27).getTime(), "Nov 5 1997 5:23:27")
     test(new Date(97, 10, 1).getTime(), "Nov 1 1997")
     test(new Date(70, 0, 1, 18, 11, 1).getTime(), "Jan 1 1970 18:11:01")
+
+    // Some time zone abbreviations are explicitly supported (mix of cases)
+    val supportedTimeZones = List(
+      "GMT" -> 0,
+      "UT" -> 0,
+      "utc" -> 0,
+      "Est" -> -5,
+      "cSt" -> -6,
+      "MsT" -> -7,
+      "pst" -> -8,
+      "eDT" -> -4,
+      "CDt" -> -5,
+      "MdT" -> -6,
+      "PDT" -> -7
+    )
+    for ((tzName, offset) <- supportedTimeZones) {
+      test(1774089000000L - offset * MSPerHour, s"Mar 21 2026 10:30 $tzName")
+    }
+
+    // But other abbreviations are not
+    for (tzName <- List("CET", "JST", "cest"))
+      testFailure(s"Mar 21 2026 10:30 $tzName")
 
     testFailure("not a date")
   }

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/DateTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/DateTest.scala
@@ -23,64 +23,86 @@ import org.scalajs.testsuite.utils.Platform.executingInJVM
 
 /** tests the implementation of the java standard library Date */
 class DateTest {
+  private final val MSPerDay = 24 * 60 * 60 * 1000
 
-  @Test def compareTo(): Unit = {
-    def compare(x: Date, y: Date): Int =
-      x.compareTo(y)
-
-    assertTrue(compare(new Date(97, 11, 5, 0, 0), new Date(98, 11, 5, 0, 0)) < 0)
-    assertTrue(compare(new Date(98, 11, 5, 0, 0), new Date(97, 11, 5, 0, 0)) > 0)
-    assertEquals(0, compare(new Date(97, 11, 5, 0, 0), new Date(97, 11, 5)))
-    assertTrue(compare(new Date(97, 11, 5, 0, 0), new Date(97, 11, 5, 0, 1)) < 0)
-    assertEquals(0, compare(new Date(97, 11, 5), new Date(97, 11, 5, 0, 0)))
+  @Test def fromUTC(): Unit = {
+    assertEquals(-2209075200000L, Date.UTC(1899 - 1900, 11, 31, 0, 0, 0))
+    assertEquals(878534607000L, Date.UTC(97, 10, 3, 5, 23, 27))
+    assertEquals(-2145542331000L, Date.UTC(2, 0, 5, 8, 1, 9))
+    assertEquals(29348715784000L, Date.UTC(2900 - 1900, 0, 9, 5, 3, 4))
   }
 
-  @Test def comparable(): Unit = {
-    def compare(x: Any, y: Any): Int =
-      x.asInstanceOf[Comparable[Any]].compareTo(y)
+  @Test def fromLocalFields(): Unit = {
+    def test(expectedUTC: Long, date: Date): Unit = {
+      // Whatever the local timezone, we should not be more than 1 day away from UTC
+      assertTrue(Math.abs(date.getTime() - expectedUTC) <= MSPerDay)
+    }
 
-    assertTrue(compare(new Date(97, 11, 5, 0, 0), new Date(98, 11, 5, 0, 0)) < 0)
-    assertTrue(compare(new Date(98, 11, 5, 0, 0), new Date(97, 11, 5, 0, 0)) > 0)
-    assertEquals(0, compare(new Date(97, 11, 5, 0, 0), new Date(97, 11, 5)))
-    assertTrue(compare(new Date(97, 11, 5, 0, 0), new Date(97, 11, 5, 0, 1)) < 0)
-    assertEquals(0, compare(new Date(97, 11, 5), new Date(97, 11, 5, 0, 0)))
+    test(-2209075200000L, new Date(1899 - 1900, 11, 31))
+    test(878534580000L, new Date(97, 10, 3, 5, 23))
+    test(-2145542331000L, new Date(2, 0, 5, 8, 1, 9))
+    test(29348715784000L, new Date(2900 - 1900, 0, 9, 5, 3, 4))
+  }
+
+  @Test def comparisons(): Unit = {
+    def assertCompare(expectedSign: Int, tx: Long, ty: Long): Unit = {
+      val x = new Date(tx)
+      val y = new Date(ty)
+      assertEquals(expectedSign, Integer.signum(x.compareTo(y)))
+
+      // also check that ju.Date implements Comparable
+      val cx: Comparable[Date] = x
+      assertEquals(expectedSign, Integer.signum(cx.compareTo(y)))
+
+      assertEquals(expectedSign > 0, x.after(y))
+      assertEquals(expectedSign < 0, x.before(y))
+    }
+
+    assertCompare(-1, 881280000000L, 912816000000L)
+    assertCompare(1, 912816000000L, 881280000000L)
+    assertCompare(0, 881280000000L, 881280000000L)
+    assertCompare(-1, -912816000000L, 881280000000L)
+    assertCompare(1, 881280000000L, -912816000000L)
+    assertCompare(-1, Long.MinValue, 0L)
+    assertCompare(1, Long.MaxValue, 0L)
   }
 
   @Test def parseStrings(): Unit = {
-    def test(s: String, v: Date): Unit = {
-      assertEquals(0, new Date(s).compareTo(v))
-      assertEquals(0, Date.parse(s).compareTo(v.getTime))
+    def test(expected: Long, s: String): Unit = {
+      assertEquals(s, expected, new Date(s).getTime())
+      assertEquals(s, expected, Date.parse(s))
     }
 
-    test("Nov 5 1997 5:23:27 GMT", new Date(Date.UTC(97, 10, 5, 5, 23, 27)))
-    test("Nov 1 1997 GMT", new Date(Date.UTC(97, 10, 1, 0, 0, 0)))
-    test("Jan 1 1970 18:11:01 GMT", new Date(Date.UTC(70, 0, 1, 18, 11, 1)))
+    def testFailure(s: String): Unit = {
+      assertThrows(classOf[IllegalArgumentException], new Date(s))
+      assertThrows(classOf[IllegalArgumentException], Date.parse(s))
+    }
 
-    assertThrows(classOf[IllegalArgumentException], new Date("not a date"))
-    assertThrows(classOf[IllegalArgumentException], Date.parse("not a date"))
-  }
+    // Explicit GMT time zone
+    test(878707407000L, "Nov 5 1997 5:23:27 GMT")
+    test(878342400000L, "Nov 1 1997 GMT")
+    test(65461000L, "Jan 1 1970 18:11:01 GMT")
+    test(878707407000L, "Nov 5 1997 (ig(no)ré) 5:23:27 GMT")
 
-  @Test def after(): Unit = {
-    assertFalse(new Date(97, 11, 5, 0, 0).after(new Date(98, 11, 5, 0, 0)))
-    assertTrue(new Date(99, 11, 5, 0, 0).after(new Date(98, 11, 5, 0, 0)))
-    assertFalse(new Date(99, 11, 5, 0, 0).after(new Date(99, 11, 5, 0, 0)))
-  }
+    // Implicit time zone -> local time zone
+    test(new Date(97, 10, 5, 5, 23, 27).getTime(), "Nov 5 1997 5:23:27")
+    test(new Date(97, 10, 1).getTime(), "Nov 1 1997")
+    test(new Date(70, 0, 1, 18, 11, 1).getTime(), "Jan 1 1970 18:11:01")
 
-  @Test def before(): Unit = {
-    assertTrue(new Date(97, 11, 5, 0, 0).before(new Date(98, 11, 5, 0, 0)))
-    assertFalse(new Date(99, 11, 5, 0, 0).before(new Date(98, 11, 5, 0, 0)))
-    assertFalse(new Date(99, 11, 5, 0, 0).before(new Date(99, 11, 5, 0, 0)))
+    testFailure("not a date")
   }
 
   @Test def cloneTest(): Unit = {
-    def testClone(date: Date): Boolean = {
+    def testClone(time: Long): Unit = {
+      val date = new Date(time)
       val cloned = date.clone()
-      date == cloned
+      assertNotSame(date, cloned)
+      assertEquals(date, cloned)
     }
 
-    assertTrue(testClone(new Date(97, 11, 5, 0, 0)))
-    assertTrue(testClone(new Date(92, 14, 6, 2, 1)))
-    assertTrue(testClone(new Date(4, 1, 2, 3, 0, 0)))
+    testClone(881276400000L)
+    testClone(731379660000L)
+    testClone(-2080072800000L)
   }
 
   @Test def getYear(): Unit = {
@@ -108,10 +130,10 @@ class DateTest {
   }
 
   @Test def toGMTString(): Unit = {
-    assertEquals("31 Dec 1899 00:00:00 GMT", new Date(Date.UTC(0, 0, 0, 0, 0, 0)).toGMTString)
-    assertEquals("3 Nov 1997 05:23:27 GMT", new Date(Date.UTC(97, 10, 3, 5, 23, 27)).toGMTString)
-    assertEquals("5 Jan 1902 08:01:09 GMT", new Date(Date.UTC(1, 12, 5, 8, 1, 9)).toGMTString)
-    assertEquals("9 Jan 2900 05:03:04 GMT", new Date(Date.UTC(1000, 0, 9, 5, 3, 4)).toGMTString)
+    assertEquals("3 Nov 1997 05:23:27 GMT", new Date(878534607567L).toGMTString())
+    assertEquals("31 Dec 1899 00:00:00 GMT", new Date(-2209075200000L).toGMTString())
+    assertEquals("5 Jan 1902 08:01:09 GMT", new Date(-2145542330500L).toGMTString())
+    assertEquals("9 Jan 2900 05:03:04 GMT", new Date(29348715784999L).toGMTString())
   }
 
   // #4131

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/DateTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/DateTest.scala
@@ -42,6 +42,17 @@ class DateTest {
     assertEquals(1776745119000L, Date.UTC(2026 - 1900, 3, 21, 5, -42, 39))
     assertEquals(1776750285000L, Date.UTC(2026 - 1900, 3, 21, 5, 43, 105))
     assertEquals(1776750173000L, Date.UTC(2026 - 1900, 3, 21, 5, 43, -7))
+
+    // First Gregorian second and last Julian second
+    assertEquals(-12219292800000L, Date.UTC(1582 - 1900, 9, 15, 0, 0, 0))
+    assertEquals(-12219292801000L, Date.UTC(1582 - 1900, 9, 4, 23, 59, 59))
+
+    // The last second interpreted as Julian (but wrapping into the Gregorian calendar)
+    assertEquals(-12218428801000L, Date.UTC(1582 - 1900, 9, 14, 23, 59, 59))
+
+    // Large values
+    assertEquals(94668649689600000L, Date.UTC(3000000, 1, 1, 0, 0, 0))
+    assertEquals(-94675005273600000L, Date.UTC(-3000000, 1, 1, 0, 0, 0))
   }
 
   @Test def fromLocalFields(): Unit = {
@@ -62,6 +73,10 @@ class DateTest {
     assertEquals(1776745119000L, new Date(2026 - 1900, 3, 21, 5, -42, 39).getTime())
     assertEquals(1776750285000L, new Date(2026 - 1900, 3, 21, 5, 43, 105).getTime())
     assertEquals(1776750173000L, new Date(2026 - 1900, 3, 21, 5, 43, -7).getTime())
+
+    // Large values
+    assertEquals(94668649689600000L, new Date(3000000, 1, 1).getTime())
+    assertEquals(-94675005273600000L, new Date(-3000000, 1, 1).getTime())
   }
 
   @Test def comparisons(): Unit = {
@@ -259,6 +274,22 @@ class DateTest {
     for (tzName <- List("CET", "JST", "cest"))
       testFailure(s"Mar 21 2026 10:30 $tzName")
 
+    // First Gregorian second
+    test(-12219292800000L, "15 Oct 1582")
+
+    // For some reason, the JVM gets these wrong
+    if (!executingInJVM) {
+      // Last Julian second
+      test(-12219292801000L, "4 Oct 1582 23:59:59")
+
+      // The last second interpreted as Julian (but wrapping into the Gregorian calendar)
+      test(-12218428801000L, "14 Oct 1582 23:59:59")
+    }
+
+    // The earliest and latest dates we can parse
+    test(-58980009600000L, "1 Jan 101 0:0:0") // but the JVM gets this one right!
+    test(9223372036854775000L, "Aug 17 07:12:55 GMT 292278994")
+
     testFailure("not a date")
   }
 
@@ -275,15 +306,236 @@ class DateTest {
     testClone(-2080072800000L)
   }
 
-  @Test def getYear(): Unit = {
-    def testYear(year: Int): Unit = {
-      val date = new Date()
-      date.setYear(year)
-      assertEquals(year, date.getYear)
+  @Test def components(): Unit = {
+    def testWith(d: Date, year: Int, month: Int, date: Int, day: Int,
+        hours: Int, minutes: Int, seconds: Int): Unit = {
+      val timeStr = d.getTime().toString()
+      assertEquals(timeStr, year, d.getYear())
+      assertEquals(timeStr, month, d.getMonth())
+      assertEquals(timeStr, date, d.getDate())
+      assertEquals(timeStr, day, d.getDay())
+      assertEquals(timeStr, hours, d.getHours())
+      assertEquals(timeStr, minutes, d.getMinutes())
+      assertEquals(timeStr, seconds, d.getSeconds())
     }
-    testYear(1940)
-    testYear(1920)
-    testYear(2030)
+
+    def test(time: Long, year: Int, month: Int, date: Int, day: Int,
+        hours: Int, minutes: Int, seconds: Int): Unit = {
+      testWith(new Date(time), year, month, date, day, hours, minutes, seconds)
+    }
+
+    // Some points of interest
+    test(Long.MaxValue, 292277094, 7, 17, 0, 7, 12, 55)
+    test(0L, 70, 0, 1, 4, 0, 0, 0)
+    test(-1L, 69, 11, 31, 3, 23, 59, 59)
+    test(-12219292800000L, -318, 9, 15, 5, 0, 0, 0) // first Gregorian
+    test(-12219292800001L, -318, 9, 4, 4, 23, 59, 59) // last Julian
+    test(Long.MinValue, 292267155, 11, 2, 0, 16, 47, 4)
+
+    // Random values
+    test(99340127223205L, 3217, 11, 18, 2, 23, 47, 3)
+    test(89733015185664L, 2913, 6, 11, 4, 13, 33, 5)
+    test(81953270636458L, 2666, 11, 30, 2, 5, 23, 56)
+    test(69268172576093L, 2265, 0, 7, 1, 23, 2, 56)
+    test(58819923690243L, 1933, 11, 6, 5, 3, 41, 30)
+    test(58767886310098L, 1932, 3, 12, 4, 20, 51, 50)
+    test(52888209773058L, 1745, 11, 17, 0, 1, 22, 53)
+    test(44645843127687L, 1484, 9, 8, 5, 7, 5, 27)
+    test(33258918856225L, 1123, 11, 8, 1, 4, 34, 16)
+    test(32270012544164L, 1092, 7, 5, 0, 12, 22, 24)
+    test(26786570947801L, 918, 9, 31, 3, 18, 9, 7)
+    test(18311220369554L, 650, 3, 5, 0, 10, 6, 9)
+    test(13317439658811L, 492, 0, 6, 1, 0, 47, 38)
+    test(12566402703667L, 468, 2, 19, 2, 11, 25, 3)
+    test(5782592879274L, 253, 2, 30, 5, 3, 47, 59)
+    test(2647264422444L, 153, 10, 20, 4, 15, 13, 42)
+    test(1438185308498L, 115, 6, 29, 3, 15, 55, 8)
+    test(1428035218076L, 115, 3, 3, 5, 4, 26, 58)
+    test(-493700455846L, 54, 4, 10, 1, 20, 59, 4)
+    test(-29183007698061L, -855, 2, 18, 1, 16, 58, 21)
+    test(-38639617496656L, -1155, 6, 20, 2, 4, 55, 3)
+    test(-54045640857406L, -1643, 4, 12, 2, 17, 59, 2)
+    test(-54842186819106L, -1668, 1, 14, 2, 11, 13, 0)
+    test(-61571195674902L, -1882, 10, 22, 2, 10, 5, 25)
+    // And now years go back up towards 0 because we enter the BC era -_-'
+    test(-71905403644441L, -1590, 5, 3, 2, 12, 45, 55)
+    test(-81499512678878L, -1286, 4, 27, 0, 14, 28, 41)
+    test(-82456568363058L, -1256, 0, 27, 4, 13, 40, 36)
+    test(-97594691897105L, -776, 4, 17, 4, 19, 21, 42)
+    test(-97897314087185L, -766, 9, 15, 2, 5, 38, 32)
+    test(-99303558586855L, -722, 2, 24, 1, 6, 10, 13)
+
+    // setTime() invalidates the cache
+    locally {
+      val d = new Date(1428035218076L)
+      testWith(d, 115, 3, 3, 5, 4, 26, 58) // fill cache
+      d.setTime(-493700455846L) // must invalidate the cache
+      testWith(d, 54, 4, 10, 1, 20, 59, 4)
+    }
+  }
+
+  @noinline
+  private def testSetter(expected: Long, initial: Long, newValue: Int)(
+      setter: (Date, Int) => Unit): Unit = {
+    val date = new Date(initial)
+    setter(date, newValue)
+    assertEquals(s"$initial set $newValue", expected, date.getTime())
+  }
+
+  @Test def setYear(): Unit = {
+    def test(expected: Long, initial: Long, newValue: Int): Unit =
+      testSetter(expected, initial, newValue)(_.setYear(_))
+
+    test(79393491344194L, -287871855806L, 2585)
+    test(-71406625383548L, 89218664216452L, -2193)
+    test(35441711269763L, -98707853530237L, 1193)
+    test(9906084044406L, -97924917555594L, 383)
+    test(1947573953806L, 57266988353806L, 131)
+    test(-48189753682787L, -61443945682787L, -1458)
+    test(-52998987023648L, 93393716976352L, -1610)
+    test(7860408493787L, 25406088493787L, 319)
+    test(-65195993178101L, 68290192421899L, -1996)
+    test(-52794226021896L, -84162523621896L, -1603)
+    test(51078631833231L, 21825319833231L, 1688)
+    test(3261020682076L, 99257123082076L, 173)
+    test(87110478926282L, -80331165873718L, 2830)
+    test(59844827207474L, 83007630407474L, 1966)
+    test(-77635564802517L, -15340905602517L, -2391)
+    test(57139824642608L, -2913100157392L, 1880)
+    test(14117102751370L, 42202718751370L, 517)
+    test(-8645510841901L, -63649478841901L, -204)
+    test(-68921504024418L, -37553292824418L, -2115)
+    test(-94286356289795L, -96684733889795L, -2918)
+  }
+
+  @Test def setMonth(): Unit = {
+    def test(expected: Long, initial: Long, newValue: Int): Unit =
+      testSetter(expected, initial, newValue)(_.setMonth(_))
+
+    test(-55264618814483L, -55262026814483L, 8)
+    test(12801226961434L, 12843390161434L, -5)
+    test(77271532574308L, 77295119774308L, -5)
+    test(-47407443472430L, -47373229072430L, -4)
+    test(-78642447981854L, -78574019181854L, -25)
+    test(-28882615794838L, -28911559794838L, 20)
+    test(27109122857966L, 27106444457966L, 12)
+    test(-52921512167646L, -52924104167646L, 11)
+    test(59681429792935L, 59697327392935L, 2)
+    test(2753535846952L, 2769347046952L, 3)
+    test(-12483333096351L, -12478062696351L, 4)
+    test(89599509291124L, 89610050091124L, 3)
+    test(54917918705237L, 54899601905237L, 15)
+    test(86722649571768L, 86793497571768L, -23)
+    test(-39359000174305L, -39369540974305L, 9)
+    test(726317499385L, 778848699385L, -12)
+    test(-44555908258027L, -44529642658027L, 0)
+    test(26905338123988L, 26902659723988L, 7)
+    test(-98562628815097L, -98565307215097L, 8)
+    test(70284850111486L, 70300747711486L, 2)
+  }
+
+  @Test def setDate(): Unit = {
+    def test(expected: Long, initial: Long, newValue: Int): Unit =
+      testSetter(expected, initial, newValue)(_.setDate(_))
+
+    test(76532783701118L, 76531228501118L, 25)
+    test(20864165250209L, 20863646850209L, 28)
+    test(-62090405034284L, -62090232234284L, 10)
+    test(-92290969792197L, -92291488192197L, 10)
+    test(-85934580157880L, -85935271357880L, 11)
+    test(-26926769355269L, -26926510155269L, 15)
+    test(13360796533449L, 13361574133449L, 21)
+    test(-46986025694074L, -46987840094074L, 25)
+    test(-5134623771979L, -5134710171979L, 17)
+    test(4873941073602L, 4874977873602L, 13)
+    test(26636716477745L, 26646911677745L, -89)
+    test(45810597092289L, 45815176292289L, -24)
+    test(78877590627373L, 78887094627373L, -79)
+    test(-4926381742802L, -4920506542802L, -40)
+    test(95725658455542L, 95728596055542L, -25)
+    test(-80176623787574L, -80171094187574L, -34)
+    test(-91502392537399L, -91497381337399L, -55)
+    test(-2679673120112L, -2681141920112L, 31)
+    test(14488915920738L, 14491075920738L, -10)
+    test(-3443498568308L, -3437191368308L, -44)
+  }
+
+  @Test def setHours(): Unit = {
+    def test(expected: Long, initial: Long, newValue: Int): Unit =
+      testSetter(expected, initial, newValue)(_.setHours(_))
+
+    test(-17488963046067L, -17488995446067L, 10)
+    test(20558498037054L, 20558490837054L, 13)
+    test(5312786026257L, 5312742826257L, 13)
+    test(-65966784064652L, -65966812864652L, 13)
+    test(-68790482213316L, -68790500213316L, 20)
+    test(-11491697044338L, -11491643044338L, 5)
+    test(-64868933043469L, -64868889843469L, 3)
+    test(20379542983344L, 20379571783344L, 8)
+    test(-61950407165078L, -61950428765078L, 9)
+    test(73736170221394L, 73736109021394L, 21)
+    test(90566664522591L, 90566776122591L, -18)
+    test(-87819242016796L, -87819141216796L, -10)
+    test(29345423459562L, 29345481059562L, 2)
+    test(46349518463981L, 46349396063981L, 42)
+    test(-38641530814740L, -38641581214740L, 25)
+    test(67124714832512L, 67125020832512L, -62)
+    test(88841609636685L, 88841775236685L, -40)
+    test(40010656373609L, 40010976773609L, -89)
+    test(81865947325636L, 81865652125636L, 84)
+    test(27907328578556L, 27907245778556L, 35)
+  }
+
+  @Test def setMinutes(): Unit = {
+    def test(expected: Long, initial: Long, newValue: Int): Unit =
+      testSetter(expected, initial, newValue)(_.setMinutes(_))
+
+    test(64315845496143L, 64315845376143L, 38)
+    test(-9903546919527L, -9903548419527L, 44)
+    test(23392080130556L, 23392081210556L, 2)
+    test(-36309966906037L, -36309964086037L, 4)
+    test(-92453321669244L, -92453323769244L, 45)
+    test(26082597712442L, 26082599932442L, 1)
+    test(-13001098921998L, -13001100721998L, 37)
+    test(22808221349696L, 22808224649696L, 2)
+    test(20862412619567L, 20862412919567L, 36)
+    test(38825155309936L, 38825156029936L, 21)
+    test(-75754984947944L, -75755146887944L, 2737)
+    test(6939261825864L, 6939267885864L, -77)
+    test(3974566501322L, 3974466301322L, 1695)
+    test(-55574815076054L, -55574860316054L, 802)
+    test(-73126905171394L, -73126838511394L, -1093)
+    test(8195994590020L, 8195827190020L, 2829)
+    test(73067202776788L, 73067125496788L, 1332)
+    test(88946681407202L, 88946858467202L, -2910)
+    test(15418859258006L, 15419010818006L, -2493)
+    test(-4462950467694L, -4462950107694L, 32)
+  }
+
+  @Test def setSeconds(): Unit = {
+    def test(expected: Long, initial: Long, newValue: Int): Unit =
+      testSetter(expected, initial, newValue)(_.setSeconds(_))
+
+    test(-56862422032005L, -56862422024005L, 7)
+    test(-88709798217310L, -88709798216310L, 2)
+    test(14361189950164L, 14361189911164L, 50)
+    test(85754971234137L, 85754971231137L, 34)
+    test(-27614360099220L, -27614360084220L, 0)
+    test(-56829714919918L, -56829714945918L, 40)
+    test(22917485891028L, 22917485882028L, 11)
+    test(52726495934253L, 52726495933253L, 14)
+    test(85072081820766L, 85072081822766L, 20)
+    test(-48842660560263L, -48842660530263L, 19)
+    test(-72259899038775L, -72259901495775L, 2481)
+    test(6115199760364L, 6115197741364L, 2040)
+    test(29936731892049L, 29936730464049L, 1472)
+    test(28079228385585L, 28079227494585L, 945)
+    test(83698936996712L, 83698939936712L, -2924)
+    test(69828183263190L, 69828181733190L, 1583)
+    test(55571126137699L, 55571128069699L, -1883)
+    test(-25587489429797L, -25587491106797L, 1730)
+    test(37701620787726L, 37701623218726L, -2373)
+    test(-68282722577557L, -68282724741557L, 2202)
   }
 
   // #2392
@@ -295,6 +547,10 @@ class DateTest {
     assertEquals("Sun Dec 31 00:00:00 GMT 1899", new Date(-2209075200000L).toString())
     assertEquals("Sun Jan 05 08:01:09 GMT 1902", new Date(-2145542330500L).toString())
     assertEquals("Sat Jan 09 05:03:04 GMT 2900", new Date(29348715784999L).toString())
+
+    assertEquals("Sat Sep 13 00:00:00 GMT 275760", new Date(8640000000000001L).toString())
+    assertEquals("Sun Aug 17 07:12:55 GMT 292278994", new Date(Long.MaxValue).toString())
+    assertEquals("Sun Dec 02 16:47:04 GMT 292269055", new Date(Long.MinValue).toString())
   }
 
   @Test def toGMTString(): Unit = {
@@ -302,6 +558,10 @@ class DateTest {
     assertEquals("31 Dec 1899 00:00:00 GMT", new Date(-2209075200000L).toGMTString())
     assertEquals("5 Jan 1902 08:01:09 GMT", new Date(-2145542330500L).toGMTString())
     assertEquals("9 Jan 2900 05:03:04 GMT", new Date(29348715784999L).toGMTString())
+
+    assertEquals("13 Sep 275760 00:00:00 GMT", new Date(8640000000000001L).toGMTString())
+    assertEquals("17 Aug 292278994 07:12:55 GMT", new Date(Long.MaxValue).toGMTString())
+    assertEquals("2 Dec 292269055 16:47:04 GMT", new Date(Long.MinValue).toGMTString())
   }
 
   @Test def toLocaleString(): Unit = {
@@ -321,6 +581,10 @@ class DateTest {
     assertEquals("1899 Dec 31 00:00:00", new Date(-2209075200000L).toLocaleString())
     assertEquals("1902 Jan 5 08:01:09", new Date(-2145542330500L).toLocaleString())
     assertEquals("2900 Jan 9 05:03:04", new Date(29348715784999L).toLocaleString())
+
+    assertEquals("275760 Sep 13 00:00:00", new Date(8640000000000001L).toLocaleString())
+    assertEquals("292278994 Aug 17 07:12:55", new Date(Long.MaxValue).toLocaleString())
+    assertEquals("292269055 Dec 2 16:47:04", new Date(Long.MinValue).toLocaleString())
   }
 
   // #4131
@@ -330,30 +594,5 @@ class DateTest {
 
     val lo = new Date(-8640000000000001L)
     assertEquals(-8640000000000001L, lo.getTime())
-  }
-
-  @Test def largeToString(): Unit = {
-    assumeFalse(executingInJVM)
-    assertEquals("java.util.Date(8640000000000001)", new Date(8640000000000001L).toString())
-  }
-
-  @Test def preventsUnsafeRead(): Unit = {
-    assumeFalse(executingInJVM)
-    assertThrows(classOf[IllegalArgumentException], new Date(8640000000000001L).getDate())
-    assertThrows(classOf[IllegalArgumentException], new Date(-8640000000000001L).getDate())
-  }
-
-  @Test def preventsUnsafeWrite(): Unit = {
-    assumeFalse(executingInJVM)
-    val date = new Date(0L)
-    assertThrows(classOf[IllegalArgumentException], date.setYear(300000))
-    assertEquals(0L, date.getTime())
-    assertThrows(classOf[IllegalArgumentException], date.setYear(-300000))
-  }
-
-  @Test def preventsUnsafeConstruct(): Unit = {
-    assumeFalse(executingInJVM)
-    assertThrows(classOf[IllegalArgumentException], new Date(3000000, 1, 1))
-    assertThrows(classOf[IllegalArgumentException], Date.UTC(3000000, 1, 1, 0, 0, 0))
   }
 }

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/DateTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/DateTest.scala
@@ -19,12 +19,11 @@ import org.junit.Assume._
 import org.junit.Test
 
 import org.scalajs.testsuite.utils.AssertThrows.assertThrows
-import org.scalajs.testsuite.utils.Platform.executingInJVM
+import org.scalajs.testsuite.utils.Platform._
 
 /** tests the implementation of the java standard library Date */
 class DateTest {
   private final val MSPerHour = 60L * 60L * 1000L
-  private final val MSPerDay = 24L * MSPerHour
 
   @Test def fromUTC(): Unit = {
     assertEquals(-2209075200000L, Date.UTC(1899 - 1900, 11, 31, 0, 0, 0))
@@ -46,27 +45,23 @@ class DateTest {
   }
 
   @Test def fromLocalFields(): Unit = {
-    def test(expectedUTC: Long, date: Date): Unit = {
-      // Whatever the local timezone, we should not be more than 1 day away from UTC
-      assertTrue(Math.abs(date.getTime() - expectedUTC) <= MSPerDay)
-    }
-
-    test(-2209075200000L, new Date(1899 - 1900, 11, 31))
-    test(878534580000L, new Date(97, 10, 3, 5, 23))
-    test(-2145542331000L, new Date(2, 0, 5, 8, 1, 9))
-    test(29348715784000L, new Date(2900 - 1900, 0, 9, 5, 3, 4))
+    // The locale timezone is always GMT
+    assertEquals(-2209075200000L, new Date(1899 - 1900, 11, 31).getTime())
+    assertEquals(878534580000L, new Date(97, 10, 3, 5, 23).getTime())
+    assertEquals(-2145542331000L, new Date(2, 0, 5, 8, 1, 9).getTime())
+    assertEquals(29348715784000L, new Date(2900 - 1900, 0, 9, 5, 3, 4).getTime())
 
     // Overflow and underflow of some fields into bigger ones
-    test(1808286219000L, new Date(2026 - 1900, 15, 21, 5, 43, 39))
-    test(1763703819000L, new Date(2026 - 1900, -2, 21, 5, 43, 39))
-    test(1777959819000L, new Date(2026 - 1900, 3, 35, 5, 43, 39))
-    test(1774676619000L, new Date(2026 - 1900, 3, -3, 5, 43, 39))
-    test(1776825819000L, new Date(2026 - 1900, 3, 21, 26, 43, 39))
-    test(1776696219000L, new Date(2026 - 1900, 3, 21, -10, 43, 39))
-    test(1776751419000L, new Date(2026 - 1900, 3, 21, 5, 63, 39))
-    test(1776745119000L, new Date(2026 - 1900, 3, 21, 5, -42, 39))
-    test(1776750285000L, new Date(2026 - 1900, 3, 21, 5, 43, 105))
-    test(1776750173000L, new Date(2026 - 1900, 3, 21, 5, 43, -7))
+    assertEquals(1808286219000L, new Date(2026 - 1900, 15, 21, 5, 43, 39).getTime())
+    assertEquals(1763703819000L, new Date(2026 - 1900, -2, 21, 5, 43, 39).getTime())
+    assertEquals(1777959819000L, new Date(2026 - 1900, 3, 35, 5, 43, 39).getTime())
+    assertEquals(1774676619000L, new Date(2026 - 1900, 3, -3, 5, 43, 39).getTime())
+    assertEquals(1776825819000L, new Date(2026 - 1900, 3, 21, 26, 43, 39).getTime())
+    assertEquals(1776696219000L, new Date(2026 - 1900, 3, 21, -10, 43, 39).getTime())
+    assertEquals(1776751419000L, new Date(2026 - 1900, 3, 21, 5, 63, 39).getTime())
+    assertEquals(1776745119000L, new Date(2026 - 1900, 3, 21, 5, -42, 39).getTime())
+    assertEquals(1776750285000L, new Date(2026 - 1900, 3, 21, 5, 43, 105).getTime())
+    assertEquals(1776750173000L, new Date(2026 - 1900, 3, 21, 5, 43, -7).getTime())
   }
 
   @Test def comparisons(): Unit = {
@@ -237,10 +232,10 @@ class DateTest {
     test(1194240207000L, "noVemb 5/7 5:23:27 GMT") // 2007
     test(2298777807000L, "11/5/42 5:23:27 GMT") // 2042
 
-    // Implicit time zone -> local time zone
-    test(new Date(97, 10, 5, 5, 23, 27).getTime(), "Nov 5 1997 5:23:27")
-    test(new Date(97, 10, 1).getTime(), "Nov 1 1997")
-    test(new Date(70, 0, 1, 18, 11, 1).getTime(), "Jan 1 1970 18:11:01")
+    // Implicit time zone -> always GMT for us
+    test(878707407000L, "Nov 5 1997 5:23:27")
+    test(878342400000L, "Nov 1 1997")
+    test(65461000L, "Jan 1 1970 18:11:01")
 
     // Some time zone abbreviations are explicitly supported (mix of cases)
     val supportedTimeZones = List(
@@ -293,15 +288,13 @@ class DateTest {
 
   // #2392
   @Test def getTimezoneOffset(): Unit =
-    new Date().getTimezoneOffset // Test that it links.
+    assertEquals(0, new Date().getTimezoneOffset())
 
   @Test def toStringTest(): Unit = {
-    def test(expectedRegex: String, actual: String): Unit =
-      assertTrue(s"expected:<$expectedRegex> to match:<$actual>", actual.matches(expectedRegex))
-    test("Mon Nov 03 05:23:27 .+ 1997", new Date(97, 10, 3, 5, 23, 27).toString)
-    test("Sun Dec 31 00:00:00 .+ 1899", new Date(0, 0, 0, 0, 0, 0).toString)
-    test("Sun Jan 05 08:01:09 .+ 1902", new Date(1, 12, 5, 8, 1, 9).toString)
-    test("Sat Jan 09 05:03:04 .+ 2900", new Date(1000, 0, 9, 5, 3, 4).toString)
+    assertEquals("Mon Nov 03 05:23:27 GMT 1997", new Date(878534607567L).toString())
+    assertEquals("Sun Dec 31 00:00:00 GMT 1899", new Date(-2209075200000L).toString())
+    assertEquals("Sun Jan 05 08:01:09 GMT 1902", new Date(-2145542330500L).toString())
+    assertEquals("Sat Jan 09 05:03:04 GMT 2900", new Date(29348715784999L).toString())
   }
 
   @Test def toGMTString(): Unit = {
@@ -309,6 +302,25 @@ class DateTest {
     assertEquals("31 Dec 1899 00:00:00 GMT", new Date(-2209075200000L).toGMTString())
     assertEquals("5 Jan 1902 08:01:09 GMT", new Date(-2145542330500L).toGMTString())
     assertEquals("9 Jan 2900 05:03:04 GMT", new Date(29348715784999L).toGMTString())
+  }
+
+  @Test def toLocaleString(): Unit = {
+    /* On JDK 8, the results are of the form "Nov 3, 1997 5:23:27 AM". That
+     * corresponds to the pattern of a DateFormat string obtained with
+     *   DateFormat.getDateTimeInstance(DateFormat.MEDIUM, DateFormat.MEDIUM, Locale.ENGLISH)
+     *
+     * On JDK 11+, and in our implementation, we get the format below, which
+     * corresponds to the pattern "y MMM d HH:mm:ss", which we get with
+     *   DateFormat.getDateTimeInstance(DateFormat.MEDIUM, DateFormat.MEDIUM, Locale.ROOT)
+     */
+    assumeFalse(
+        "JDK 8 did not abide by the default Locale rules yet",
+        executingInJVMOnLowerThanJDK(11))
+
+    assertEquals("1997 Nov 3 05:23:27", new Date(878534607567L).toLocaleString())
+    assertEquals("1899 Dec 31 00:00:00", new Date(-2209075200000L).toLocaleString())
+    assertEquals("1902 Jan 5 08:01:09", new Date(-2145542330500L).toLocaleString())
+    assertEquals("2900 Jan 9 05:03:04", new Date(29348715784999L).toLocaleString())
   }
 
   // #4131

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/DateTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/DateTest.scala
@@ -23,64 +23,110 @@ import org.scalajs.testsuite.utils.Platform.executingInJVM
 
 /** tests the implementation of the java standard library Date */
 class DateTest {
+  private final val MSPerDay = 24 * 60 * 60 * 1000
 
-  @Test def compareTo(): Unit = {
-    def compare(x: Date, y: Date): Int =
-      x.compareTo(y)
+  @Test def fromUTC(): Unit = {
+    assertEquals(-2209075200000L, Date.UTC(1899 - 1900, 11, 31, 0, 0, 0))
+    assertEquals(878534607000L, Date.UTC(97, 10, 3, 5, 23, 27))
+    assertEquals(-2145542331000L, Date.UTC(2, 0, 5, 8, 1, 9))
+    assertEquals(29348715784000L, Date.UTC(2900 - 1900, 0, 9, 5, 3, 4))
 
-    assertTrue(compare(new Date(97, 11, 5, 0, 0), new Date(98, 11, 5, 0, 0)) < 0)
-    assertTrue(compare(new Date(98, 11, 5, 0, 0), new Date(97, 11, 5, 0, 0)) > 0)
-    assertEquals(0, compare(new Date(97, 11, 5, 0, 0), new Date(97, 11, 5)))
-    assertTrue(compare(new Date(97, 11, 5, 0, 0), new Date(97, 11, 5, 0, 1)) < 0)
-    assertEquals(0, compare(new Date(97, 11, 5), new Date(97, 11, 5, 0, 0)))
+    // Overflow and underflow of some fields into bigger ones
+    assertEquals(1808286219000L, Date.UTC(2026 - 1900, 15, 21, 5, 43, 39))
+    assertEquals(1763703819000L, Date.UTC(2026 - 1900, -2, 21, 5, 43, 39))
+    assertEquals(1777959819000L, Date.UTC(2026 - 1900, 3, 35, 5, 43, 39))
+    assertEquals(1774676619000L, Date.UTC(2026 - 1900, 3, -3, 5, 43, 39))
+    assertEquals(1776825819000L, Date.UTC(2026 - 1900, 3, 21, 26, 43, 39))
+    assertEquals(1776696219000L, Date.UTC(2026 - 1900, 3, 21, -10, 43, 39))
+    assertEquals(1776751419000L, Date.UTC(2026 - 1900, 3, 21, 5, 63, 39))
+    assertEquals(1776745119000L, Date.UTC(2026 - 1900, 3, 21, 5, -42, 39))
+    assertEquals(1776750285000L, Date.UTC(2026 - 1900, 3, 21, 5, 43, 105))
+    assertEquals(1776750173000L, Date.UTC(2026 - 1900, 3, 21, 5, 43, -7))
   }
 
-  @Test def comparable(): Unit = {
-    def compare(x: Any, y: Any): Int =
-      x.asInstanceOf[Comparable[Any]].compareTo(y)
+  @Test def fromLocalFields(): Unit = {
+    def test(expectedUTC: Long, date: Date): Unit = {
+      // Whatever the local timezone, we should not be more than 1 day away from UTC
+      assertTrue(Math.abs(date.getTime() - expectedUTC) <= MSPerDay)
+    }
 
-    assertTrue(compare(new Date(97, 11, 5, 0, 0), new Date(98, 11, 5, 0, 0)) < 0)
-    assertTrue(compare(new Date(98, 11, 5, 0, 0), new Date(97, 11, 5, 0, 0)) > 0)
-    assertEquals(0, compare(new Date(97, 11, 5, 0, 0), new Date(97, 11, 5)))
-    assertTrue(compare(new Date(97, 11, 5, 0, 0), new Date(97, 11, 5, 0, 1)) < 0)
-    assertEquals(0, compare(new Date(97, 11, 5), new Date(97, 11, 5, 0, 0)))
+    test(-2209075200000L, new Date(1899 - 1900, 11, 31))
+    test(878534580000L, new Date(97, 10, 3, 5, 23))
+    test(-2145542331000L, new Date(2, 0, 5, 8, 1, 9))
+    test(29348715784000L, new Date(2900 - 1900, 0, 9, 5, 3, 4))
+
+    // Overflow and underflow of some fields into bigger ones
+    test(1808286219000L, new Date(2026 - 1900, 15, 21, 5, 43, 39))
+    test(1763703819000L, new Date(2026 - 1900, -2, 21, 5, 43, 39))
+    test(1777959819000L, new Date(2026 - 1900, 3, 35, 5, 43, 39))
+    test(1774676619000L, new Date(2026 - 1900, 3, -3, 5, 43, 39))
+    test(1776825819000L, new Date(2026 - 1900, 3, 21, 26, 43, 39))
+    test(1776696219000L, new Date(2026 - 1900, 3, 21, -10, 43, 39))
+    test(1776751419000L, new Date(2026 - 1900, 3, 21, 5, 63, 39))
+    test(1776745119000L, new Date(2026 - 1900, 3, 21, 5, -42, 39))
+    test(1776750285000L, new Date(2026 - 1900, 3, 21, 5, 43, 105))
+    test(1776750173000L, new Date(2026 - 1900, 3, 21, 5, 43, -7))
+  }
+
+  @Test def comparisons(): Unit = {
+    def assertCompare(expectedSign: Int, tx: Long, ty: Long): Unit = {
+      val x = new Date(tx)
+      val y = new Date(ty)
+      assertEquals(expectedSign, Integer.signum(x.compareTo(y)))
+
+      // also check that ju.Date implements Comparable
+      val cx: Comparable[Date] = x
+      assertEquals(expectedSign, Integer.signum(cx.compareTo(y)))
+
+      assertEquals(expectedSign > 0, x.after(y))
+      assertEquals(expectedSign < 0, x.before(y))
+    }
+
+    assertCompare(-1, 881280000000L, 912816000000L)
+    assertCompare(1, 912816000000L, 881280000000L)
+    assertCompare(0, 881280000000L, 881280000000L)
+    assertCompare(-1, -912816000000L, 881280000000L)
+    assertCompare(1, 881280000000L, -912816000000L)
+    assertCompare(-1, Long.MinValue, 0L)
+    assertCompare(1, Long.MaxValue, 0L)
   }
 
   @Test def parseStrings(): Unit = {
-    def test(s: String, v: Date): Unit = {
-      assertEquals(0, new Date(s).compareTo(v))
-      assertEquals(0, Date.parse(s).compareTo(v.getTime))
+    def test(expected: Long, s: String): Unit = {
+      assertEquals(s, expected, new Date(s).getTime())
+      assertEquals(s, expected, Date.parse(s))
     }
 
-    test("Nov 5 1997 5:23:27 GMT", new Date(Date.UTC(97, 10, 5, 5, 23, 27)))
-    test("Nov 1 1997 GMT", new Date(Date.UTC(97, 10, 1, 0, 0, 0)))
-    test("Jan 1 1970 18:11:01 GMT", new Date(Date.UTC(70, 0, 1, 18, 11, 1)))
+    def testFailure(s: String): Unit = {
+      assertThrows(classOf[IllegalArgumentException], new Date(s))
+      assertThrows(classOf[IllegalArgumentException], Date.parse(s))
+    }
 
-    assertThrows(classOf[IllegalArgumentException], new Date("not a date"))
-    assertThrows(classOf[IllegalArgumentException], Date.parse("not a date"))
-  }
+    // Explicit GMT time zone
+    test(878707407000L, "Nov 5 1997 5:23:27 GMT")
+    test(878342400000L, "Nov 1 1997 GMT")
+    test(65461000L, "Jan 1 1970 18:11:01 GMT")
+    test(878707407000L, "Nov 5 1997 (ig(no)ré) 5:23:27 GMT")
 
-  @Test def after(): Unit = {
-    assertFalse(new Date(97, 11, 5, 0, 0).after(new Date(98, 11, 5, 0, 0)))
-    assertTrue(new Date(99, 11, 5, 0, 0).after(new Date(98, 11, 5, 0, 0)))
-    assertFalse(new Date(99, 11, 5, 0, 0).after(new Date(99, 11, 5, 0, 0)))
-  }
+    // Implicit time zone -> local time zone
+    test(new Date(97, 10, 5, 5, 23, 27).getTime(), "Nov 5 1997 5:23:27")
+    test(new Date(97, 10, 1).getTime(), "Nov 1 1997")
+    test(new Date(70, 0, 1, 18, 11, 1).getTime(), "Jan 1 1970 18:11:01")
 
-  @Test def before(): Unit = {
-    assertTrue(new Date(97, 11, 5, 0, 0).before(new Date(98, 11, 5, 0, 0)))
-    assertFalse(new Date(99, 11, 5, 0, 0).before(new Date(98, 11, 5, 0, 0)))
-    assertFalse(new Date(99, 11, 5, 0, 0).before(new Date(99, 11, 5, 0, 0)))
+    testFailure("not a date")
   }
 
   @Test def cloneTest(): Unit = {
-    def testClone(date: Date): Boolean = {
+    def testClone(time: Long): Unit = {
+      val date = new Date(time)
       val cloned = date.clone()
-      date == cloned
+      assertNotSame(date, cloned)
+      assertEquals(date, cloned)
     }
 
-    assertTrue(testClone(new Date(97, 11, 5, 0, 0)))
-    assertTrue(testClone(new Date(92, 14, 6, 2, 1)))
-    assertTrue(testClone(new Date(4, 1, 2, 3, 0, 0)))
+    testClone(881276400000L)
+    testClone(731379660000L)
+    testClone(-2080072800000L)
   }
 
   @Test def getYear(): Unit = {
@@ -108,10 +154,10 @@ class DateTest {
   }
 
   @Test def toGMTString(): Unit = {
-    assertEquals("31 Dec 1899 00:00:00 GMT", new Date(Date.UTC(0, 0, 0, 0, 0, 0)).toGMTString)
-    assertEquals("3 Nov 1997 05:23:27 GMT", new Date(Date.UTC(97, 10, 3, 5, 23, 27)).toGMTString)
-    assertEquals("5 Jan 1902 08:01:09 GMT", new Date(Date.UTC(1, 12, 5, 8, 1, 9)).toGMTString)
-    assertEquals("9 Jan 2900 05:03:04 GMT", new Date(Date.UTC(1000, 0, 9, 5, 3, 4)).toGMTString)
+    assertEquals("3 Nov 1997 05:23:27 GMT", new Date(878534607567L).toGMTString())
+    assertEquals("31 Dec 1899 00:00:00 GMT", new Date(-2209075200000L).toGMTString())
+    assertEquals("5 Jan 1902 08:01:09 GMT", new Date(-2145542330500L).toGMTString())
+    assertEquals("9 Jan 2900 05:03:04 GMT", new Date(29348715784999L).toGMTString())
   }
 
   // #4131

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/DateTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/DateTest.scala
@@ -23,7 +23,8 @@ import org.scalajs.testsuite.utils.Platform.executingInJVM
 
 /** tests the implementation of the java standard library Date */
 class DateTest {
-  private final val MSPerDay = 24 * 60 * 60 * 1000
+  private final val MSPerHour = 60L * 60L * 1000L
+  private final val MSPerDay = 24L * MSPerHour
 
   @Test def fromUTC(): Unit = {
     assertEquals(-2209075200000L, Date.UTC(1899 - 1900, 11, 31, 0, 0, 0))
@@ -108,10 +109,160 @@ class DateTest {
     test(65461000L, "Jan 1 1970 18:11:01 GMT")
     test(878707407000L, "Nov 5 1997 (ig(no)ré) 5:23:27 GMT")
 
+    // Unbalanced parentheses
+    test(878688000000L, "Nov 5 1997 GMT (ig(noré) 5:23:27") // not closed -> ignore until EOF
+    testFailure("Nov 5 1997 GMT (ig(no)ré)) 5:23:27") // too many closed -> failure
+
+    // Parentheses separate numbers from their 'next' char, causing a failure
+    testFailure("Nov 5() 1997 GMT 5:23:27")
+    testFailure("Nov 5 1997() GMT 5:23:27")
+    testFailure("Nov 5 1997 GMT 5():23:27")
+    testFailure("Nov 5 1997 GMT 5:23():27")
+    testFailure("Nov 5 1997 GMT 5:23:27()")
+
+    // Explicit time zone offsets
+    test(878689407000L, "Nov 5 1997 5:23:27 +5")
+    test(878725407000L, "Nov 5 1997 5:23:27 -5")
+    test(878414400000L, "Nov 1 1997 utc-20")
+    test(-11939000L, "Jan 1 1970 18:11:01 +2130")
+    test(878711907000L, "Nov 5 1997 (ig(no)ré) 5:23:27 GMT-0115")
+
+    // The JVM allows parens and other neutral chars between +/- and the offset. We don't.
+    if (!executingInJVM) {
+      testFailure("Nov 5 1997 5:23:27 +()5")
+      testFailure("Nov 5 1997 5:23:27 - 5")
+      testFailure("Nov 5 1997 5:23:27 -(foo)5")
+      testFailure("Nov 5 1997 5:23:27 -,5")
+    }
+
+    /* If there are several time zones, the last one wins
+     * (which is why GMT-0115 works without dedicated code paths, btw).
+     */
+    test(878711907000L, "Nov 5 1997 GMT 5:23:27 -0115")
+    test(878725407000L, "Nov 5 1997 +0 GMT -0115 EST 5:23:27")
+    test(878725407000L, "Nov 5 1997 +0 GMT EST 5:23:27")
+    test(878707407000L, "Nov 5 1997 +0 -0115 EST GMT 5:23:27")
+    test(878689407000L, "Nov 5 1997 +0 EST GMT 5:23:27 +5")
+    test(878689407000L, "Nov 5 1997 +0 +5 5:23:27")
+
+    // Duplicate + or -
+    test(878689407000L, "Nov 5 1997 5:23:27 ++5")
+    test(878414400000L, "Nov 1 1997 utc--20")
+
+    // But a time zone offset is rejected if the last time zone so far is non-UTC (out of spec)
+    testFailure("Nov 5 1997 +0 -0115 +5 5:23:27")
+    testFailure("Nov 5 1997 +0 EST -0115 GMT 5:23:27")
+
+    // 12-hour format
+    test(878707407000L, "Nov 5 1997 5:23:27 AM GMT")
+    test(878750607000L, "Nov 5 1997 5:23:27 pM GMT")
+    test(878750607000L, "Nov 5 1997 5:23:27 am pm GMT")
+    test(878707407000L, "Nov 5 1997 5:23:27 AM AM GMT")
+    testFailure("Nov 5 1997 15:23:27 AM GMT")
+    testFailure("Nov 5 1997 5:23:27 pm am GMT")
+    testFailure("Nov 5 1997 5:23:27 PM PM GMT")
+    testFailure("Nov 5 1997 AM 5:23:27 GMT")
+    testFailure("Nov 5 1997 0:23:27 AM GMT")
+    testFailure("Nov 5 1997 0:23:27 PM GMT")
+
+    // Some other formats
+    test(878711007000L, "5 Nov 1997 6:23:27 GMT")
+    test(878711007000L, "11/5/1997 6:23:27 GMT")
+    test(878711007000L, "11/5/1997/ 6:23:27 GMT")
+    test(878711007000L, "Nov 5 Thu 1997 6:  23:  27 GMT") // It was a Wednesday, actually
+    test(878711007000L, "Nov 5 1997 6:23:27 GMT")
+    test(878711007000L, "Nov 5 1997 6:23 :27 GMT")
+
+    // Cases where we end up choosing a field that was already recognized
+    testFailure("Nov 5 1997 6 :23:27 GMT") // 6 is interpreted as dayOfMonth
+    testFailure("Nov 5 1997 6:23:27: GMT") // 27 is interpreted as minute
+    testFailure("11/5/7/ 6:23:27 GMT") // 7 is interpreted as dayOfMonth
+    testFailure("5 10 March 6:23:27 +1") // 10 wants to be a year, but we have no month yet
+
+    // Other separators
+    test(878707407000L, "5\tNov\n1997 5:23:27 GMT")
+    test(878707407000L, "1997, 5\rNov 5:23:27 GMT")
+    test(878707407000L, "5\tNov\n1997 5:23,27 GMT")
+
+    // Duplicate separators
+    test(878711007000L, "5 Nov /1997 6:23:27 GMT")
+    test(878711007000L, "11/5//1997 6::23:27 GMT")
+    test(878711007000L, "11/5/1997/ 6:23::27 GMT")
+    test(878711007000L, "1997, , 11/5 6:23:27 GMT")
+
+    // Number followed by anything but the allowed separators is failure (incl. ASCII letter)
+    testFailure("5@Nov 1997 5:23:27 GMT")
+    testFailure("5Nov 1997 5:23:27 GMT")
+    testFailure("5=Nov 1997 5:23:27 GMT")
+    testFailure("5+Nov 1997 5:23:27 GMT")
+    testFailure("5 Nov 1997 5^23:27 GMT")
+    testFailure("5 Nov 1997 5:23\\27 GMT")
+    testFailure("5 Nov 1997 5:23:27# GMT")
+
+    // Various prefixes
+    test(878707407000L, "No 5 1997 5:23:27 GMT")
+    test(876029007000L, "October 5 1997 sunday 5:23:27 GMT")
+    test(876029007000L, "Oct5 1997 sunday5:23:27 GMT")
+
+    // 1-letter prefix is not allowed (out of spec)
+    testFailure("J 5 1997 5:23:27 GMT")
+
+    /* The JavaDoc specifically calls out
+     * > So is Ma, which is recognized as MARCH, not MAY.
+     * but the JDK answers May ...
+     */
+    if (executingInJVM)
+      test(862809807000L, "ma 5 1997 5:23:27 GMT") // oops, that's May
+    else
+      test(857539407000L, "ma 5 1997 5:23:27 GMT") // March, not May
+
+    // We can omit time components
+    test(878707380000L, "Nov 5 1997 5:23 GMT")
+    test(878706000000L, "Nov 5 1997 5: GMT")
+    test(878688000000L, "Nov 5 1997 GMT")
+
+    // But not date components
+    testFailure("Nov 5 GMT") // no year
+    testFailure("5 1997 5:23:27 GMT") // no month
+    testFailure("10/ 1997 5:23:27 GMT") // no day
+
+    /* To reject this, we must not interpret a number as a year if it follows
+     * or precedes a ':'. It makes sense, but it's out of spec.
+     */
+    testFailure("Nov 5 5:23:27 GMT")
+
+    // Year smaller than 100, time-dependent
+    // These tests will start failing in 2078 (since 2078 - 80 > 1997)
+    test(878707407000L, "5 Nov 97 5:23:27 GMT") // 1997
+    test(1194240207000L, "noVemb 5/7 5:23:27 GMT") // 2007
+    test(2298777807000L, "11/5/42 5:23:27 GMT") // 2042
+
     // Implicit time zone -> local time zone
     test(new Date(97, 10, 5, 5, 23, 27).getTime(), "Nov 5 1997 5:23:27")
     test(new Date(97, 10, 1).getTime(), "Nov 1 1997")
     test(new Date(70, 0, 1, 18, 11, 1).getTime(), "Jan 1 1970 18:11:01")
+
+    // Some time zone abbreviations are explicitly supported (mix of cases)
+    val supportedTimeZones = List(
+      "GMT" -> 0,
+      "UT" -> 0,
+      "utc" -> 0,
+      "Est" -> -5,
+      "cSt" -> -6,
+      "MsT" -> -7,
+      "pst" -> -8,
+      "eDT" -> -4,
+      "CDt" -> -5,
+      "MdT" -> -6,
+      "PDT" -> -7
+    )
+    for ((tzName, offset) <- supportedTimeZones) {
+      test(1774089000000L - offset * MSPerHour, s"Mar 21 2026 10:30 $tzName")
+    }
+
+    // But other abbreviations are not
+    for (tzName <- List("CET", "JST", "cest"))
+      testFailure(s"Mar 21 2026 10:30 $tzName")
 
     testFailure("not a date")
   }

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/DateTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/DateTest.scala
@@ -191,5 +191,6 @@ class DateTest {
   @Test def preventsUnsafeConstruct(): Unit = {
     assumeFalse(executingInJVM)
     assertThrows(classOf[IllegalArgumentException], new Date(3000000, 1, 1))
+    assertThrows(classOf[IllegalArgumentException], Date.UTC(3000000, 1, 1, 0, 0, 0))
   }
 }


### PR DESCRIPTION
This is a policy decision, which standardizes on GMT as the default timezone for every Scala.js codebase.

This policy is in line with other things thar are normally environment-dependent on the JVM:

* The default locale is always `ROOT`.
* The default encoding is always UTF-8.
* The default line separator is always `\n`.
* And now the default timezone is always Etc/GMT.

---

The implementation without JS interop also fixes several issues that are unfixable with `js.Date`:

* We are freed from the range limitation of `js.Date`.
* We correctly handle the Julian half of the timeline (`js.Date` is Gregorian-only, while `ju.Date` is Julian/Gregorian).
* We do not suffer from subtle precision errors surfaced by the (specified) calculations in `Double`s of `js.Date`.

In addition, this implementation will work in Wasm without a JS host.

---

~~WiP because needs more tests, especially of the Julian calendar and of `set*` methods.~~