### PR TITLE
Fix #5347: Fix the codegen for private var's in anon JS classes.

### DIFF
--- a/compiler/src/main/scala/org/scalajs/nscplugin/GenJSCode.scala
+++ b/compiler/src/main/scala/org/scalajs/nscplugin/GenJSCode.scala
@@ -1053,7 +1053,7 @@ abstract class GenJSCode[G <: Global with Singleton](val global: G)
         val fieldsObjValue = {
           js.JSObjectConstr(privateFieldDefs.toList.map { fdef =>
             implicit val pos = fdef.pos
-            js.StringLiteral(fdef.name.name.nameString) -> jstpe.zeroOf(fdef.ftpe)
+            anonJSClassFieldIdentToStringLiteral(fdef.name) -> jstpe.zeroOf(fdef.ftpe)
           })
         }
         val definePrivateFieldsObj = {
@@ -7164,7 +7164,7 @@ abstract class GenJSCode[G <: Global with Singleton](val global: G)
         } else if (isAnonymousJSClass(sym.owner)) {
           js.JSSelect(
               js.JSSelect(qual, genPrivateFieldsSymbol()),
-              encodeFieldSymAsStringLiteral(sym))
+              encodeAnonJSClassFieldSymAsStringLiteral(sym))
         } else {
           js.JSPrivateSelect(qual, encodeFieldSym(sym))
         }

--- a/compiler/src/main/scala/org/scalajs/nscplugin/JSEncoding.scala
+++ b/compiler/src/main/scala/org/scalajs/nscplugin/JSEncoding.scala
@@ -188,7 +188,16 @@ trait JSEncoding[G <: Global with Singleton] extends SubComponent {
     js.FieldIdent(FieldName(className, simpleName))
   }
 
-  def encodeFieldSymAsStringLiteral(sym: Symbol)(
+  /** Turns a FieldIdent for a private field an anon JS class into a string literal.
+   *
+   *  Since we only do that for anon JS classes, which cannot be extended, we
+   *  can ignore the `className` qualifier of the field ident.
+   */
+  def anonJSClassFieldIdentToStringLiteral(ident: js.FieldIdent): js.StringLiteral =
+    js.StringLiteral(ident.name.simpleName.nameString)(ident.pos)
+
+  /** Shortcut for `anonJSClassFieldIdentToStringLiteral(encodeFieldSym(sym))`. */
+  def encodeAnonJSClassFieldSymAsStringLiteral(sym: Symbol)(
       implicit pos: Position): js.StringLiteral = {
 
     requireSymIsField(sym)

--- a/test-suite/js/src/test/scala/org/scalajs/testsuite/jsinterop/NonNativeJSTypeTest.scala
+++ b/test-suite/js/src/test/scala/org/scalajs/testsuite/jsinterop/NonNativeJSTypeTest.scala
@@ -486,10 +486,14 @@ class NonNativeJSTypeTest {
     val obj = new js.Object {
       var x: String = _
       var y: Int = _
+      private var z: Double = _ // #5347
+
+      def getZ(): Double = z
     }
 
     assertNull(obj.asInstanceOf[js.Dynamic].x)
     assertEquals(0, obj.asInstanceOf[js.Dynamic].y)
+    assertEquals(0.0, obj.asInstanceOf[js.Dynamic].getZ())
   }
 
   @Test def anonymousClassFieldInitOrder(): Unit = {


### PR DESCRIPTION
The definition site and use sites did not agree on the encoding. That was unobservable as long as the variable was set before being read. But if we relied on the default, uninitialized value, then reading would fail.