### PR TITLE
Fix the syntax in LazyListBase for older versions of Scala 2.13.x.

### DIFF
--- a/scalalib/overrides-2.13/scala/collection/immutable/LazyListBase.scala
+++ b/scalalib/overrides-2.13/scala/collection/immutable/LazyListBase.scala
@@ -28,10 +28,10 @@ abstract class LazyListBase[+A] private[immutable] (initialTail: AnyRef) extends
 
 private[immutable] object LazyListBase {
   final class TailUpdater {
-    @inline def compareAndSet(ll: LazyListBase[?], expected: AnyRef, value: AnyRef): Boolean =
+    @inline def compareAndSet(ll: LazyListBase[_], expected: AnyRef, value: AnyRef): Boolean =
       if (ll._tail eq expected) { ll._tail = value; true } else false
 
-    @inline def getAndSet(ll: LazyListBase[?], value: AnyRef): AnyRef = {
+    @inline def getAndSet(ll: LazyListBase[_], value: AnyRef): AnyRef = {
       val old = ll._tail
       ll._tail = value
       old


### PR DESCRIPTION
Caught by the nightly build. I configured this PR's CI to run a `full` build.