### PR TITLE
[WIP] Cache Scala.js linker task with sbt2

### DIFF
--- a/sbt-plugin/src/main/scala-2.12/org/scalajs/sbtplugin/PluginCompat.scala
+++ b/sbt-plugin/src/main/scala-2.12/org/scalajs/sbtplugin/PluginCompat.scala
@@ -28,6 +28,13 @@ private[sbtplugin] object PluginCompat {
   def virtualFileRefToFile(f: File)(implicit conv: FileConverter): File = f
   def fileToVirtualFileRef(f: File)(implicit conv: FileConverter): File = f
 
+  def withLinkerOutputCache(cacheDirectory: File, reportFile: File, configChanged: Boolean)(
+      body: Set[File] => Set[File])(realFiles: Set[File]): Set[File] = {
+    if (reportFile.exists() && configChanged)
+      reportFile.delete() // triggers re-linking through FileFunction.cached
+    FileFunction.cached(cacheDirectory, FilesInfo.lastModified, FilesInfo.exists)(body)(realFiles)
+  }
+
   def toFiles(cp: Seq[Attributed[File]])(implicit conv: FileConverter): Seq[File] =
     Attributed.data(cp)
 
@@ -81,9 +88,10 @@ private[sbtplugin] object PluginCompat {
     org % name % version cross CrossVersion.full
   }
 
-  // `Def.uncached(...)`
   implicit class DefOps(private val singleton: Def.type) extends AnyVal {
     def uncached[A](a: A): A = a
+    def cachedTask[A](a: => A): Def.Initialize[Task[A]] = Def.task(a)
+    def declareOutput[A](a: A): A = a
   }
 
 }

--- a/sbt-plugin/src/main/scala-3/org/scalajs/sbtplugin/JsonFormats.scala
+++ b/sbt-plugin/src/main/scala-3/org/scalajs/sbtplugin/JsonFormats.scala
@@ -12,14 +12,102 @@
 
 package org.scalajs.sbtplugin
 
+import java.nio.file.Paths
+
+import sbt.Attributed
+import sbt.util.StringStrings.given
 import sjsonnew._
 import sjsonnew.BasicJsonProtocol._
+import xsbti.FileConverter
 
-import org.scalajs.linker.interface.ModuleInitializer
+import org.scalajs.ir.Version
+import org.scalajs.linker.interface.{IRFile, ModuleInitializer, StandardConfig}
+import org.scalajs.linker.interface.unstable.IRFileImpl
 import org.scalajs.linker.interface.unstable.ModuleInitializerImpl
 import org.scalajs.linker.interface.unstable.ModuleInitializerImpl._
 
 trait JsonFormats {
+
+  given virtualFileRefHashWriter: HashWriter[xsbti.VirtualFileRef] with {
+    def write[J](x: xsbti.VirtualFileRef, builder: Builder[J]): Unit =
+      builder.writeString(x.id())
+  }
+
+  given versionHashWriter: HashWriter[Version] with {
+    def write[J](x: Version, builder: Builder[J]): Unit =
+      builder.writeString(x.toString)
+  }
+
+  /* This mirrors the current path encoding used by the linker implementation
+   * in `PathIRContainer`: IR files use their file path,
+   * or IR files inside JARs use "<jar path>:<entry path>".
+   * Ideally, the linker interface should expose a portable cache identity for
+   * IRFile so this logic is not duplicated here (?)
+   */
+  given irFileHashWriter(using conv: FileConverter): HashWriter[IRFile] with {
+    def write[J](x: IRFile, builder: Builder[J]): Unit = {
+      val impl = IRFileImpl.fromIRFile(x)
+      val path = impl.path
+      val portablePath = {
+        val idx = path.indexOf(".jar:")
+        if (idx >= 0) {
+          val jarEnd = idx + ".jar".length
+          val jarPath = path.substring(0, jarEnd)
+          val entry = path.substring(jarEnd) // includes the leading ':'
+          s"${conv.toVirtualFile(Paths.get(jarPath)).id}$entry"
+        } else {
+          conv.toVirtualFile(Paths.get(path)).id
+        }
+      }
+
+      builder.beginObject()
+      builder.addField("path", portablePath)
+      builder.addField("version", impl.version.toString)
+      builder.endObject()
+    }
+  }
+
+  given attributedHashWriter[T](using inner: HashWriter[T]): HashWriter[Attributed[T]] with {
+    // Only the data is currently relevant to fastLinkJS/fullLinkJS.
+    // If attributes affect linker semantics, they must be hashed explicitly here?
+    def write[J](x: Attributed[T], builder: Builder[J]): Unit =
+      inner.write(x.data, builder)
+  }
+
+  given standardConfigHashWriter: HashWriter[StandardConfig] with {
+    def write[J](x: StandardConfig, builder: Builder[J]): Unit =
+      builder.writeString(StandardConfig.fingerprint(x))
+  }
+
+  // HashWriter[T] can be derived from `JsonFormats`, but
+  // there's no inductive auto derivation is provided by sjson-new.
+
+  given seqHashWriter[T](using inner: HashWriter[T]): HashWriter[Seq[T]] with {
+    def write[J](x: Seq[T], builder: Builder[J]): Unit = {
+      builder.beginObject()
+      x.iterator.zipWithIndex.foreach { case (item, index) =>
+        inner.addField(index.toString, item, builder)
+      }
+      builder.endObject()
+    }
+  }
+
+  given emptyTupleHashWriter: HashWriter[EmptyTuple] with {
+    def write[J](x: EmptyTuple, builder: Builder[J]): Unit = {
+      builder.beginArray()
+      builder.endArray()
+    }
+  }
+
+  given consTupleHashWriter[H, T <: Tuple](
+      using H: HashWriter[H], T: HashWriter[T]): HashWriter[H *: T] with {
+    def write[J](x: H *: T, builder: Builder[J]): Unit = {
+      builder.beginArray()
+      H.write(x.head, builder)
+      T.write(x.tail, builder)
+      builder.endArray()
+    }
+  }
 
   /** Hand-written JsonFormat for ModuleInitializer.
    *

--- a/sbt-plugin/src/main/scala-3/org/scalajs/sbtplugin/PluginCompat.scala
+++ b/sbt-plugin/src/main/scala-3/org/scalajs/sbtplugin/PluginCompat.scala
@@ -19,7 +19,7 @@ import sbt.Keys.*
 import sbt.librarymanagement.DependencyResolution
 import lmcoursier.{CoursierConfiguration, CoursierDependencyResolution}
 import sbt.internal.util.StringAttributeKey
-import xsbti.{FileConverter, HashedVirtualFileRef, VirtualFile, VirtualFileRef}
+import xsbti.{FileConverter, HashedVirtualFileRef, VirtualFileRef}
 
 import org.scalajs.ir.ScalaJSVersions
 import org.scalajs.linker.interface.ModuleKind
@@ -34,6 +34,11 @@ private[sbtplugin] object PluginCompat {
 
   def fileToVirtualFileRef(f: File)(using conv: FileConverter): VirtualFileRef =
     conv.toVirtualFile(f.toPath)
+
+  def withLinkerOutputCache(cacheDirectory: File, reportFile: File, configChanged: Boolean)(
+      body: Set[File] => Set[File])(realFiles: Set[File]): Set[File] = {
+    body(realFiles)
+  }
 
   def toFiles(cp: Seq[Attributed[HashedVirtualFileRef]])(using conv: FileConverter): Seq[File] =
     cp.map(a => conv.toPath(a.data).toFile)

--- a/sbt-plugin/src/main/scala/org/scalajs/sbtplugin/ScalaJSPlugin.scala
+++ b/sbt-plugin/src/main/scala/org/scalajs/sbtplugin/ScalaJSPlugin.scala
@@ -298,6 +298,7 @@ object ScalaJSPlugin extends AutoPlugin {
      *    **Unstable API**: this API is subject to backward incompatible
      *    changes in future minor versions of Scala.js.
      */
+    @transient
     val scalaJSLoggerFactory = SettingKey[sbt.Logger => SJSLogger]("scalaJSLoggerFactory",
         "Factory for logger",
         KeyRanks.Invisible)

--- a/sbt-plugin/src/main/scala/org/scalajs/sbtplugin/ScalaJSPluginInternal.scala
+++ b/sbt-plugin/src/main/scala/org/scalajs/sbtplugin/ScalaJSPluginInternal.scala
@@ -53,7 +53,7 @@ import PluginCompat.DefOps
 /** Implementation details of `ScalaJSPlugin`. */
 private[sbtplugin] object ScalaJSPluginInternal {
 
-  import ScalaJSPlugin.autoImport.{ModuleKind => _, _}
+  import ScalaJSPlugin.autoImport.{ModuleKind => _, *, given}
 
   @tailrec
   final private def registerResource[T <: AnyRef](
@@ -207,7 +207,7 @@ private[sbtplugin] object ScalaJSPluginInternal {
 
       key / scalaJSLinkerConfig := (legacyKey / scalaJSLinkerConfig).value,
 
-      key := Def.uncached(Def.taskDyn {
+      key := Def.taskDyn {
         /* It is very important that we evaluate all of those `.value`s from
          * here, and not from within the `Def.task { ... }`, otherwise the
          * relevant dependencies will not show up in `inspect tree`. We use a
@@ -216,13 +216,12 @@ private[sbtplugin] object ScalaJSPluginInternal {
          * dynamic dependencies, so `inspect tree` is happy with it.
          */
         val s = streams.value
-        val irInfo = (key / scalaJSIR).value
-        val moduleInitializers = scalaJSModuleInitializers.value
         val reportFile = s.cacheDirectory / "linking-report.bin"
         val outputDir = (key / scalaJSLinkerOutputDirectory).value
         val linker = (key / scalaJSLinker).value
         val linkerImpl = (key / scalaJSLinkerImpl).value
         val usesLinkerTag = (key / usesScalaJSLinkerTag).value
+        implicit val fc: FileConverter = fileConverter.value
 
         val configChanged = {
           def moduleInitializersChanged = (key / scalaJSModuleInitializersFingerprints)
@@ -239,20 +238,31 @@ private[sbtplugin] object ScalaJSPluginInternal {
         def reportIncompatible =
           Report.deserialize(IO.readBytes(reportFile)).isEmpty
 
-        if (reportFile.exists() && (configChanged || reportIncompatible)) {
-          reportFile.delete() // triggers re-linking through FileFunction.cached
-        }
+        val forceRelink = // sbt1 only
+          reportFile.exists() && (configChanged || reportIncompatible)
 
-        Def.task {
+        val cachedLinkTask = Def.cachedTask {
           val log = s.log
           val tlog = scalaJSLoggerFactory.value(log)
 
+          val irInfo = (key / scalaJSIR).value
           val realFiles = PluginCompat.attributedGetFiles(irInfo, scalaJSSourceFiles).get
           val ir = irInfo.data
+          val moduleInitializers = scalaJSModuleInitializers.value
+          val linkerConfig = (key / scalaJSLinkerConfig).value
 
-          FileFunction.cached(s.cacheDirectory, FilesInfo.lastModified,
-              FilesInfo.exists) { _ => // We don't need the files
+          /* Put `scalaJSLinkerOutputDirectory` as the action-cache key
+           * in the VirtualFileRef form (not as an absolute File path).
+           * Upcast to `VirtualFileRef` so sbt try not to hash based on the file content.
+           */
+          val outputDirRef = Def.task[xsbti.VirtualFileRef] {
+            fileConverter.value.toVirtualFile(
+                (key / scalaJSLinkerOutputDirectory).value.toPath)
+          }.value
+          val outputDir = fileConverter.value.toPath(outputDirRef).toFile
 
+          val generatedFiles = PluginCompat.withLinkerOutputCache(
+              s.cacheDirectory, reportFile, forceRelink) { _ =>
             val stageName = stage match {
               case Stage.FastOpt => "Fast"
               case Stage.FullOpt => "Full"
@@ -278,6 +288,32 @@ private[sbtplugin] object ScalaJSPluginInternal {
             IO.listFiles(outputDir).toSet + reportFile
           }(realFiles.toSet)
 
+          /* Declare files individually instead of `Def.declareOutputDirectory`.
+           * In sbt 2, the default `target` is under target/out/..., but
+           * `scalaJSLinkerOutputDirectory` can be set elsewhere, such as
+           * target/fastopt. Directory outputs are packed relative to the sbt
+           * `target`, so target/fastopt files may become "../fastopt/..."
+           * zip entries and be rejected on restore.
+           */
+          generatedFiles.foreach { file =>
+            Def.unit(Def.declareOutput(fc.toVirtualFile(file.toPath)))
+          }
+          ()
+        }.tag(usesLinkerTag, ScalaJSTags.Link)
+
+        /* Build the `Attributed[Report]` outside the cache so it always have
+         * the current output directory, not a cached absolute path from another
+         * build. For example, a cache entry produced in /tmp/build-A must not
+         * make a later /tmp/build-B run return /tmp/build-A/target/... here.
+         *
+         * Internally, we read that attribute in `fastLinkJSOutput` and
+         * `jsEnvInput`, and we might want to store the outputDir in relative path.
+         * However, downstream builds may read this public task result directly.
+         * Therefore, keeping that contract; attribute contains absolute path for now.
+         */
+        Def.uncached(Def.task {
+          Def.unit(cachedLinkTask.value)
+
           val report = Report.deserialize(IO.readBytes(reportFile)).getOrElse {
             throw new MessageOnlyException(
                 "Failed to deserialize report after linking. " +
@@ -287,8 +323,8 @@ private[sbtplugin] object ScalaJSPluginInternal {
           PluginCompat.attributedPutFile(
               Attributed.blank(report),
               scalaJSLinkerOutputDirectory.key, outputDir)
-        }.tag(usesLinkerTag, ScalaJSTags.Link)
-      }.value),
+        })
+      }.value,
 
       outputKey := Def.uncached {
         linkerOutputDirectory(key.value, resolvedScoped.value.scope, key)


### PR DESCRIPTION
This PR is still an experimental to see what challenges are there for implementing the link task using sbt2's action cache.

---

Previously, the sbt plugin relied on `FileFunction.cached` inside the link tasks, based on configuration and input sources.

This commit tries to use sbt2 action caching for `fastLinkJS` and `fullLinkJS` while sbt1 remains using `FileFunction.cached`.