### PR TITLE
Remove obsolete Node.js options for Wasm.

### DIFF
--- a/TESTING.md
+++ b/TESTING.md
@@ -29,9 +29,6 @@ $ python3 -m http.server
 
 WebAssembly requires modules, so this is manual as well.
 
-This test currently requires Chrome (or another V8-based browser) with `--wasm-experimental-exnref` enabled.
-That option can be configured as "Experimental WebAssembly" at [chrome://flags/#enable-experimental-webassembly-features](chrome://flags/#enable-experimental-webassembly-features).
-
 ```
 $ sbt
 > set Global/enableWasmEverywhere := true

--- a/partest/src/main/scala/scala/tools/nsc/MainGenericRunner.scala
+++ b/partest/src/main/scala/scala/tools/nsc/MainGenericRunner.scala
@@ -135,21 +135,12 @@ class MainGenericRunner {
         dir.resolve(report.publicModules.head.jsFileName)
       }
 
-      val jsEnvConfig: NodeJSEnv.Config = if (!useWasm) {
-        NodeJSEnv.Config()
-      } else {
-        NodeJSEnv.Config().withArgs(List(
-          "--experimental-wasm-exnref",
-          "--experimental-wasm-imported-strings" // for JS string builtins
-        ))
-      }
-
       val input =
         if (useESModule) Input.ESModule(sjsCode) :: Nil
         else Input.Script(sjsCode) :: Nil
       val config = RunConfig().withLogger(logger)
 
-      val run = new NodeJSEnv(jsEnvConfig).start(input, config)
+      val run = new NodeJSEnv().start(input, config)
       try {
         Await.result(run.future, Duration.Inf)
       } finally {

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -243,16 +243,7 @@ object MyScalaJSPlugin extends AutoPlugin {
       wantSourceMaps := true,
 
       jsEnv := {
-        val baseConfig = NodeJSEnv.Config().withSourceMap(wantSourceMaps.value)
-        val config = if (enableWasmEverywhere.value) {
-          baseConfig.withArgs(List(
-            "--experimental-wasm-exnref",
-            "--experimental-wasm-imported-strings", // for JS string builtins
-            "--experimental-wasm-jspi", // for JSPI, used by async/await
-          ))
-        } else {
-          baseConfig
-        }
+        val config = NodeJSEnv.Config().withSourceMap(wantSourceMaps.value)
         new NodeJSEnv(config)
       },
 


### PR DESCRIPTION
They are not necessary anymore with Node.js 25, and they won't be *allowed* with Node.js 26.