### PR TITLE
Opt: Manually optimize range checks in the javalib.

### DIFF
--- a/javalib/src/main/scala/java/io/BufferedReader.scala
+++ b/javalib/src/main/scala/java/io/BufferedReader.scala
@@ -69,8 +69,7 @@ class BufferedReader(in: Reader, sz: Int) extends Reader {
   override def read(cbuf: Array[Char], off: Int, len: Int): Int = {
     ensureOpen()
 
-    if (off < 0 || len < 0 || len > cbuf.length - off)
-      throw new IndexOutOfBoundsException
+    BoundsChecks.checkOffsetCount(off, len, cbuf.length)
 
     if (len == 0) 0
     else if (prepareRead()) {

--- a/javalib/src/main/scala/java/io/ByteArrayInputStream.scala
+++ b/javalib/src/main/scala/java/io/ByteArrayInputStream.scala
@@ -34,8 +34,7 @@ class ByteArrayInputStream(
   }
 
   override def read(b: Array[Byte], off: Int, reqLen: Int): Int = {
-    if (off < 0 || reqLen < 0 || reqLen > b.length - off)
-      throw new IndexOutOfBoundsException
+    BoundsChecks.checkOffsetCount(off, reqLen, b.length)
 
     if (pos == count) {
       /* There is nothing left to read.

--- a/javalib/src/main/scala/java/io/ByteArrayOutputStream.scala
+++ b/javalib/src/main/scala/java/io/ByteArrayOutputStream.scala
@@ -30,8 +30,7 @@ class ByteArrayOutputStream(initBufSize: Int) extends OutputStream {
   }
 
   override def write(b: Array[Byte], off: Int, len: Int): Unit = {
-    if (off < 0 || len < 0 || len > b.length - off)
-      throw new IndexOutOfBoundsException()
+    BoundsChecks.checkOffsetCount(off, len, b.length)
 
     if (count + len > buf.length)
       growBuf(len)

--- a/javalib/src/main/scala/java/io/CharArrayReader.scala
+++ b/javalib/src/main/scala/java/io/CharArrayReader.scala
@@ -13,7 +13,10 @@
 package java.io
 
 class CharArrayReader(protected var buf: Array[Char], offset: Int, length: Int) extends Reader {
-  if (offset < 0 || offset > buf.length || length < 0 || offset + length < 0)
+  /* Non-standard bounds checks: we must tolerate offset+length > buf.length,
+   * and we throw a different type of exception.
+   */
+  if ((offset | length | (offset + length) | (buf.length - offset)) < 0)
     throw new IllegalArgumentException
 
   protected var pos: Int = offset
@@ -47,11 +50,7 @@ class CharArrayReader(protected var buf: Array[Char], offset: Int, length: Int) 
   }
 
   override def read(buffer: Array[Char], offset: Int, len: Int): Int = {
-    if (offset < 0 || offset > buffer.length)
-      throw new IndexOutOfBoundsException("Offset out of bounds : " + offset)
-
-    if (len < 0 || len > buffer.length - offset)
-      throw new IndexOutOfBoundsException("Length out of bounds : " + len)
+    BoundsChecks.checkOffsetCount(offset, len, buffer.length)
 
     ensureOpen()
 

--- a/javalib/src/main/scala/java/io/CharArrayWriter.scala
+++ b/javalib/src/main/scala/java/io/CharArrayWriter.scala
@@ -42,8 +42,7 @@ class CharArrayWriter(initialSize: Int) extends Writer {
   override def toString(): String = new String(this.buf, 0, this.count)
 
   override def write(c: Array[Char], offset: Int, len: Int): Unit = {
-    if (offset < 0 || offset > c.length || len < 0 || len > c.length - offset)
-      throw new IndexOutOfBoundsException
+    BoundsChecks.checkOffsetCount(offset, len, c.length)
 
     ensureCapacity(len)
     System.arraycopy(c, offset, this.buf, this.count, len)
@@ -57,11 +56,10 @@ class CharArrayWriter(initialSize: Int) extends Writer {
   }
 
   override def write(str: String, offset: Int, len: Int): Unit = {
-    if (offset < 0 || offset > str.length || len < 0 || len > str.length - offset)
-      throw new IndexOutOfBoundsException
+    val endOffset = BoundsChecks.checkOffsetCount(offset, len, str.length())
 
     ensureCapacity(len)
-    str.getChars(offset, offset + len, this.buf, this.count)
+    str.getChars(offset, endOffset, this.buf, this.count)
     this.count += len
   }
 

--- a/javalib/src/main/scala/java/io/DataInputStream.scala
+++ b/javalib/src/main/scala/java/io/DataInputStream.scala
@@ -46,8 +46,7 @@ class DataInputStream(in: InputStream) extends FilterInputStream(in) with DataIn
   def readFully(b: Array[Byte]): Unit = readFully(b, 0, b.length)
 
   def readFully(b: Array[Byte], off: Int, len: Int): Unit = {
-    if (off < 0 || len < 0 || off + len > b.length)
-      throw new IndexOutOfBoundsException()
+    BoundsChecks.checkOffsetCount(off, len, b.length)
 
     var remaining = len
     var offset = off

--- a/javalib/src/main/scala/java/io/InputStream.scala
+++ b/javalib/src/main/scala/java/io/InputStream.scala
@@ -21,8 +21,7 @@ abstract class InputStream extends Closeable {
   def read(b: Array[Byte]): Int = read(b, 0, b.length)
 
   def read(b: Array[Byte], off: Int, len: Int): Int = {
-    if (off < 0 || len < 0 || len > b.length - off)
-      throw new IndexOutOfBoundsException
+    BoundsChecks.checkOffsetCount(off, len, b.length)
 
     if (len == 0) 0
     else {
@@ -94,8 +93,7 @@ abstract class InputStream extends Closeable {
   }
 
   def readNBytes(b: Array[Byte], off: Int, len: Int): Int = {
-    if (off < 0 || len < 0 || len > b.length - off)
-      throw new IndexOutOfBoundsException
+    BoundsChecks.checkOffsetCount(off, len, b.length)
 
     var bytesRead = 0
     var lastRead = 0

--- a/javalib/src/main/scala/java/io/InputStreamReader.scala
+++ b/javalib/src/main/scala/java/io/InputStreamReader.scala
@@ -80,8 +80,7 @@ class InputStreamReader(private[this] var in: InputStream,
   def read(cbuf: Array[Char], off: Int, len: Int): Int = {
     ensureOpen()
 
-    if (off < 0 || len < 0 || len > cbuf.length - off)
-      throw new IndexOutOfBoundsException
+    BoundsChecks.checkOffsetCount(off, len, cbuf.length)
 
     if (len == 0) {
       0

--- a/javalib/src/main/scala/java/io/OutputStream.scala
+++ b/javalib/src/main/scala/java/io/OutputStream.scala
@@ -19,11 +19,8 @@ abstract class OutputStream extends Object with Closeable with Flushable {
     write(b, 0, b.length)
 
   def write(b: Array[Byte], off: Int, len: Int): Unit = {
-    if (off < 0 || len < 0 || len > b.length - off)
-      throw new IndexOutOfBoundsException()
-
+    val stop = BoundsChecks.checkOffsetCount(off, len, b.length)
     var n = off
-    val stop = off + len
     while (n < stop) {
       write(b(n))
       n += 1
@@ -56,8 +53,7 @@ object OutputStream {
     override def write(b: Array[Byte], off: Int, len: Int): Unit = {
       ensureOpen()
 
-      if (off < 0 || len < 0 || len > b.length - off)
-        throw new IndexOutOfBoundsException()
+      BoundsChecks.checkOffsetCount(off, len, b.length)
     }
 
     override def close(): Unit =

--- a/javalib/src/main/scala/java/io/StringReader.scala
+++ b/javalib/src/main/scala/java/io/StringReader.scala
@@ -44,8 +44,7 @@ class StringReader(s: String) extends Reader {
   override def read(cbuf: Array[Char], off: Int, len: Int): Int = {
     ensureOpen()
 
-    if (off < 0 || len < 0 || len > cbuf.length - off)
-      throw new IndexOutOfBoundsException
+    BoundsChecks.checkOffsetCount(off, len, cbuf.length)
 
     if (len == 0) 0
     else {

--- a/javalib/src/main/scala/java/lang/BoundsChecks.scala
+++ b/javalib/src/main/scala/java/lang/BoundsChecks.scala
@@ -1,0 +1,152 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
+package java.lang
+
+import scala.language.implicitConversions
+
+import java.util.function._
+
+import scala.scalajs.js
+import scala.scalajs.js.annotation._
+
+/** Utilities to perform bounds checks. */
+private[java] object BoundsChecks {
+
+  /* All the tests optimize for the happy path, where all values are valid.
+   *
+   * Throwing the exceptions is always extracted in a separate @noinline
+   * helper. We do this so that we can construct good error message without
+   * fear of duplicating that code everywhere.
+   *
+   * We explicitly write `BoundsChecks.*` so that the outer `LoadModule` for
+   * `BoundsChecks` can be removed, and the module is only loaded inside the
+   * failure path.
+   */
+
+  /** Checks that `capacity >= 0`.
+   *
+   *  If the conditions do not hold, throw an `IllegalArgumentException`.
+   */
+  @inline
+  def checkCapacity(capacity: Int): Unit = {
+    if (capacity < 0)
+      BoundsChecks.throwIllegalCapacityException(capacity)
+  }
+
+  @noinline
+  private def throwIllegalCapacityException(capacity: Int): Nothing =
+    throw new IllegalArgumentException(s"Illegal capacity: $capacity")
+
+  /** Checks that `0 <= index < length` hold.
+   *
+   *  If the conditions do not hold, throw an `IndexOutOfBoundsException`.
+   *
+   *  Assumes that `length >= 0`.
+   */
+  @inline
+  def checkIndex(index: Int, length: Int): Unit = {
+    if (isIndexInvalid(index, length))
+      BoundsChecks.throwIOOBE(index, length)
+  }
+
+  @noinline
+  private def throwIOOBE(index: Int, length: Int): Nothing =
+    throw new IndexOutOfBoundsException(s"Index $index out of bounds [0, $length)")
+
+  /** Returns true if the inequalities `0 <= index < length` do *not* hold.
+   *
+   *  Assumes `length >= 0`.
+   */
+  @inline
+  def isIndexInvalid(index: Int, length: Int): scala.Boolean =
+    Integer.unsigned_>=(index, length)
+
+  /** Checks that `0 <= index <= length` hold.
+   *
+   *  If the conditions do not hold, throw an `IndexOutOfBoundsException`.
+   *
+   *  Assumes that `length >= 0`.
+   */
+  @inline
+  def checkIndexInclusive(index: Int, length: Int): Unit = {
+    if (isIndexInclusiveInvalid(index, length))
+      BoundsChecks.throwInclusiveIOOBE(index, length)
+  }
+
+  @noinline
+  private def throwInclusiveIOOBE(index: Int, length: Int): Nothing =
+    throw new IndexOutOfBoundsException(s"Index $index out of bounds [0, $length]")
+
+  /** Returns true if the inequalities `0 <= index <= length` do *not* hold.
+   *
+   *  Assumes `length >= 0`.
+   */
+  @inline
+  def isIndexInclusiveInvalid(index: Int, length: Int): scala.Boolean =
+    Integer.unsigned_>(index, length)
+
+  /** Checks that `0 <= start <= end <= length` hold.
+   *
+   *  If the conditions do not hold, throw an `IndexOutOfBoundsException`.
+   *
+   *  Assumes that `length >= 0`.
+   *
+   *  @return `end - start`, the number of elements in the range.
+   */
+  @inline
+  def checkStartEnd(start: Int, end: Int, length: Int): Int = {
+    val count = end - start
+    if (isStartCountEndInvalid(start, count, end, length))
+      BoundsChecks.throwStartEndOOBE(start, end, length)
+    count
+  }
+
+  @noinline
+  private def throwStartEndOOBE(start: Int, end: Int, length: Int): Nothing =
+    throw new IndexOutOfBoundsException(s"Range [$start, $end) out of bounds [0, $length)")
+
+  /** Checks that offset >= 0, count >= 0 and offset + count <= length.
+   *
+   *  Where `offset + count` is understood as the mathematical (non-wrapping)
+   *  addition.
+   *
+   *  If the conditions do not hold, throw an `IndexOutOfBoundsException`.
+   *
+   *  Assumes that `length >= 0`.
+   *
+   *  @return `offset + count`, the end index of the range.
+   */
+  @inline
+  def checkOffsetCount(offset: Int, count: Int, length: Int): Int = {
+    val endOffset = offset + count
+    if (isStartCountEndInvalid(offset, count, endOffset, length))
+      BoundsChecks.throwOffsetCountOOBE(offset, count, length)
+    endOffset
+  }
+
+  @noinline
+  private def throwOffsetCountOOBE(offset: Int, count: Int, length: Int): Nothing = {
+    throw new IndexOutOfBoundsException(
+        s"Range [$offset, $offset + $count) out of bounds [0, $length)")
+  }
+
+  /** Returns true if any of the inequalities `0 <= start <= end <= length` or
+   *  `0 <= count <= length - start` does *not* hold.
+   *
+   *  Assumes `length >= 0`, as well as `end == start + count` (equivalently,
+   *  `count = end - start`).
+   */
+  @inline
+  def isStartCountEndInvalid(start: Int, count: Int, end: Int, length: Int): scala.Boolean =
+    (start | count | end | (length - end)) < 0
+}

--- a/javalib/src/main/scala/java/lang/Character.scala
+++ b/javalib/src/main/scala/java/lang/Character.scala
@@ -221,8 +221,8 @@ object Character {
 
   @noinline
   def codePointAt(a: Array[Char], index: Int, limit: Int): Int = {
-    // implicit null check and bounds check
-    if (!(limit <= a.length && 0 <= index && index < limit))
+    // Non-standard bounds checks: 0 <= index < limit <= a.length
+    if (Integer.unsigned_>(limit, a.length) || Integer.unsigned_>=(index, limit))
       throw new IndexOutOfBoundsException()
 
     if (index == limit - 1)
@@ -255,8 +255,8 @@ object Character {
 
   @noinline
   def codePointBefore(a: Array[Char], index: Int, start: Int): Int = {
-    // implicit null check and bounds check
-    if (!(index <= a.length && 0 <= start && start < index))
+    // Non-standard bounds checks: 0 <= start < index <= a.length
+    if (Integer.unsigned_>(index, a.length) || Integer.unsigned_>=(start, index))
       throw new IndexOutOfBoundsException()
 
     if (index == start + 1)
@@ -302,20 +302,26 @@ object Character {
   }
 
   @noinline
-  def codePointCount(seq: CharSequence, beginIndex: Int, endIndex: Int): Int =
-    codePointCountImpl(seq, beginIndex, endIndex)
+  def codePointCount(seq: CharSequence, beginIndex: Int, endIndex: Int): Int = {
+    val count = BoundsChecks.checkStartEnd(beginIndex, endIndex, seq.length())
+    codePointCountInternal(seq, beginIndex, count, endIndex)
+  }
 
   @noinline
-  def codePointCount(a: Array[Char], offset: Int, count: Int): Int =
-    codePointCountImpl(CharSequence.ofArray(a), offset, offset + count)
+  def codePointCount(a: Array[Char], offset: Int, count: Int): Int = {
+    val endOffset = BoundsChecks.checkOffsetCount(offset, count, a.length)
+    codePointCountInternal(CharSequence.ofArray(a), offset, count, endOffset)
+  }
 
+  /** Internal implementation of `codePointCount`.
+   *
+   *  Assumes that the bounds are correct, and that `endIndex == beginIndex + count`.
+   */
   @inline
-  private[lang] def codePointCountImpl(seq: CharSequence, beginIndex: Int, endIndex: Int): Int = {
-    // Bounds check (and implicit null check)
-    if (endIndex > seq.length() || beginIndex < 0 || endIndex < beginIndex)
-      throw new IndexOutOfBoundsException()
+  private[lang] def codePointCountInternal(seq: CharSequence, beginIndex: Int,
+      count: Int, endIndex: Int): Int = {
 
-    var res = endIndex - beginIndex
+    var res = count
     var i = beginIndex
     val end = endIndex - 1
     while (i < end) {
@@ -334,12 +340,18 @@ object Character {
   def offsetByCodePoints(a: Array[Char], start: Int, count: Int, index: Int,
       codePointOffset: Int): Int = {
 
-    val len = a.length // implicit null check
-
-    // Bounds check
     val limit = start + count
-    if (start < 0 || count < 0 || limit > len || index < start || index > limit)
+
+    /* Non-standard bounds checks: 0 <= start <= index <= limit <= length.
+     *
+     * Note that if count < 0, at least one of these inequalities does not hold.
+     * By contradiction: since `0 <= start`, `start + count` does not overflow
+     * and `start + count = limit < start`.
+     */
+    if (Integer.unsigned_>(limit, a.length) || Integer.unsigned_>(index, limit) ||
+        Integer.unsigned_>(start, index)) {
       throw new IndexOutOfBoundsException()
+    }
 
     offsetByCodePointsInternal(CharSequence.ofArray(a), start, limit, index, codePointOffset)
   }
@@ -348,11 +360,7 @@ object Character {
   private[lang] def offsetByCodePointsImpl(seq: CharSequence, index: Int,
       codePointOffset: Int): Int = {
     val len = seq.length() // implicit null check
-
-    // Bounds check
-    if (index < 0 || index > len)
-      throw new IndexOutOfBoundsException()
-
+    BoundsChecks.checkIndexInclusive(index, len)
     offsetByCodePointsInternal(seq, start = 0, limit = len, index, codePointOffset)
   }
 

--- a/javalib/src/main/scala/java/lang/StringBuilder.scala
+++ b/javalib/src/main/scala/java/lang/StringBuilder.scala
@@ -49,7 +49,7 @@ class StringBuilder extends AnyRef with CharSequence with Appendable with java.i
 
   def append(s: CharSequence, start: Int, end: Int): StringBuilder = {
     val s2 = if (s == null) "null" else s
-    checkStartEnd(start, end, s2.length())
+    BoundsChecks.checkStartEnd(start, end, s2.length())
     append(s2.subSequence(start, end).toString())
   }
 
@@ -57,11 +57,7 @@ class StringBuilder extends AnyRef with CharSequence with Appendable with java.i
     append(String.valueOf(str))
 
   def append(str: Array[scala.Char], offset: Int, len: Int): StringBuilder = {
-    /* Since we check offset >= 0, if offset + len can only overflow from the
-     * positives into the negatives, in which case offset + len < offset, which
-     * is reported as well.
-     */
-    checkStartEnd(offset, offset + len, str.length)
+    BoundsChecks.checkOffsetCount(offset, len, str.length)
     append(String.valueOf(str, offset, len))
   }
 
@@ -134,7 +130,7 @@ class StringBuilder extends AnyRef with CharSequence with Appendable with java.i
       end: Int): StringBuilder = {
     checkInsertOffset(dstOffset)
     val s2 = if (s == null) "null" else s
-    checkStartEnd(start, end, s2.length())
+    BoundsChecks.checkStartEnd(start, end, s2.length())
     insert(dstOffset, s2.subSequence(start, end).toString())
   }
 
@@ -164,21 +160,8 @@ class StringBuilder extends AnyRef with CharSequence with Appendable with java.i
    *  StringIOOBE.
    */
   @inline
-  private def checkInsertOffset(offset: Int): Unit = {
-    if (offset < 0 || offset > content.length)
-      throw new IndexOutOfBoundsException(offset)
-  }
-
-  /** Explicitly checks start and end indices.
-   *
-   *  Used by the overloads of append() and insert() that specify IOOBE,
-   *  instead of UB StringIOOBE.
-   */
-  @inline
-  private def checkStartEnd(start: Int, end: Int, length: Int): Unit = {
-    if (start < 0 || start > end || end > length)
-      throw new IndexOutOfBoundsException()
-  }
+  private def checkInsertOffset(offset: Int): Unit =
+    BoundsChecks.checkIndexInclusive(offset, content.length())
 
   def indexOf(str: String): Int = content.indexOf(str)
 

--- a/javalib/src/main/scala/java/lang/System.scala
+++ b/javalib/src/main/scala/java/lang/System.scala
@@ -319,8 +319,7 @@ private final class JSConsoleBasedPrintStream(isErr: scala.Boolean)
      * in all applications that use OutputStreams (not just PrintStreams).
      * Instead, we use a trivial ISO-8859-1 decoder in here.
      */
-    if (off < 0 || len < 0 || len > buf.length - off)
-      throw new IndexOutOfBoundsException
+    BoundsChecks.checkOffsetCount(off, len, buf.length)
 
     var i = 0
     while (i < len) {

--- a/javalib/src/main/scala/java/lang/_String.scala
+++ b/javalib/src/main/scala/java/lang/_String.scala
@@ -68,8 +68,10 @@ final class _String private () // scalastyle:ignore
     Character.codePointBeforeImpl(this, index)
 
   @noinline
-  def codePointCount(beginIndex: Int, endIndex: Int): Int =
-    Character.codePointCountImpl(this, beginIndex, endIndex)
+  def codePointCount(beginIndex: Int, endIndex: Int): Int = {
+    val count = BoundsChecks.checkStartEnd(beginIndex, endIndex, length())
+    Character.codePointCountInternal(this, beginIndex, count, endIndex)
+  }
 
   @noinline
   def offsetByCodePoints(index: Int, codePointOffset: Int): Int =
@@ -219,7 +221,8 @@ final class _String private () // scalastyle:ignore
     val dstLength = dst.length // implies null check
 
     // Bounds checks on the source
-    if (srcEnd > length() || srcBegin < 0 || srcEnd < 0 || srcBegin > srcEnd) {
+    val count = srcEnd - srcBegin
+    if (BoundsChecks.isStartCountEndInvalid(srcBegin, count, srcEnd, length())) {
       if (srcBegin < 0)
         charAt(srcBegin)
       if (srcEnd > length())
@@ -233,8 +236,8 @@ final class _String private () // scalastyle:ignore
      */
     if (dstBegin < 0)
       "".charAt(dstBegin)
-    if (dstBegin > dstLength - (srcEnd - srcBegin))
-      "".charAt(dstBegin + (srcEnd - srcBegin))
+    if (dstBegin > dstLength - count)
+      "".charAt(dstBegin + count)
 
     val offset = dstBegin - srcBegin
     var i = srcBegin
@@ -294,7 +297,9 @@ final class _String private () // scalastyle:ignore
   def regionMatches(ignoreCase: scala.Boolean, toffset: Int, other: String,
       ooffset: Int, len: Int): scala.Boolean = {
     val otherNonNull = requireNonNull(other)
-    if (toffset < 0 || ooffset < 0 || len > this.length() - toffset ||
+
+    // We must tolerate `len < 0`, so the regular tests in BoundsChecks do not apply
+    if ((toffset | ooffset) < 0 || len > this.length() - toffset ||
         len > otherNonNull.length() - ooffset) {
       false
     } else if (len <= 0) {
@@ -384,7 +389,7 @@ final class _String private () // scalastyle:ignore
      * *only if* the JVM throws an NPE (but not always).
      */
 
-    toffset <= length() && toffset >= 0 && {
+    !BoundsChecks.isIndexInclusiveInvalid(toffset, length()) && {
       if (LinkingInfo.esVersion >= ESVersion.ES2015) {
         thisString.asInstanceOf[js.Dynamic]
           .startsWith(requireNonNull(prefix), toffset)
@@ -402,8 +407,7 @@ final class _String private () // scalastyle:ignore
   // Wasm intrinsic
   @inline
   def substring(beginIndex: Int): String = {
-    // Bounds check
-    if (beginIndex < 0 || beginIndex > length())
+    if (BoundsChecks.isIndexInclusiveInvalid(beginIndex, length()))
       charAt(beginIndex)
 
     thisString.jsSubstring(beginIndex)
@@ -412,13 +416,14 @@ final class _String private () // scalastyle:ignore
   // Wasm intrinsic
   @inline
   def substring(beginIndex: Int, endIndex: Int): String = {
-    // Bounds check
-    if (beginIndex < 0)
-      charAt(beginIndex)
-    if (endIndex > length())
+    val count = endIndex - beginIndex
+    if (BoundsChecks.isStartCountEndInvalid(beginIndex, count, endIndex, length())) {
+      if (beginIndex < 0)
+        charAt(beginIndex)
+      if (endIndex < beginIndex)
+        charAt(-1)
       charAt(endIndex)
-    if (endIndex < beginIndex)
-      charAt(-1)
+    }
 
     thisString.jsSubstring(beginIndex, endIndex)
   }
@@ -995,8 +1000,7 @@ object _String { // scalastyle:ignore
     `new`(value, 0, value.length)
 
   def `new`(value: Array[Char], offset: Int, count: Int): String = {
-    checkBoundsForNewFromArray(offset, count, value.length)
-    val end = offset + count
+    val end = checkBoundsForNewFromArray(offset, count, value.length)
     var result = ""
     var i = offset
     while (i != end) {
@@ -1029,8 +1033,7 @@ object _String { // scalastyle:ignore
   }
 
   def `new`(codePoints: Array[Int], offset: Int, count: Int): String = {
-    checkBoundsForNewFromArray(offset, count, codePoints.length)
-    val end = offset + count
+    val end = checkBoundsForNewFromArray(offset, count, codePoints.length)
     var result = ""
     var i = offset
     while (i != end) {
@@ -1049,19 +1052,22 @@ object _String { // scalastyle:ignore
   def `new`(builder: java.lang.StringBuilder): String =
     builder.toString
 
+  /** Checks bounds and returns `offset + count`, the end offset. */
   @inline
-  private def checkBoundsForNewFromArray(offset: Int, count: Int, arrayLength: Int): Unit = {
+  private def checkBoundsForNewFromArray(offset: Int, count: Int, arrayLength: Int): Int = {
     /* Publicly specified as throwing an IndexOutOfBoundsException.
      * Intuitively, should throw an ArrayIOOBE. However, in practice, the JVM
      * throws a StringIOOBE. We replicate that behavior.
      */
-    if (offset < 0 || count < 0 || offset > arrayLength - count) {
-      if (offset < 0 || offset >= arrayLength)
+    val endOffset = offset + count
+    if (BoundsChecks.isStartCountEndInvalid(offset, count, endOffset, arrayLength)) {
+      if (BoundsChecks.isIndexInvalid(offset, arrayLength))
         "".charAt(offset)
       if (count < 0)
         "".charAt(count)
-      "".charAt(offset + count - 1)
+      "".charAt(endOffset - 1)
     }
+    endOffset
   }
 
   // Static methods (aka methods on the companion object)

--- a/javalib/src/main/scala/java/math/BigDecimal.scala
+++ b/javalib/src/main/scala/java/math/BigDecimal.scala
@@ -392,10 +392,11 @@ class BigDecimal() extends Number with Comparable[BigDecimal] {
   def this(in: Array[Char], offset: Int, len: Int) = {
     this()
 
-    val last = offset + len - 1 // last index to be copied
+    val endOffset = offset + len
+    val last = endOffset - 1 // last index to be copied
 
     // implicit null check for `in`
-    if (last >= in.length || offset < 0 || len <= 0 || last < 0) {
+    if (BoundsChecks.isStartCountEndInvalid(offset, len, endOffset, in.length)) {
       throw new NumberFormatException(
           s"Bad offset/length: offset=${offset} len=$len in.length=${in.length}")
     }

--- a/javalib/src/main/scala/java/nio/Buffer.scala
+++ b/javalib/src/main/scala/java/nio/Buffer.scala
@@ -36,7 +36,7 @@ abstract class Buffer private[nio] (val _capacity: Int) {
   final def position(): Int = _position
 
   def position(newPosition: Int): Buffer = {
-    if (newPosition < 0 || newPosition > limit())
+    if (BoundsChecks.isIndexInclusiveInvalid(newPosition, limit()))
       throw new IllegalArgumentException
     _position = newPosition
     if (_mark > newPosition)
@@ -47,7 +47,7 @@ abstract class Buffer private[nio] (val _capacity: Int) {
   final def limit(): Int = _limit
 
   def limit(newLimit: Int): Buffer = {
-    if (newLimit < 0 || newLimit > capacity())
+    if (BoundsChecks.isIndexInclusiveInvalid(newLimit, capacity()))
       throw new IllegalArgumentException
     _limit = newLimit
     if (_position > newLimit) {
@@ -195,13 +195,6 @@ abstract class Buffer private[nio] (val _capacity: Int) {
       throw new ReadOnlyBufferException
   }
 
-  @inline private[nio] def validateArrayIndexRange(
-      array: Array[ElementType], offset: Int, length: Int)(
-      implicit arrayOps: ArrayOps[ElementType]): Unit = {
-    if (offset < 0 || length < 0 || offset > arrayOps.length(array) - length)
-      throw new IndexOutOfBoundsException
-  }
-
   @inline private[nio] def getPosAndAdvanceRead(): Int = {
     val p = _position
     if (p == limit())
@@ -236,15 +229,8 @@ abstract class Buffer private[nio] (val _capacity: Int) {
     p
   }
 
-  @inline private[nio] def validateIndex(index: Int): Int = {
-    if (index < 0 || index >= limit())
-      throw new IndexOutOfBoundsException
-    index
-  }
-
   @inline private[nio] def validateIndex(index: Int, length: Int): Int = {
-    if (index < 0 || index + length > limit())
-      throw new IndexOutOfBoundsException
+    BoundsChecks.checkOffsetCount(index, length, limit())
     index
   }
 }

--- a/javalib/src/main/scala/java/nio/Buffer.scala
+++ b/javalib/src/main/scala/java/nio/Buffer.scala
@@ -228,9 +228,4 @@ abstract class Buffer private[nio] (val _capacity: Int) {
     _position = newPos
     p
   }
-
-  @inline private[nio] def validateIndex(index: Int, length: Int): Int = {
-    BoundsChecks.checkOffsetCount(index, length, limit())
-    index
-  }
 }

--- a/javalib/src/main/scala/java/nio/ByteBuffer.scala
+++ b/javalib/src/main/scala/java/nio/ByteBuffer.scala
@@ -13,6 +13,7 @@
 package java.nio
 
 import java.util.Objects.requireNonNull
+import java.util.function.IntConsumer
 
 import scala.scalajs.js
 import scala.scalajs.js.typedarray._
@@ -234,5 +235,25 @@ abstract class ByteBuffer private[nio] (
   private[nio] def store(startIndex: Int,
       src: Array[Byte], offset: Int, length: Int): Unit = {
     GenBuffer(this).generic_store(startIndex, src, offset, length)
+  }
+
+  @inline
+  private[nio] def validateIndex(index: Int, bytes: Int): Int = {
+    BoundsChecks.checkOffsetCount(index, bytes, limit())
+    index
+  }
+
+  @inline
+  private[nio] def multiByteRelWrite(bytes: Int)(op: IntConsumer): this.type = {
+    ensureNotReadOnly()
+    op.accept(getPosAndAdvanceWrite(bytes))
+    this
+  }
+
+  @inline
+  private[nio] def multiByteAbsWrite(bytes: Int, index: Int)(op: IntConsumer): this.type = {
+    ensureNotReadOnly()
+    op.accept(validateIndex(index, bytes))
+    this
   }
 }

--- a/javalib/src/main/scala/java/nio/ByteBuffer.scala
+++ b/javalib/src/main/scala/java/nio/ByteBuffer.scala
@@ -24,12 +24,12 @@ object ByteBuffer {
   private final val HashSeed = -547316498 // "java.nio.ByteBuffer".##
 
   def allocate(capacity: Int): ByteBuffer = {
-    GenBuffer.validateAllocateCapacity(capacity)
+    BoundsChecks.checkCapacity(capacity)
     wrap(new Array[Byte](capacity))
   }
 
   def allocateDirect(capacity: Int): ByteBuffer = {
-    GenBuffer.validateAllocateCapacity(capacity)
+    BoundsChecks.checkCapacity(capacity)
 
     if (LinkingInfo.esVersion >= ESVersion.ES2015 ||
         js.typeOf(js.Dynamic.global.Int8Array) != "undefined") {

--- a/javalib/src/main/scala/java/nio/CharBuffer.scala
+++ b/javalib/src/main/scala/java/nio/CharBuffer.scala
@@ -18,7 +18,7 @@ object CharBuffer {
   private final val HashSeed = -182887236 // "java.nio.CharBuffer".##
 
   def allocate(capacity: Int): CharBuffer = {
-    GenBuffer.validateAllocateCapacity(capacity)
+    BoundsChecks.checkCapacity(capacity)
     wrap(new Array[Char](capacity))
   }
 

--- a/javalib/src/main/scala/java/nio/DataViewCharBuffer.scala
+++ b/javalib/src/main/scala/java/nio/DataViewCharBuffer.scala
@@ -43,8 +43,7 @@ private[nio] final class DataViewCharBuffer private (
     GenDataViewBuffer(this).generic_asReadOnlyBuffer()
 
   def subSequence(start: Int, end: Int): CharBuffer = {
-    if (start < 0 || end < start || end > remaining())
-      throw new IndexOutOfBoundsException
+    BoundsChecks.checkStartEnd(start, end, remaining())
     new DataViewCharBuffer(_dataView,
         position() + start, position() + end, isReadOnly(), isBigEndian)
   }

--- a/javalib/src/main/scala/java/nio/DoubleBuffer.scala
+++ b/javalib/src/main/scala/java/nio/DoubleBuffer.scala
@@ -18,7 +18,7 @@ object DoubleBuffer {
   private final val HashSeed = 2140173175 // "java.nio.DoubleBuffer".##
 
   def allocate(capacity: Int): DoubleBuffer = {
-    GenBuffer.validateAllocateCapacity(capacity)
+    BoundsChecks.checkCapacity(capacity)
     wrap(new Array[Double](capacity))
   }
 

--- a/javalib/src/main/scala/java/nio/FloatBuffer.scala
+++ b/javalib/src/main/scala/java/nio/FloatBuffer.scala
@@ -18,7 +18,7 @@ object FloatBuffer {
   private final val HashSeed = 1920204022 // "java.nio.FloatBuffer".##
 
   def allocate(capacity: Int): FloatBuffer = {
-    GenBuffer.validateAllocateCapacity(capacity)
+    BoundsChecks.checkCapacity(capacity)
     wrap(new Array[Float](capacity))
   }
 

--- a/javalib/src/main/scala/java/nio/GenBuffer.scala
+++ b/javalib/src/main/scala/java/nio/GenBuffer.scala
@@ -18,11 +18,6 @@ import java.util.internal.GenericArrayOps._
 private[nio] object GenBuffer {
   def apply[B <: Buffer](self: B): GenBuffer[B] =
     new GenBuffer(self)
-
-  @inline def validateAllocateCapacity(capacity: Int): Unit = {
-    if (capacity < 0)
-      throw new IllegalArgumentException
-  }
 }
 
 /* The underlying `val self` is intentionally public because
@@ -45,20 +40,23 @@ private[nio] final class GenBuffer[B <: Buffer] private (val self: B) extends An
   }
 
   @inline
-  def generic_get(index: Int): ElementType =
-    load(validateIndex(index))
+  def generic_get(index: Int): ElementType = {
+    BoundsChecks.checkIndex(index, limit())
+    load(index)
+  }
 
   @inline
   def generic_put(index: Int, elem: ElementType): BufferType = {
     ensureNotReadOnly()
-    store(validateIndex(index), elem)
+    BoundsChecks.checkIndex(index, limit())
+    store(index, elem)
     self
   }
 
   @inline
   def generic_get(dst: Array[ElementType], offset: Int, length: Int)(
       implicit arrayOps: ArrayOps[ElementType]): BufferType = {
-    validateArrayIndexRange(dst, offset, length)
+    BoundsChecks.checkOffsetCount(offset, length, arrayOps.length(dst))
     load(getPosAndAdvanceRead(length), dst, offset, length)
     self
   }
@@ -92,7 +90,7 @@ private[nio] final class GenBuffer[B <: Buffer] private (val self: B) extends An
   def generic_put(src: Array[ElementType], offset: Int, length: Int)(
       implicit arrayOps: ArrayOps[ElementType]): BufferType = {
     ensureNotReadOnly()
-    validateArrayIndexRange(src, offset, length)
+    BoundsChecks.checkOffsetCount(offset, length, arrayOps.length(src))
     store(getPosAndAdvanceWrite(length), src, offset, length)
     self
   }

--- a/javalib/src/main/scala/java/nio/GenHeapBuffer.scala
+++ b/javalib/src/main/scala/java/nio/GenHeapBuffer.scala
@@ -36,11 +36,8 @@ private[nio] object GenHeapBuffer {
       initialPosition: Int, initialLength: Int, isReadOnly: Boolean)(
       implicit arrayOps: ArrayOps[ElementType],
       newHeapBuffer: NewHeapBuffer[BufferType, ElementType]): BufferType = {
-    if (arrayOffset < 0 || capacity < 0 || arrayOffset + capacity > arrayOps.length(array))
-      throw new IndexOutOfBoundsException
-    val initialLimit = initialPosition + initialLength
-    if (initialPosition < 0 || initialLength < 0 || initialLimit > capacity)
-      throw new IndexOutOfBoundsException
+    BoundsChecks.checkOffsetCount(arrayOffset, capacity, arrayOps.length(array))
+    val initialLimit = BoundsChecks.checkOffsetCount(initialPosition, initialLength, capacity)
     newHeapBuffer(capacity, array, arrayOffset,
         initialPosition, initialLimit, isReadOnly, false)
   }

--- a/javalib/src/main/scala/java/nio/HeapByteBuffer.scala
+++ b/javalib/src/main/scala/java/nio/HeapByteBuffer.scala
@@ -75,16 +75,14 @@ private[nio] final class HeapByteBuffer private (
   @noinline def getChar(): Char =
     arrayBits.loadChar(getPosAndAdvanceRead(2))
 
-  @noinline def putChar(value: Char): ByteBuffer = {
-    ensureNotReadOnly(); arrayBits.storeChar(getPosAndAdvanceWrite(2), value); this
-  }
+  @noinline def putChar(value: Char): ByteBuffer =
+    multiByteRelWrite(bytes = 2)(arrayBits.storeChar(_, value))
 
   @noinline def getChar(index: Int): Char =
     arrayBits.loadChar(validateIndex(index, 2))
 
-  @noinline def putChar(index: Int, value: Char): ByteBuffer = {
-    ensureNotReadOnly(); arrayBits.storeChar(validateIndex(index, 2), value); this
-  }
+  @noinline def putChar(index: Int, value: Char): ByteBuffer =
+    multiByteAbsWrite(bytes = 2, index)(arrayBits.storeChar(_, value))
 
   def asCharBuffer(): CharBuffer =
     HeapByteBufferCharView.fromHeapByteBuffer(this)
@@ -92,16 +90,14 @@ private[nio] final class HeapByteBuffer private (
   @noinline def getShort(): Short =
     arrayBits.loadShort(getPosAndAdvanceRead(2))
 
-  @noinline def putShort(value: Short): ByteBuffer = {
-    ensureNotReadOnly(); arrayBits.storeShort(getPosAndAdvanceWrite(2), value); this
-  }
+  @noinline def putShort(value: Short): ByteBuffer =
+    multiByteRelWrite(bytes = 2)(arrayBits.storeShort(_, value))
 
   @noinline def getShort(index: Int): Short =
     arrayBits.loadShort(validateIndex(index, 2))
 
-  @noinline def putShort(index: Int, value: Short): ByteBuffer = {
-    ensureNotReadOnly(); arrayBits.storeShort(validateIndex(index, 2), value); this
-  }
+  @noinline def putShort(index: Int, value: Short): ByteBuffer =
+    multiByteAbsWrite(bytes = 2, index)(arrayBits.storeShort(_, value))
 
   def asShortBuffer(): ShortBuffer =
     HeapByteBufferShortView.fromHeapByteBuffer(this)
@@ -109,16 +105,14 @@ private[nio] final class HeapByteBuffer private (
   @noinline def getInt(): Int =
     arrayBits.loadInt(getPosAndAdvanceRead(4))
 
-  @noinline def putInt(value: Int): ByteBuffer = {
-    ensureNotReadOnly(); arrayBits.storeInt(getPosAndAdvanceWrite(4), value); this
-  }
+  @noinline def putInt(value: Int): ByteBuffer =
+    multiByteRelWrite(bytes = 4)(arrayBits.storeInt(_, value))
 
   @noinline def getInt(index: Int): Int =
     arrayBits.loadInt(validateIndex(index, 4))
 
-  @noinline def putInt(index: Int, value: Int): ByteBuffer = {
-    ensureNotReadOnly(); arrayBits.storeInt(validateIndex(index, 4), value); this
-  }
+  @noinline def putInt(index: Int, value: Int): ByteBuffer =
+    multiByteAbsWrite(bytes = 4, index)(arrayBits.storeInt(_, value))
 
   def asIntBuffer(): IntBuffer =
     HeapByteBufferIntView.fromHeapByteBuffer(this)
@@ -126,16 +120,14 @@ private[nio] final class HeapByteBuffer private (
   @noinline def getLong(): Long =
     arrayBits.loadLong(getPosAndAdvanceRead(8))
 
-  @noinline def putLong(value: Long): ByteBuffer = {
-    ensureNotReadOnly(); arrayBits.storeLong(getPosAndAdvanceWrite(8), value); this
-  }
+  @noinline def putLong(value: Long): ByteBuffer =
+    multiByteRelWrite(bytes = 8)(arrayBits.storeLong(_, value))
 
   @noinline def getLong(index: Int): Long =
     arrayBits.loadLong(validateIndex(index, 8))
 
-  @noinline def putLong(index: Int, value: Long): ByteBuffer = {
-    ensureNotReadOnly(); arrayBits.storeLong(validateIndex(index, 8), value); this
-  }
+  @noinline def putLong(index: Int, value: Long): ByteBuffer =
+    multiByteAbsWrite(bytes = 8, index)(arrayBits.storeLong(_, value))
 
   def asLongBuffer(): LongBuffer =
     HeapByteBufferLongView.fromHeapByteBuffer(this)
@@ -143,16 +135,14 @@ private[nio] final class HeapByteBuffer private (
   @noinline def getFloat(): Float =
     arrayBits.loadFloat(getPosAndAdvanceRead(4))
 
-  @noinline def putFloat(value: Float): ByteBuffer = {
-    ensureNotReadOnly(); arrayBits.storeFloat(getPosAndAdvanceWrite(4), value); this
-  }
+  @noinline def putFloat(value: Float): ByteBuffer =
+    multiByteRelWrite(bytes = 4)(arrayBits.storeFloat(_, value))
 
   @noinline def getFloat(index: Int): Float =
     arrayBits.loadFloat(validateIndex(index, 4))
 
-  @noinline def putFloat(index: Int, value: Float): ByteBuffer = {
-    ensureNotReadOnly(); arrayBits.storeFloat(validateIndex(index, 4), value); this
-  }
+  @noinline def putFloat(index: Int, value: Float): ByteBuffer =
+    multiByteAbsWrite(bytes = 4, index)(arrayBits.storeFloat(_, value))
 
   def asFloatBuffer(): FloatBuffer =
     HeapByteBufferFloatView.fromHeapByteBuffer(this)
@@ -160,16 +150,14 @@ private[nio] final class HeapByteBuffer private (
   @noinline def getDouble(): Double =
     arrayBits.loadDouble(getPosAndAdvanceRead(8))
 
-  @noinline def putDouble(value: Double): ByteBuffer = {
-    ensureNotReadOnly(); arrayBits.storeDouble(getPosAndAdvanceWrite(8), value); this
-  }
+  @noinline def putDouble(value: Double): ByteBuffer =
+    multiByteRelWrite(bytes = 8)(arrayBits.storeDouble(_, value))
 
   @noinline def getDouble(index: Int): Double =
     arrayBits.loadDouble(validateIndex(index, 8))
 
-  @noinline def putDouble(index: Int, value: Double): ByteBuffer = {
-    ensureNotReadOnly(); arrayBits.storeDouble(validateIndex(index, 8), value); this
-  }
+  @noinline def putDouble(index: Int, value: Double): ByteBuffer =
+    multiByteAbsWrite(bytes = 8, index)(arrayBits.storeDouble(_, value))
 
   def asDoubleBuffer(): DoubleBuffer =
     HeapByteBufferDoubleView.fromHeapByteBuffer(this)

--- a/javalib/src/main/scala/java/nio/HeapByteBufferCharView.scala
+++ b/javalib/src/main/scala/java/nio/HeapByteBufferCharView.scala
@@ -44,8 +44,7 @@ private[nio] final class HeapByteBufferCharView private (
     GenHeapBufferView(this).generic_asReadOnlyBuffer()
 
   def subSequence(start: Int, end: Int): CharBuffer = {
-    if (start < 0 || end < start || end > remaining())
-      throw new IndexOutOfBoundsException
+    BoundsChecks.checkStartEnd(start, end, remaining())
     new HeapByteBufferCharView(capacity(), _byteArray, _byteArrayOffset,
         position() + start, position() + end, isReadOnly(), isDirect(), isBigEndian)
   }

--- a/javalib/src/main/scala/java/nio/HeapCharBuffer.scala
+++ b/javalib/src/main/scala/java/nio/HeapCharBuffer.scala
@@ -39,8 +39,7 @@ private[nio] final class HeapCharBuffer private (
     GenHeapBuffer(this).generic_asReadOnlyBuffer()
 
   def subSequence(start: Int, end: Int): CharBuffer = {
-    if (start < 0 || end < start || end > remaining())
-      throw new IndexOutOfBoundsException
+    BoundsChecks.checkStartEnd(start, end, remaining())
     new HeapCharBuffer(capacity(), _array, _arrayOffset,
         position() + start, position() + end, isReadOnly())
   }

--- a/javalib/src/main/scala/java/nio/IntBuffer.scala
+++ b/javalib/src/main/scala/java/nio/IntBuffer.scala
@@ -18,7 +18,7 @@ object IntBuffer {
   private final val HashSeed = 39599817 // "java.nio.IntBuffer".##
 
   def allocate(capacity: Int): IntBuffer = {
-    GenBuffer.validateAllocateCapacity(capacity)
+    BoundsChecks.checkCapacity(capacity)
     wrap(new Array[Int](capacity))
   }
 

--- a/javalib/src/main/scala/java/nio/LongBuffer.scala
+++ b/javalib/src/main/scala/java/nio/LongBuffer.scala
@@ -16,7 +16,7 @@ object LongBuffer {
   private final val HashSeed = -1709696158 // "java.nio.LongBuffer".##
 
   def allocate(capacity: Int): LongBuffer = {
-    GenBuffer.validateAllocateCapacity(capacity)
+    BoundsChecks.checkCapacity(capacity)
     wrap(new Array[Long](capacity))
   }
 

--- a/javalib/src/main/scala/java/nio/ShortBuffer.scala
+++ b/javalib/src/main/scala/java/nio/ShortBuffer.scala
@@ -18,7 +18,7 @@ object ShortBuffer {
   private final val HashSeed = 383731478 // "java.nio.ShortBuffer".##
 
   def allocate(capacity: Int): ShortBuffer = {
-    GenBuffer.validateAllocateCapacity(capacity)
+    BoundsChecks.checkCapacity(capacity)
     wrap(new Array[Short](capacity))
   }
 

--- a/javalib/src/main/scala/java/nio/StringCharBuffer.scala
+++ b/javalib/src/main/scala/java/nio/StringCharBuffer.scala
@@ -39,8 +39,7 @@ private[nio] final class StringCharBuffer private (
   def asReadOnlyBuffer(): CharBuffer = duplicate()
 
   def subSequence(start: Int, end: Int): CharBuffer = {
-    if (start < 0 || end < start || end > remaining())
-      throw new IndexOutOfBoundsException
+    BoundsChecks.checkStartEnd(start, end, remaining())
     new StringCharBuffer(capacity(), _csq, _csqOffset,
         position() + start, position() + end)
   }
@@ -102,11 +101,8 @@ private[nio] final class StringCharBuffer private (
 private[nio] object StringCharBuffer {
   private[nio] def wrap(csq: CharSequence, csqOffset: Int, capacity: Int,
       initialPosition: Int, initialLength: Int): CharBuffer = {
-    if (csqOffset < 0 || capacity < 0 || csqOffset + capacity > csq.length())
-      throw new IndexOutOfBoundsException
-    val initialLimit = initialPosition + initialLength
-    if (initialPosition < 0 || initialLength < 0 || initialLimit > capacity)
-      throw new IndexOutOfBoundsException
+    BoundsChecks.checkOffsetCount(csqOffset, capacity, csq.length())
+    val initialLimit = BoundsChecks.checkOffsetCount(initialPosition, initialLength, capacity)
     new StringCharBuffer(capacity, csq, csqOffset,
         initialPosition, initialLimit)
   }

--- a/javalib/src/main/scala/java/nio/TypedArrayByteBuffer.scala
+++ b/javalib/src/main/scala/java/nio/TypedArrayByteBuffer.scala
@@ -255,8 +255,7 @@ private[nio] object TypedArrayByteBuffer {
   }
 
   def allocate(capacity: Int): ByteBuffer = {
-    if (capacity < 0)
-      throw new IllegalArgumentException
+    BoundsChecks.checkCapacity(capacity)
     new TypedArrayByteBuffer(new Int8Array(capacity), 0, capacity, false)
   }
 

--- a/javalib/src/main/scala/java/nio/TypedArrayByteBuffer.scala
+++ b/javalib/src/main/scala/java/nio/TypedArrayByteBuffer.scala
@@ -83,16 +83,14 @@ private[nio] final class TypedArrayByteBuffer private (
   @noinline def getChar(): Char =
     _dataView.getUint16(getPosAndAdvanceRead(2), !isBigEndian).toChar
 
-  @noinline def putChar(value: Char): ByteBuffer = {
-    ensureNotReadOnly(); _dataView.setUint16(getPosAndAdvanceWrite(2), value, !isBigEndian); this
-  }
+  @noinline def putChar(value: Char): ByteBuffer =
+    multiByteRelWrite(bytes = 2)(_dataView.setUint16(_, value, !isBigEndian))
 
   @noinline def getChar(index: Int): Char =
     _dataView.getUint16(validateIndex(index, 2), !isBigEndian).toChar
 
-  @noinline def putChar(index: Int, value: Char): ByteBuffer = {
-    ensureNotReadOnly(); _dataView.setUint16(validateIndex(index, 2), value, !isBigEndian); this
-  }
+  @noinline def putChar(index: Int, value: Char): ByteBuffer =
+    multiByteAbsWrite(bytes = 2, index)(_dataView.setUint16(_, value, !isBigEndian))
 
   def asCharBuffer(): CharBuffer = {
     if (hasNativeOrder && (_arrayBufferOffset + position()) % 2 == 0)
@@ -104,16 +102,14 @@ private[nio] final class TypedArrayByteBuffer private (
   @noinline def getShort(): Short =
     _dataView.getInt16(getPosAndAdvanceRead(2), !isBigEndian)
 
-  @noinline def putShort(value: Short): ByteBuffer = {
-    ensureNotReadOnly(); _dataView.setInt16(getPosAndAdvanceWrite(2), value, !isBigEndian); this
-  }
+  @noinline def putShort(value: Short): ByteBuffer =
+    multiByteRelWrite(bytes = 2)(_dataView.setInt16(_, value, !isBigEndian))
 
   @noinline def getShort(index: Int): Short =
     _dataView.getInt16(validateIndex(index, 2), !isBigEndian)
 
-  @noinline def putShort(index: Int, value: Short): ByteBuffer = {
-    ensureNotReadOnly(); _dataView.setInt16(validateIndex(index, 2), value, !isBigEndian); this
-  }
+  @noinline def putShort(index: Int, value: Short): ByteBuffer =
+    multiByteAbsWrite(bytes = 2, index)(_dataView.setInt16(_, value, !isBigEndian))
 
   def asShortBuffer(): ShortBuffer = {
     if (hasNativeOrder && (_arrayBufferOffset + position()) % 2 == 0)
@@ -125,16 +121,14 @@ private[nio] final class TypedArrayByteBuffer private (
   @noinline def getInt(): Int =
     _dataView.getInt32(getPosAndAdvanceRead(4), !isBigEndian)
 
-  @noinline def putInt(value: Int): ByteBuffer = {
-    ensureNotReadOnly(); _dataView.setInt32(getPosAndAdvanceWrite(4), value, !isBigEndian); this
-  }
+  @noinline def putInt(value: Int): ByteBuffer =
+    multiByteRelWrite(bytes = 4)(_dataView.setInt32(_, value, !isBigEndian))
 
   @noinline def getInt(index: Int): Int =
     _dataView.getInt32(validateIndex(index, 4), !isBigEndian)
 
-  @noinline def putInt(index: Int, value: Int): ByteBuffer = {
-    ensureNotReadOnly(); _dataView.setInt32(validateIndex(index, 4), value, !isBigEndian); this
-  }
+  @noinline def putInt(index: Int, value: Int): ByteBuffer =
+    multiByteAbsWrite(bytes = 4, index)(_dataView.setInt32(_, value, !isBigEndian))
 
   def asIntBuffer(): IntBuffer = {
     if (hasNativeOrder && (_arrayBufferOffset + position()) % 4 == 0)
@@ -146,18 +140,14 @@ private[nio] final class TypedArrayByteBuffer private (
   @noinline def getLong(): Long =
     dataViewGetInt64(_dataView, getPosAndAdvanceRead(8), !isBigEndian)
 
-  @noinline def putLong(value: Long): ByteBuffer = {
-    ensureNotReadOnly(); dataViewSetInt64(_dataView, getPosAndAdvanceWrite(8), value, !isBigEndian);
-    this
-  }
+  @noinline def putLong(value: Long): ByteBuffer =
+    multiByteRelWrite(bytes = 8)(dataViewSetInt64(_dataView, _, value, !isBigEndian))
 
   @noinline def getLong(index: Int): Long =
     dataViewGetInt64(_dataView, validateIndex(index, 8), !isBigEndian)
 
-  @noinline def putLong(index: Int, value: Long): ByteBuffer = {
-    ensureNotReadOnly(); dataViewSetInt64(_dataView, validateIndex(index, 8), value, !isBigEndian);
-    this
-  }
+  @noinline def putLong(index: Int, value: Long): ByteBuffer =
+    multiByteAbsWrite(bytes = 8, index)(dataViewSetInt64(_dataView, _, value, !isBigEndian))
 
   def asLongBuffer(): LongBuffer =
     DataViewLongBuffer.fromTypedArrayByteBuffer(this)
@@ -165,16 +155,14 @@ private[nio] final class TypedArrayByteBuffer private (
   @noinline def getFloat(): Float =
     _dataView.getFloat32(getPosAndAdvanceRead(4), !isBigEndian)
 
-  @noinline def putFloat(value: Float): ByteBuffer = {
-    ensureNotReadOnly(); _dataView.setFloat32(getPosAndAdvanceWrite(4), value, !isBigEndian); this
-  }
+  @noinline def putFloat(value: Float): ByteBuffer =
+    multiByteRelWrite(bytes = 4)(_dataView.setFloat32(_, value, !isBigEndian))
 
   @noinline def getFloat(index: Int): Float =
     _dataView.getFloat32(validateIndex(index, 4), !isBigEndian)
 
-  @noinline def putFloat(index: Int, value: Float): ByteBuffer = {
-    ensureNotReadOnly(); _dataView.setFloat32(validateIndex(index, 4), value, !isBigEndian); this
-  }
+  @noinline def putFloat(index: Int, value: Float): ByteBuffer =
+    multiByteAbsWrite(bytes = 4, index)(_dataView.setFloat32(_, value, !isBigEndian))
 
   def asFloatBuffer(): FloatBuffer = {
     if (hasNativeOrder && (_arrayBufferOffset + position()) % 4 == 0)
@@ -186,16 +174,14 @@ private[nio] final class TypedArrayByteBuffer private (
   @noinline def getDouble(): Double =
     _dataView.getFloat64(getPosAndAdvanceRead(8), !isBigEndian)
 
-  @noinline def putDouble(value: Double): ByteBuffer = {
-    ensureNotReadOnly(); _dataView.setFloat64(getPosAndAdvanceWrite(8), value, !isBigEndian); this
-  }
+  @noinline def putDouble(value: Double): ByteBuffer =
+    multiByteRelWrite(bytes = 8)(_dataView.setFloat64(_, value, !isBigEndian))
 
   @noinline def getDouble(index: Int): Double =
     _dataView.getFloat64(validateIndex(index, 8), !isBigEndian)
 
-  @noinline def putDouble(index: Int, value: Double): ByteBuffer = {
-    ensureNotReadOnly(); _dataView.setFloat64(validateIndex(index, 8), value, !isBigEndian); this
-  }
+  @noinline def putDouble(index: Int, value: Double): ByteBuffer =
+    multiByteAbsWrite(bytes = 8, index)(_dataView.setFloat64(_, value, !isBigEndian))
 
   def asDoubleBuffer(): DoubleBuffer = {
     if (hasNativeOrder && (_arrayBufferOffset + position()) % 8 == 0)

--- a/javalib/src/main/scala/java/nio/TypedArrayCharBuffer.scala
+++ b/javalib/src/main/scala/java/nio/TypedArrayCharBuffer.scala
@@ -42,8 +42,7 @@ private[nio] final class TypedArrayCharBuffer private (
     GenTypedArrayBuffer(this).generic_asReadOnlyBuffer()
 
   def subSequence(start: Int, end: Int): CharBuffer = {
-    if (start < 0 || end < start || end > remaining())
-      throw new IndexOutOfBoundsException
+    BoundsChecks.checkStartEnd(start, end, remaining())
     new TypedArrayCharBuffer(_typedArray,
         position() + start, position() + end, isReadOnly())
   }

--- a/javalib/src/main/scala/java/util/AbstractList.scala
+++ b/javalib/src/main/scala/java/util/AbstractList.scala
@@ -75,12 +75,7 @@ abstract class AbstractList[E] protected () extends AbstractCollection[E] with L
   }
 
   def subList(fromIndex: Int, toIndex: Int): List[E] = {
-    if (fromIndex < 0)
-      throw new IndexOutOfBoundsException(fromIndex.toString)
-    else if (toIndex > size())
-      throw new IndexOutOfBoundsException(toIndex.toString)
-    else if (fromIndex > toIndex)
-      throw new IllegalArgumentException
+    BoundsChecks.checkStartEnd(fromIndex, toIndex, size())
 
     self match {
       case _: RandomAccess =>
@@ -134,15 +129,13 @@ abstract class AbstractList[E] protected () extends AbstractCollection[E] with L
     }
   }
 
-  protected[this] def checkIndexInBounds(index: Int): Unit = {
-    if (index < 0 || index >= size())
-      throw new IndexOutOfBoundsException(index.toString)
-  }
+  @inline
+  private[util] final def checkIndexInBounds(index: Int): Unit =
+    BoundsChecks.checkIndex(index, size())
 
-  protected[this] def checkIndexOnBounds(index: Int): Unit = {
-    if (index < 0 || index > size())
-      throw new IndexOutOfBoundsException(index.toString)
-  }
+  @inline
+  private[util] final def checkIndexOnBounds(index: Int): Unit =
+    BoundsChecks.checkIndexInclusive(index, size())
 }
 
 private abstract class AbstractListView[E](protected val list: List[E],

--- a/javalib/src/main/scala/java/util/ArrayList.scala
+++ b/javalib/src/main/scala/java/util/ArrayList.scala
@@ -42,8 +42,7 @@ class ArrayList[E] private (innerInit: AnyRef, private var _size: Int)
   def this(initialCapacity: Int) = {
     this(
       {
-        if (initialCapacity < 0)
-          throw new IllegalArgumentException
+        BoundsChecks.checkCapacity(initialCapacity)
         if (isWebAssembly) new Array[AnyRef](initialCapacity)
         else new js.Array[E]
       },
@@ -165,17 +164,16 @@ class ArrayList[E] private (innerInit: AnyRef, private var _size: Int)
   }
 
   override protected def removeRange(fromIndex: Int, toIndex: Int): Unit = {
-    if (fromIndex < 0 || toIndex > size() || toIndex < fromIndex)
-      throw new IndexOutOfBoundsException()
+    val count = BoundsChecks.checkStartEnd(fromIndex, toIndex, size())
     if (isWebAssembly) {
-      if (fromIndex != toIndex) {
+      if (count != 0) {
         System.arraycopy(innerWasm, toIndex, innerWasm, fromIndex, size() - toIndex)
-        val newSize = size() - toIndex + fromIndex
+        val newSize = size() - count
         Arrays.fill(innerWasm, newSize, size(), null) // free references for GC
         _size = newSize
       }
     } else {
-      innerJS.splice(fromIndex, toIndex - fromIndex)
+      innerJS.splice(fromIndex, count)
     }
   }
 

--- a/javalib/src/main/scala/java/util/Base64.scala
+++ b/javalib/src/main/scala/java/util/Base64.scala
@@ -382,8 +382,7 @@ object Base64 {
       if (closed)
         throw new IOException("Stream is closed")
 
-      if (off < 0 || len < 0 || len > b.length - off)
-        throw new IndexOutOfBoundsException()
+      BoundsChecks.checkOffsetCount(off, len, b.length)
 
       if (eof) {
         -1
@@ -547,16 +546,16 @@ object Base64 {
     override def write(bytes: Array[Byte], off: Int, len: Int): Unit = {
       if (closed)
         throw new IOException("Stream is closed")
-      if (off < 0 || len < 0 || len > bytes.length - off)
-        throw new IndexOutOfBoundsException()
+
+      val endOffset = BoundsChecks.checkOffsetCount(off, len, bytes.length)
 
       if (len != 0) {
         addLineSeparators()
-        for (i <- off until (off + len)) {
+        for (i <- off until endOffset) {
           inputBuf.put(bytes(i))
           if (!inputBuf.hasRemaining) {
             writeBuffer(4)
-            if (i < (off + len - 1))
+            if (i < (endOffset - 1))
               addLineSeparators()
           }
         }

--- a/javalib/src/main/scala/java/util/BitSet.scala
+++ b/javalib/src/main/scala/java/util/BitSet.scala
@@ -663,22 +663,21 @@ class BitSet private (private var bits: Array[Int]) extends Serializable with Cl
     idx + 1
   }
 
+  // Bounds checks for BitSet are non-standard, because there is no upper-bound for the length
+
+  @inline
   private def checkToAndFromIndex(fromIndex: Int, toIndex: Int): Unit = {
-    if (fromIndex < 0)
-      throw new IndexOutOfBoundsException(s"fromIndex < 0: $fromIndex")
-
-    if (toIndex < 0)
-      throw new IndexOutOfBoundsException(s"toIndex < 0: $toIndex")
-
-    if (toIndex < fromIndex)
-      throw new IndexOutOfBoundsException(s"fromIndex: $fromIndex > toIndex: $toIndex")
+    if ((fromIndex | toIndex | (toIndex - fromIndex)) < 0)
+      throw new IndexOutOfBoundsException(s"Illegal range: [$fromIndex, $toIndex)")
   }
 
+  @inline
   private def checkFromIndex(fromIndex: Int): Unit = {
     if (fromIndex < 0)
       throw new IndexOutOfBoundsException(s"fromIndex < 0: $fromIndex")
   }
 
+  @inline
   private def checkBitIndex(bitIndex: Int): Unit = {
     if (bitIndex < 0)
       throw new IndexOutOfBoundsException(s"bitIndex < 0: $bitIndex")

--- a/javalib/src/main/scala/java/util/Collections.scala
+++ b/javalib/src/main/scala/java/util/Collections.scala
@@ -522,8 +522,7 @@ object Collections {
       def size(): Int = n
 
       def get(index: Int): T = {
-        if (index < 0 || index >= n)
-          throw new IndexOutOfBoundsException
+        BoundsChecks.checkIndex(index, n)
         o
       }
     }

--- a/javalib/src/main/scala/java/util/Formatter.scala
+++ b/javalib/src/main/scala/java/util/Formatter.scala
@@ -742,7 +742,7 @@ final class Formatter private (private[this] var dest: Appendable,
       width: Int, precision: Int, str: String): Unit = {
 
     val truncatedStr =
-      if (precision < 0 || precision >= str.length()) str
+      if (BoundsChecks.isIndexInvalid(precision, str.length())) str
       else str.substring(0, precision)
     padAndSendToDestNoZeroPad(flags, width,
         applyUpperCase(localeInfo, flags, truncatedStr))

--- a/javalib/src/main/scala/java/util/HashMap.scala
+++ b/javalib/src/main/scala/java/util/HashMap.scala
@@ -26,8 +26,7 @@ class HashMap[K, V](initialCapacity: Int, loadFactor: Float)
 
   import HashMap._
 
-  if (initialCapacity < 0)
-    throw new IllegalArgumentException("initialCapacity < 0")
+  BoundsChecks.checkCapacity(initialCapacity)
   if (loadFactor <= 0.0f)
     throw new IllegalArgumentException("loadFactor <= 0.0")
 

--- a/javalib/src/main/scala/java/util/concurrent/CopyOnWriteArrayList.scala
+++ b/javalib/src/main/scala/java/util/concurrent/CopyOnWriteArrayList.scala
@@ -287,8 +287,7 @@ class CopyOnWriteArrayList[E <: AnyRef] private (initialCapacity: Int)
   }
 
   def subList(fromIndex: Int, toIndex: Int): List[E] = {
-    if (fromIndex < 0 || fromIndex > toIndex || toIndex > size())
-      throw new IndexOutOfBoundsException
+    BoundsChecks.checkStartEnd(fromIndex, toIndex, size())
     new CopyOnWriteArrayListView(fromIndex, toIndex)
   }
 
@@ -356,8 +355,7 @@ class CopyOnWriteArrayList[E <: AnyRef] private (initialCapacity: Int)
     }
 
     override def subList(fromIndex: Int, toIndex: Int): List[E] = {
-      if (fromIndex < 0 || fromIndex > toIndex || toIndex > size())
-        throw new IndexOutOfBoundsException
+      BoundsChecks.checkStartEnd(fromIndex, toIndex, size())
 
       new CopyOnWriteArrayListView(viewSelf.fromIndex + fromIndex,
           viewSelf.fromIndex + toIndex) {
@@ -413,15 +411,13 @@ class CopyOnWriteArrayList[E <: AnyRef] private (initialCapacity: Int)
       toIndex += delta
   }
 
-  protected def checkIndexInBounds(index: Int): Unit = {
-    if (index < 0 || index >= size())
-      throw new IndexOutOfBoundsException(index.toString)
-  }
+  @inline
+  private def checkIndexInBounds(index: Int): Unit =
+    BoundsChecks.checkIndex(index, size())
 
-  protected def checkIndexOnBounds(index: Int): Unit = {
-    if (index < 0 || index > size())
-      throw new IndexOutOfBoundsException(index.toString)
-  }
+  @inline
+  private def checkIndexOnBounds(index: Int): Unit =
+    BoundsChecks.checkIndexInclusive(index, size())
 }
 
 private class CopyOnWriteArrayListIterator[E](

--- a/javalib/src/main/scala/java/util/regex/Pattern.scala
+++ b/javalib/src/main/scala/java/util/regex/Pattern.scala
@@ -127,8 +127,7 @@ final class Pattern private[regex] (
   }
 
   private[regex] def numberedGroup(group: Int): Int = {
-    if (group < 0 || group > groupCount)
-      throw new IndexOutOfBoundsException(group.toString())
+    BoundsChecks.checkIndexInclusive(group, groupCount)
     groupNumberMap(group)
   }
 

--- a/linker/shared/src/main/scala/org/scalajs/linker/frontend/optimizer/OptimizerCore.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/frontend/optimizer/OptimizerCore.scala
@@ -5473,6 +5473,20 @@ private[optimizer] abstract class OptimizerCore(
             foldCmp(cmp.withRels(if (cmp.rels == Rels_>) Rels_== else Rels_!=), lhs,
                 cmp.makeLit(maxValue))
 
+          case 0L if cmp.isSigned && !cmp.isLongOp && (cmp.rels == Rels_< || cmp.rels == Rels_>=) =>
+            /* Only the sign bit matters. Simplify the lhs based on the sign bit mask.
+             * This is particularly useful things like `(a | b) < 0`, when one
+             * of the operands is folded to a non-negative constant.
+             *
+             * We only apply this for int ops because mask simplification only
+             * supports ints.
+             */
+            val newLhs = simplifyOnlyInterestedInMask(lhs, Int.MinValue)
+            if (newLhs eq lhs)
+              default
+            else
+              foldCmp(cmp, newLhs, rhs)
+
           case _ =>
             default
         }


### PR DESCRIPTION
We centralize all the bounds checks in a single `BoundsChecks` object, where they are implemented efficiently. Moreover, they provide good error messages.

The efficient tests are mostly based on the knowledge that the length is non-negative, which the optimizer does not know.