### PR TITLE
Opt: Use a branchless if in RuntimeLong.{add,sub,abs}.

### DIFF
--- a/ir/shared/src/main/scala/org/scalajs/ir/Printers.scala
+++ b/ir/shared/src/main/scala/org/scalajs/ir/Printers.scala
@@ -418,7 +418,7 @@ object Printers {
               p("((byte)", ")")
             case IntToShort =>
               p("((short)", ")")
-            case CharToInt | ByteToInt | ShortToInt | LongToInt | DoubleToInt =>
+            case CharToInt | ByteToInt | ShortToInt | LongToInt | DoubleToInt | BoolToInt =>
               p("((int)", ")")
             case IntToLong | DoubleToLong =>
               p("((long)", ")")

--- a/ir/shared/src/main/scala/org/scalajs/ir/ScalaJSVersions.scala
+++ b/ir/shared/src/main/scala/org/scalajs/ir/ScalaJSVersions.scala
@@ -17,8 +17,8 @@ import java.util.concurrent.ConcurrentHashMap
 import scala.util.matching.Regex
 
 object ScalaJSVersions extends VersionChecks(
-      current = "1.21.1-SNAPSHOT",
-      binaryEmitted = "1.21"
+      current = "1.22.0-SNAPSHOT",
+      binaryEmitted = "1.22-SNAPSHOT"
     )
 
 /** Helper class to allow for testing of logic. */

--- a/ir/shared/src/main/scala/org/scalajs/ir/Trees.scala
+++ b/ir/shared/src/main/scala/org/scalajs/ir/Trees.scala
@@ -546,6 +546,9 @@ object Trees {
     final val Long_clz = 37
     final val UnsignedIntToLong = 38
 
+    // Bool to int, introduced in 1.22
+    final val BoolToInt = 39
+
     def isClassOp(op: Code): Boolean =
       op >= Class_name && op <= Class_superClass
 
@@ -568,7 +571,7 @@ object Trees {
         ShortType
       case CharToInt | ByteToInt | ShortToInt | LongToInt | DoubleToInt |
           String_length | Array_length | IdentityHashCode | Float_toBits |
-          Int_clz | Long_clz =>
+          Int_clz | Long_clz | BoolToInt =>
         IntType
       case IntToLong | DoubleToLong | Double_toBits | UnsignedIntToLong =>
         LongType

--- a/ir/shared/src/test/scala/org/scalajs/ir/PrintersTest.scala
+++ b/ir/shared/src/test/scala/org/scalajs/ir/PrintersTest.scala
@@ -531,6 +531,8 @@ class PrintersTest {
     assertPrintEquals("<clz>(x)", UnaryOp(Long_clz, ref("x", LongType)))
 
     assertPrintEquals("<toLongUnsigned>(x)", UnaryOp(UnsignedIntToLong, ref("x", IntType)))
+
+    assertPrintEquals("((int)x)", UnaryOp(BoolToInt, ref("x", BooleanType)))
   }
 
   @Test def printPseudoUnaryOp(): Unit = {

--- a/linker-private-library/src/main/scala/org/scalajs/linker/runtime/RuntimeLong.scala
+++ b/linker-private-library/src/main/scala/org/scalajs/linker/runtime/RuntimeLong.scala
@@ -197,25 +197,16 @@ object RuntimeLong {
 
   @inline
   def add(alo: Int, ahi: Int, blo: Int, bhi: Int): Long = {
-    // Hacker's Delight, Section 2-16
     val lo = alo + blo
     pack(lo,
-        ahi + bhi + (((alo & blo) | ((alo | blo) & ~lo)) >>> 31))
+        ahi + bhi + (if (inlineUnsignedInt_<(lo, alo)) 1 else 0)) // branchless if
   }
 
   @inline
   def sub(alo: Int, ahi: Int, blo: Int, bhi: Int): Long = {
-    /* Hacker's Delight, Section 2-16
-     *
-     * We deviate a bit from the original algorithm. Hacker's Delight uses
-     * `- (... >>> 31)`. Instead, we use `+ (... >> 31)`. These are equivalent,
-     * since `(x >> 31) == -(x >>> 31)` for all x. The variant with `+` folds
-     * better when `a.hi` and `b.hi` are both known to be 0. This happens in
-     * practice when `a` and `b` are 0-extended from `Int` values.
-     */
     val lo = alo - blo
     pack(lo,
-        ahi - bhi + (((~alo & blo) | (~(alo ^ blo) & lo)) >> 31))
+        ahi - bhi - (if (inlineUnsignedInt_>(lo, alo)) 1 else 0)) // branchless if
   }
 
   @inline
@@ -1347,89 +1338,27 @@ object RuntimeLong {
      * However, a naive application of that formula does not give good code for
      * our RuntimeLong implementation.
      *
-     * Let a be the input value RTLong(lo, hi). Overall, we want to compute:
-     *   val longSign = a >> 63
-     *   (a ^ longSign) + (if (longSign) 1L else 0L)
-     * The last addition is performed as `- longSign` in the original formula.
-     * For our purpose, it is more convenient to take a step back and express
-     * it as the if expression.
+     * Spec:
+     * - if a = (lo, hi) >= 0L, return a
+     * - otherwise, return `0L - a`
      *
-     * First, observe that `longSign.lo` and `longSign.hi` are both equal to
-     * `hi >> 31`. We therefore define
-     *   val sign = hi >> 31
-     * and rewrite our second expression by expanding the long xor:
-     *   RTLong(lo ^ sign, hi ^ sign) + (if (sign) 1L else 0L)
+     * Proof:
      *
-     * Making the lo/hi words of the result of the xor explicit, we get:
+     * If a >= 0, we have sign = 0, and we can verify that r = x = a.
      *
-     *   val xlo = lo ^ sign
-     *   val xhi = hi ^ sign
-     *   RTLong(xlo, xhi) + (if (sign) 1L else 0L)
-     *
-     * At this point, it is convenient to examine what happens when we expand
-     * the addition, assuming that the 1L branch is taken. We expand
-     * `RTLong(xlo, xhi) + RTLong(1, 0)` and get:
-     *
-     *   val rlo = xlo + 1
-     *   val rhi = xhi + 0 + (((xlo & 1) | ((xlo | 1) & ~rlo)) >>> 31)
-     *   val rhi = xhi + (((xlo & 1) | ((xlo | 1) & ~rlo)) >>> 31)
-     *
-     * Since only the most significant bit of the complicated logic expression
-     * is relevant, we can rewrite the 1's as 0's so that `& 0` and `| 0` fold
-     * away:
-     *
-     *   val rhi = xhi + (((xlo & 0) | ((xlo | 0) & ~rlo)) >>> 31)
-     *           = xhi + (((      0) | ((xlo    ) & ~rlo)) >>> 31)
-     *           = xhi + ((       0  | ( xlo      & ~rlo)) >>> 31)
-     *           = xhi + ((            ( xlo      & ~rlo)) >>> 31)
-     *           = xhi + ((xlo & ~rlo) >>> 31)
-     *
-     * If the 0L branch was taken, then we should instead have
-     *
-     *   val rlo = xlo + 0 = xlo
-     *   val rhi = xhi + 0 = xhi
-     *
-     * Let us put back together everything we have so far:
-     *
-     *   val sign = hi >> 31
-     *   val xlo = lo ^ sign
-     *   val xhi = hi ^ sign
-     *   val rlo = xlo + (if (sign) 1 else 0)
-     *   val rhi = xhi + (if (sign) ((xlo & ~rlo) >>> 31) else 0)
-     *
-     * We can remove the branch for rlo as
-     *
-     *   val rlo = xlo - sign
-     *
-     * Now let's just imagine we always took the then branch for rhi. We would
-     * overall get:
-     *
-     *   val sign = hi >> 31
-     *   val xlo = lo ^ sign
-     *   val xhi = hi ^ sign
-     *   val rlo = xlo - sign
-     *   val rhi = xhi + ((xlo & ~rlo) >>> 31)
-     *
-     * That's correct when `sign = -1`. But what happens when `sign = 0`? Let
-     * us work it out:
-     *
-     *   val sign = 0
-     *   val xlo = lo ^ sign = lo
-     *   val xhi = hi ^ sign = hi
-     *   val rlo = xlo - sign = xlo = lo
-     *   val rhi = xhi + ((xlo & ~rlo) >>> 31)
-     *           = xhi + (( lo & ~lo) >>> 31)
-     *           = xhi + ((    0    ) >>> 31)
-     *           = xhi + 0
-     *
-     * Bingo! It works as well! So we can take the code of the "let's just
-     * imagine" step. We inline the rhs of xhi at the only place where it is
-     * used, and we get the final algorithm.
+     * Otherwise, sign = -1, therefore x = (~alo, ~ahi) = ~a.
+     *   rlo = xlo - sign = xlo + 1
+     *   rhi = xhi + 0 + (rlo < xlo)
+     * Observe that (rlo, rhi) is the expansion of add(x, 1L).
+     * Therefore,
+     *   r = x + 1L = ~a + 1L = 0L - a
+     * as desired.
      */
     val sign = hi >> 31
     val xlo = lo ^ sign
+    // val xhi = hi ^ sign ; but we integrate that directly in rhi for code size
     val rlo = xlo - sign
-    val rhi = (hi ^ sign) + ((xlo & ~rlo) >>> 31)
+    val rhi = (hi ^ sign) + (if (inlineUnsignedInt_<(rlo, xlo)) 1 else 0)
     pack(rlo, rhi)
   }
 

--- a/linker/shared/src/main/scala/org/scalajs/linker/backend/emitter/FunctionEmitter.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/backend/emitter/FunctionEmitter.scala
@@ -2973,6 +2973,9 @@ private[emitter] class FunctionEmitter(sjsGen: SJSGen) {
                 js.Apply(genGlobalVarRef("BigInt"), List(shr0(newLhs)))
               else
                 genLongApplyStatic(LongImpl.fromUnsignedInt, newLhs)
+
+            case BoolToInt =>
+              or0(newLhs) // branchless at least in V8 and SpiderMonkey
           }
 
         case BinaryOp(op, lhs, rhs) =>

--- a/linker/shared/src/main/scala/org/scalajs/linker/backend/wasmemitter/FunctionEmitter.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/backend/wasmemitter/FunctionEmitter.scala
@@ -1538,7 +1538,7 @@ private class FunctionEmitter private (
         fb += wa.I32Eqz
 
       // Widening conversions
-      case CharToInt | ByteToInt | ShortToInt =>
+      case CharToInt | ByteToInt | ShortToInt | BoolToInt =>
         /* These are no-ops because they are all represented as i32's with the
          * right mathematical value.
          */

--- a/linker/shared/src/main/scala/org/scalajs/linker/checker/IRChecker.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/checker/IRChecker.scala
@@ -545,7 +545,7 @@ private final class IRChecker(linkTimeProperties: LinkTimeProperties,
       case UnaryOp(op, lhs) =>
         import UnaryOp._
         val expectedArgType = (op: @switch) match {
-          case Boolean_! =>
+          case Boolean_! | BoolToInt =>
             BooleanType
           case CharToInt =>
             CharType

--- a/linker/shared/src/main/scala/org/scalajs/linker/frontend/optimizer/OptimizerCore.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/frontend/optimizer/OptimizerCore.scala
@@ -482,10 +482,13 @@ private[optimizer] abstract class OptimizerCore(
 
       case tree @ If(cond, thenp, elsep) =>
         trampoline {
-          /* foldIf only ever folds things of type boolean. Avoid
+          /* foldIf only ever folds things of type boolean or int. Avoid
            * pretransforming the branches when that is never going to be useful.
            */
-          if (isStat || thenp.tpe != BooleanType || elsep.tpe != BooleanType) {
+          def isIntOrBool(tpe: Type): Boolean =
+            tpe == IntType || tpe == BooleanType
+
+          if (isStat || !isIntOrBool(thenp.tpe) || !isIntOrBool(elsep.tpe)) {
             pretransformExpr(cond) { tcond =>
               val resultTree = tcond match {
                 case _ if tcond.tpe.isNothingType =>
@@ -3763,6 +3766,19 @@ private[optimizer] abstract class OptimizerCore(
 
             case _ => default
           }
+        } else if (thenp.tpe.base == IntType && elsep.tpe.base == IntType) {
+          (thenp, elsep) match {
+            // if (cond) 1 else 0  -->  (int) cond
+            case (PreTransLit(IntLiteral(1)), PreTransLit(IntLiteral(0))) =>
+              foldUnaryOp(UnaryOp.BoolToInt, cond)
+
+            // if (cond) 0 else 1  -->  (int) !cond
+            case (PreTransLit(IntLiteral(0)), PreTransLit(IntLiteral(1))) =>
+              foldUnaryOp(UnaryOp.BoolToInt, foldNot(cond))
+
+            case _ =>
+              default
+          }
         } else {
           default
         }
@@ -4326,6 +4342,16 @@ private[optimizer] abstract class OptimizerCore(
         arg match {
           case PreTransLit(IntLiteral(v)) =>
             PreTransLit(LongLiteral(Integer.toUnsignedLong(v)))
+          case _ =>
+            default
+        }
+
+      // bool to int
+
+      case BoolToInt =>
+        arg match {
+          case PreTransLit(BooleanLiteral(v)) =>
+            PreTransLit(IntLiteral(if (v) 1 else 0))
           case _ =>
             default
         }

--- a/linker/shared/src/test/scala/org/scalajs/linker/LibrarySizeTest.scala
+++ b/linker/shared/src/test/scala/org/scalajs/linker/LibrarySizeTest.scala
@@ -71,8 +71,8 @@ class LibrarySizeTest {
     )
 
     testLinkedSizes(
-      expectedFastLinkSize = 143862,
-      expectedFullLinkSize = 87488,
+      expectedFastLinkSize = 143615,
+      expectedFullLinkSize = 87404,
       classDefs,
       moduleInitializers = MainTestModuleInitializers
     )
@@ -105,8 +105,8 @@ class LibrarySizeTest {
     )
 
     testLinkedSizes(
-      expectedFastLinkSize = 65253,
-      expectedFullLinkSize = 44710,
+      expectedFastLinkSize = 65052,
+      expectedFullLinkSize = 44509,
       classDefs,
       moduleInitializers = MainTestModuleInitializers
     )
@@ -122,8 +122,8 @@ class LibrarySizeTest {
     )
 
     testLinkedSizes(
-      expectedFastLinkSize = 94876,
-      expectedFullLinkSize = 73586,
+      expectedFastLinkSize = 94675,
+      expectedFullLinkSize = 73385,
       classDefs,
       moduleInitializers = MainTestModuleInitializers
     )
@@ -140,8 +140,8 @@ class LibrarySizeTest {
     )
 
     testLinkedSizes(
-      expectedFastLinkSize = 96670,
-      expectedFullLinkSize = 75038,
+      expectedFastLinkSize = 96469,
+      expectedFullLinkSize = 74837,
       classDefs,
       moduleInitializers = MainTestModuleInitializers
     )

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -2167,14 +2167,14 @@ object Build {
             if (!useMinifySizes) {
               Some(ExpectedSizes(
                   fastLink = 619000 to 620000,
-                  fullLink = 283000 to 284000,
+                  fullLink = 282000 to 283000,
                   fastLinkGz = 75000 to 76000,
                   fullLinkGz = 43000 to 44000,
               ))
             } else {
               Some(ExpectedSizes(
                   fastLink = 425000 to 426000,
-                  fullLink = 283000 to 284000,
+                  fullLink = 282000 to 283000,
                   fastLinkGz = 61000 to 62000,
                   fullLinkGz = 43000 to 44000,
               ))


### PR DESCRIPTION
Alternative to #5355 where we introduce an actual `UnaryOp.BoolToInt` to capture the semantics of `if (cond) 1 else 0`.