### PR TITLE
Enable fatal warnings in Scala 3 projects.

### DIFF
--- a/linker-interface/shared/src/main/scala/org/scalajs/linker/interface/StandardConfig.scala
+++ b/linker-interface/shared/src/main/scala/org/scalajs/linker/interface/StandardConfig.scala
@@ -416,15 +416,18 @@ object StandardConfig {
           }
 
         /* Accept a hashbang comment, but only at the very beginning
-         * This is a Stage 3 proposal:
-         * https://github.com/tc39/proposal-hashbang
+         * https://262.ecma-international.org/16.0/#sec-hashbang
          * Documentation on MDN:
          * https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Lexical_grammar#hashbang_comments
          */
-        case '#' if i == 1 && len >= 2 && jsHeader.charAt(1) == '!' =>
-          i += 1
-          while (i != len && jsHeader.charAt(i) != '\n')
+        case '#' =>
+          if (i == 1 && len >= 2 && jsHeader.charAt(1) == '!') {
             i += 1
+            while (i != len && jsHeader.charAt(i) != '\n')
+              i += 1
+          } else {
+            return false
+          }
 
         /* Accept JavaScript Whitespace that are not Unicode new lines
          * https://262.ecma-international.org/12.0/#sec-white-space
@@ -432,12 +435,13 @@ object StandardConfig {
          */
         case '\t' | ' ' | 0x00a0 | 0xfeff =>
           ()
-        case _ if Character.getType(cp) == Character.SPACE_SEPARATOR =>
-          () // General category 'Zs'
-
-        // Reject anything else
         case _ =>
-          return false
+          if (Character.getType(cp) == Character.SPACE_SEPARATOR) {
+            () // General category 'Zs'
+          } else {
+            // Reject anything else
+            return false
+          }
       }
     }
 

--- a/linker-interface/shared/src/test/scala/org/scalajs/linker/interface/StandardConfigFingerprintTest.scala
+++ b/linker-interface/shared/src/test/scala/org/scalajs/linker/interface/StandardConfigFingerprintTest.scala
@@ -49,7 +49,7 @@ class StandardConfigFingerprintTest {
   @Test
   def noFingerprintCollisionRuntimeClassNameMapper(): Unit = {
     val sc1 = StandardConfig().withSemantics(_.withRuntimeClassNameMapper(
-        keepAll() andThen discardAll()))
+        keepAll().andThen(discardAll())))
     val sc2 = StandardConfig().withSemantics(_.withRuntimeClassNameMapper(
         regexReplace("""\d+""".r, "0")))
     assertFingerprintsNotEquals(sc1, sc2)

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -483,7 +483,8 @@ object Build {
 
   def addWconfSettingIf2_13(conf: String): Def.Setting[_] = {
     scalacOptions ++= {
-      if (scalaVersion.value.startsWith("2.13."))
+      val v = scalaVersion.value
+      if (v.startsWith("2.13.") || v.startsWith("3."))
         List("-Wconf:" + conf)
       else
         Nil
@@ -738,7 +739,28 @@ object Build {
   )
 
   val fatalWarningsSettings = Def.settings(
-      scalacOptions += "-Xfatal-warnings",
+      scalacOptions ++= {
+        if (scalaVersion.value.startsWith("3.")) {
+          /* Scala 3 deprecates a bunch of syntax. We cannot get rid of some of
+           * it, because we still have to cross-compile with Scala 2.
+           * We silence the corresponding warnings.
+           */
+          val messageKeywordsToSilence = List(
+            "`using` clause",
+            "`= _`",
+            "`_` is deprecated for wildcard arguments",
+            "private[this]",
+            "_*"
+          )
+          val regex = messageKeywordsToSilence.map(java.util.regex.Pattern.quote(_)).mkString("|")
+          Seq(
+            "-Werror",
+            s"-Wconf:msg=.*($regex).*:s",
+          )
+        } else {
+          Seq("-Xfatal-warnings")
+        }
+      },
 
       Compile / doc / scalacOptions := {
         val prev = (Compile / doc / scalacOptions).value
@@ -746,21 +768,6 @@ object Build {
           prev.filter(_ != "-Xfatal-warnings")
         else
           prev
-      }
-  )
-
-  /** Disables fatal warnings for Scala 3.
-   *
-   *  Scala 3 has migration warnings (e.g., implicit parameters should use `using`)
-   *  that we don't want to treat as errors for cross-compiled code.
-   */
-  val disableFatalWarningsScala3Settings = Def.settings(
-      scalacOptions := {
-        val opts = scalacOptions.value
-        if (scalaVersion.value.startsWith("3."))
-          opts.filterNot(_ == "-Xfatal-warnings")
-        else
-          opts
       }
   )
 
@@ -1112,7 +1119,6 @@ object Build {
       id = "ir", base = file("ir/jvm"), List("2.12", "2.13", "3")
   ).settings(
       commonIrProjectSettings,
-      disableFatalWarningsScala3Settings,
       libraryDependencies ++= JUnitDeps,
   )
 
@@ -1203,7 +1209,6 @@ object Build {
       id = "linkerInterface", base = file("linker-interface/jvm"), List("2.12", "2.13", "3")
   ).settings(
       commonLinkerInterfaceSettings,
-      disableFatalWarningsScala3Settings,
       libraryDependencies += "org.scala-js" %% "scalajs-logging" % "1.2.0",
       libraryDependencies ++= JUnitDeps,
   ).dependsOn(irProject, jUnitAsyncJVM % "test")
@@ -1435,7 +1440,6 @@ object Build {
       commonSettings,
       publishSettings(None),
       fatalWarningsSettings,
-      disableFatalWarningsScala3Settings,
       name := "Scala.js sbt test adapter",
       libraryDependencies ++= Seq(
           "org.scala-sbt" % "test-interface" % "1.0",
@@ -1473,8 +1477,6 @@ object Build {
           case _      => "2.0.0-RC12"
         }
       },
-
-      disableFatalWarningsScala3Settings,
 
       previousArtifactSetting,
       mimaBinaryIssueFilters ++= BinaryIncompatibilities.SbtPlugin,

--- a/sbt-plugin/src/main/scala/org/scalajs/sbtplugin/LinkerImpl.scala
+++ b/sbt-plugin/src/main/scala/org/scalajs/sbtplugin/LinkerImpl.scala
@@ -127,7 +127,7 @@ object LinkerImpl {
     )
 
     override def loadClass(name: String, resolve: Boolean): Class[_] = {
-      if (parentPrefixes.exists(name.startsWith _))
+      if (parentPrefixes.exists(name.startsWith(_)))
         super.loadClass(name, resolve)
       else
         null

--- a/sbt-plugin/src/main/scala/org/scalajs/sbtplugin/ScalaJSPlugin.scala
+++ b/sbt-plugin/src/main/scala/org/scalajs/sbtplugin/ScalaJSPlugin.scala
@@ -377,7 +377,7 @@ object ScalaJSPlugin extends AutoPlugin {
           new NodeJSEnv()
         },
 
-        scalaJSLoggerFactory := Loggers.sbtLogger2ToolsLogger _,
+        scalaJSLoggerFactory := ((logger: Logger) => Loggers.sbtLogger2ToolsLogger(logger)),
 
         // Show a deprecation message if we load the build on JDK < 17
         onLoad := {

--- a/test-adapter/src/main/scala/org/scalajs/testing/adapter/TaskAdapter.scala
+++ b/test-adapter/src/main/scala/org/scalajs/testing/adapter/TaskAdapter.scala
@@ -32,7 +32,7 @@ private[adapter] final class TaskAdapter(taskInfo: TaskInfo, runID: RunMux.RunID
     def log[T](level: Logger => (T => Unit))(log: LogElement[T]) =
       level(loggers(log.index))(log.x)
 
-    runner.attach(JVMEndpoints.event, runID)(handler.handle _)
+    runner.attach(JVMEndpoints.event, runID)(handler.handle(_))
     runner.attach(JVMEndpoints.logError, runID)(log(_.error))
     runner.attach(JVMEndpoints.logWarn, runID)(log(_.warn))
     runner.attach(JVMEndpoints.logInfo, runID)(log(_.info))


### PR DESCRIPTION
We selectively silence warnings that we cannot address because we have to cross-compile with Scala 2.