### PR TITLE
Make the WebAssembly backend non-experimental.

### DIFF
--- a/linker-interface/shared/src/main/scala/org/scalajs/linker/interface/ESFeatures.scala
+++ b/linker-interface/shared/src/main/scala/org/scalajs/linker/interface/ESFeatures.scala
@@ -44,6 +44,7 @@ final class ESFeatures private (
      * (putting Scaladoc comments on constructor param `val`s has no effect).
      */
     _esVersion: ESVersion,
+    _useWebAssembly: Boolean,
     _allowBigIntsForLongs: Boolean,
     _avoidClasses: Boolean,
     _avoidLetsAndsConsts: Boolean
@@ -53,6 +54,7 @@ final class ESFeatures private (
   private def this() = {
     this(
       _esVersion = ESVersion.ES2015,
+      _useWebAssembly = false,
       _allowBigIntsForLongs = false,
       _avoidClasses = true,
       _avoidLetsAndsConsts = true
@@ -72,6 +74,27 @@ final class ESFeatures private (
    *  feature tests.
    */
   val esVersion: ESVersion = _esVersion
+
+  /** Specifies whether to use the WebAssembly backend.
+   *
+   *  When `true`, the following properties must also hold:
+   *
+   *  - `config.moduleKind == ModuleKind.ESModule` (from `StandardConfig`)
+   *  - `esVersion >= ESVersion.ES2022`
+   *
+   *  We may lift these restrictions in the future, although we do not expect
+   *  to do so.
+   *
+   *  If any of these restrictions are not met, linking will eventually throw
+   *  an `IllegalArgumentException`.
+   *
+   *  @note
+   *    The WebAssembly backend silently ignores `@JSExport` and `@JSExportAll`
+   *    annotations. This restriction will be lifted in the future when opting
+   *    in to the Custom Descriptors proposal.
+   *    All other language features are supported.
+   */
+  val useWebAssembly: Boolean = _useWebAssembly
 
   /** Use the ECMAScript 2015 semantics of Scala.js language features.
    *
@@ -185,6 +208,9 @@ final class ESFeatures private (
   def withESVersion(esVersion: ESVersion): ESFeatures =
     copy(esVersion = esVersion)
 
+  def withUseWebAssembly(useWebAssembly: Boolean): ESFeatures =
+    copy(useWebAssembly = useWebAssembly)
+
   /** Specifies whether the linker should use ECMAScript 2015 features.
    *
    *  If `false`, this method sets the `esVersion` to `ESVersion.ES5_1`.
@@ -212,6 +238,7 @@ final class ESFeatures private (
   override def equals(that: Any): Boolean = that match {
     case that: ESFeatures =>
       this.esVersion == that.esVersion &&
+      this.useWebAssembly == that.useWebAssembly &&
       this.allowBigIntsForLongs == that.allowBigIntsForLongs &&
       this.avoidClasses == that.avoidClasses &&
       this.avoidLetsAndConsts == that.avoidLetsAndConsts
@@ -223,15 +250,17 @@ final class ESFeatures private (
     import scala.util.hashing.MurmurHash3._
     var acc = HashSeed
     acc = mix(acc, esVersion.##)
+    acc = mix(acc, useWebAssembly.##)
     acc = mix(acc, allowBigIntsForLongs.##)
     acc = mix(acc, avoidClasses.##)
     acc = mixLast(acc, avoidLetsAndConsts.##)
-    finalizeHash(acc, 4)
+    finalizeHash(acc, 5)
   }
 
   override def toString(): String = {
     s"""ESFeatures(
        |  esVersion = $esVersion,
+       |  useWebAssembly = $useWebAssembly,
        |  useECMAScript2015Semantics = $useECMAScript2015Semantics,
        |  allowBigIntsForLongs = $allowBigIntsForLongs,
        |  avoidClasses = $avoidClasses,
@@ -241,12 +270,14 @@ final class ESFeatures private (
 
   private def copy(
       esVersion: ESVersion = this.esVersion,
+      useWebAssembly: Boolean = this.useWebAssembly,
       allowBigIntsForLongs: Boolean = this.allowBigIntsForLongs,
       avoidClasses: Boolean = this.avoidClasses,
       avoidLetsAndConsts: Boolean = this.avoidLetsAndConsts
   ): ESFeatures = {
     new ESFeatures(
       _esVersion = esVersion,
+      _useWebAssembly = useWebAssembly,
       _allowBigIntsForLongs = allowBigIntsForLongs,
       _avoidClasses = avoidClasses,
       _avoidLetsAndsConsts = avoidLetsAndConsts
@@ -261,6 +292,7 @@ object ESFeatures {
   /** Default configuration of ECMAScript features.
    *
    *  - `esVersion`: `ESVersion.ES2015`
+   *  - `useWebAssembly`: false
    *  - `useECMAScript2015Semantics`: true
    *  - `allowBigIntsForLongs`: false
    *  - `avoidClasses`: true
@@ -273,6 +305,7 @@ object ESFeatures {
     override def fingerprint(esFeatures: ESFeatures): String = {
       new FingerprintBuilder("ESFeatures")
         .addField("esVersion", esFeatures.esVersion)
+        .addField("useWebAssembly", esFeatures.useWebAssembly)
         .addField("allowBigIntsForLongs", esFeatures.allowBigIntsForLongs)
         .addField("avoidClasses", esFeatures.avoidClasses)
         .addField("avoidLetsAndConsts", esFeatures.avoidLetsAndConsts)

--- a/linker-interface/shared/src/main/scala/org/scalajs/linker/interface/StandardConfig.scala
+++ b/linker-interface/shared/src/main/scala/org/scalajs/linker/interface/StandardConfig.scala
@@ -86,9 +86,7 @@ final class StandardConfig private (
      */
     val batchMode: Boolean,
     /** The maximum number of (file) writes executed concurrently. */
-    val maxConcurrentWrites: Int,
-    /** If true, use the experimental WebAssembly backend. */
-    val experimentalUseWebAssembly: Boolean
+    val maxConcurrentWrites: Int
 ) {
   private def this() = {
     this(
@@ -108,10 +106,13 @@ final class StandardConfig private (
       closureCompilerIfAvailable = false,
       prettyPrint = false,
       batchMode = false,
-      maxConcurrentWrites = 50,
-      experimentalUseWebAssembly = false
+      maxConcurrentWrites = 50
     )
   }
+
+  /** If true, use the WebAssembly backend. */
+  @deprecated("Use esFeatures.useWebAssembly instead.", since = "1.22.0")
+  val experimentalUseWebAssembly: Boolean = esFeatures.useWebAssembly
 
   def withSemantics(semantics: Semantics): StandardConfig =
     copy(semantics = semantics)
@@ -199,36 +200,9 @@ final class StandardConfig private (
   def withMaxConcurrentWrites(maxConcurrentWrites: Int): StandardConfig =
     copy(maxConcurrentWrites = maxConcurrentWrites)
 
-  /** Specifies whether to use the experimental WebAssembly backend.
-   *
-   *  When using this setting, the following properties must also hold:
-   *
-   *  - `moduleKind == ModuleKind.ESModule`
-   *  - `esFeatures.esVersion >= ESVersion.ES2022`
-   *
-   *  We may lift these restrictions in the future, although we do not expect
-   *  to do so.
-   *
-   *  If any of these restrictions are not met, linking will eventually throw
-   *  an `IllegalArgumentException`.
-   *
-   *  @note
-   *    Currently, the WebAssembly backend silently ignores `@JSExport` and
-   *    `@JSExportAll` annotations. This behavior may change in the future,
-   *    either by making them warnings or errors, or by adding support for them.
-   *    All other language features are supported.
-   *
-   *  @note
-   *    This setting is experimental. It may be removed in an upcoming *minor*
-   *    version of Scala.js. Future minor versions may also produce code that
-   *    requires more recent versions of JS engines supporting newer WebAssembly
-   *    standards.
-   *
-   *  @throws java.lang.UnsupportedOperationException
-   *    In the future, if the feature gets removed.
-   */
+  @deprecated("Use withESFeatures(_.withUseWebAssembly(.)) instead.", since = "1.22.0")
   def withExperimentalUseWebAssembly(experimentalUseWebAssembly: Boolean): StandardConfig =
-    copy(experimentalUseWebAssembly = experimentalUseWebAssembly)
+    withESFeatures(_.withUseWebAssembly(experimentalUseWebAssembly))
 
   override def toString(): String = {
     s"""StandardConfig(
@@ -249,7 +223,6 @@ final class StandardConfig private (
        |  prettyPrint                = $prettyPrint,
        |  batchMode                  = $batchMode,
        |  maxConcurrentWrites        = $maxConcurrentWrites,
-       |  experimentalUseWebAssembly = $experimentalUseWebAssembly,
        |)""".stripMargin
   }
 
@@ -270,8 +243,7 @@ final class StandardConfig private (
       closureCompilerIfAvailable: Boolean = closureCompilerIfAvailable,
       prettyPrint: Boolean = prettyPrint,
       batchMode: Boolean = batchMode,
-      maxConcurrentWrites: Int = maxConcurrentWrites,
-      experimentalUseWebAssembly: Boolean = experimentalUseWebAssembly
+      maxConcurrentWrites: Int = maxConcurrentWrites
   ): StandardConfig = {
     new StandardConfig(
       semantics,
@@ -290,8 +262,7 @@ final class StandardConfig private (
       closureCompilerIfAvailable,
       prettyPrint,
       batchMode,
-      maxConcurrentWrites,
-      experimentalUseWebAssembly
+      maxConcurrentWrites
     )
   }
 }
@@ -322,7 +293,6 @@ object StandardConfig {
         .addField("prettyPrint", config.prettyPrint)
         .addField("batchMode", config.batchMode)
         .addField("maxConcurrentWrites", config.maxConcurrentWrites)
-        .addField("experimentalUseWebAssembly", config.experimentalUseWebAssembly)
         .build()
     }
   }
@@ -351,7 +321,6 @@ object StandardConfig {
    *  - `prettyPrint`: `false`
    *  - `batchMode`: `false`
    *  - `maxConcurrentWrites`: `50`
-   *  - `experimentalUseWebAssembly`: `false`
    */
   def apply(): StandardConfig = new StandardConfig()
 

--- a/linker/shared/src/main/scala/org/scalajs/linker/backend/LinkerBackendImpl.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/backend/LinkerBackendImpl.scala
@@ -39,7 +39,7 @@ abstract class LinkerBackendImpl(
 
 object LinkerBackendImpl {
   def apply(config: Config): LinkerBackendImpl = {
-    if (config.experimentalUseWebAssembly)
+    if (config.commonConfig.coreSpec.targetIsWebAssembly)
       new WebAssemblyLinkerBackend(config)
     else
       LinkerBackendImplPlatform.createJSLinkerBackend(config)
@@ -66,9 +66,7 @@ object LinkerBackendImpl {
       /** Pretty-print the output. */
       val prettyPrint: Boolean,
       /** The maximum number of (file) writes executed concurrently. */
-      val maxConcurrentWrites: Int,
-      /** If true, use the experimental WebAssembly backend. */
-      val experimentalUseWebAssembly: Boolean
+      val maxConcurrentWrites: Int
   ) {
     private def this() = {
       this(
@@ -80,8 +78,7 @@ object LinkerBackendImpl {
         minify = false,
         closureCompilerIfAvailable = false,
         prettyPrint = false,
-        maxConcurrentWrites = 50,
-        experimentalUseWebAssembly = false
+        maxConcurrentWrites = 50
       )
     }
 
@@ -124,9 +121,6 @@ object LinkerBackendImpl {
     def withMaxConcurrentWrites(maxConcurrentWrites: Int): Config =
       copy(maxConcurrentWrites = maxConcurrentWrites)
 
-    def withExperimentalUseWebAssembly(experimentalUseWebAssembly: Boolean): Config =
-      copy(experimentalUseWebAssembly = experimentalUseWebAssembly)
-
     private def copy(
         commonConfig: CommonPhaseConfig = commonConfig,
         jsHeader: String = jsHeader,
@@ -136,8 +130,7 @@ object LinkerBackendImpl {
         minify: Boolean = minify,
         closureCompilerIfAvailable: Boolean = closureCompilerIfAvailable,
         prettyPrint: Boolean = prettyPrint,
-        maxConcurrentWrites: Int = maxConcurrentWrites,
-        experimentalUseWebAssembly: Boolean = experimentalUseWebAssembly
+        maxConcurrentWrites: Int = maxConcurrentWrites
     ): Config = {
       new Config(
         commonConfig,
@@ -148,8 +141,7 @@ object LinkerBackendImpl {
         minify,
         closureCompilerIfAvailable,
         prettyPrint,
-        maxConcurrentWrites,
-        experimentalUseWebAssembly
+        maxConcurrentWrites
       )
     }
   }

--- a/linker/shared/src/main/scala/org/scalajs/linker/standard/CoreSpec.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/standard/CoreSpec.scala
@@ -23,9 +23,7 @@ final class CoreSpec private (
     /** ECMAScript features to use. */
     val esFeatures: ESFeatures,
     /** Wasm features to use. */
-    val wasmFeatures: WasmFeatures,
-    /** Whether we are compiling to WebAssembly. */
-    val targetIsWebAssembly: Boolean
+    val wasmFeatures: WasmFeatures
 ) {
   import CoreSpec._
 
@@ -34,10 +32,19 @@ final class CoreSpec private (
       semantics = Semantics.Defaults,
       moduleKind = ModuleKind.NoModule,
       esFeatures = ESFeatures.Defaults,
-      wasmFeatures = WasmFeatures.Defaults,
-      targetIsWebAssembly = false
+      wasmFeatures = WasmFeatures.Defaults
     )
   }
+
+  /** `true` iff we are targeting WebAssembly.
+   *
+   *  Currently, this is only true if `esFeatures.useWebAssembly` is true.
+   *  However, in the future, it may also report true for Wasm-only module
+   *  kinds that do not depend on `ESFeatures`. It is therefore the recommended
+   *  way to test whether non-interop code uses Wasm, for example for
+   *  performance-related decisions.
+   */
+  val targetIsWebAssembly: Boolean = esFeatures.useWebAssembly
 
   def withSemantics(semantics: Semantics): CoreSpec =
     copy(semantics = semantics)
@@ -60,16 +67,16 @@ final class CoreSpec private (
   def withWasmFeatures(f: WasmFeatures => WasmFeatures): CoreSpec =
     copy(wasmFeatures = f(wasmFeatures))
 
+  @deprecated("use withESFeatures(_.withUseWebAssembly(.)) instead", since = "1.22.0")
   def withTargetIsWebAssembly(targetIsWebAssembly: Boolean): CoreSpec =
-    copy(targetIsWebAssembly = targetIsWebAssembly)
+    withESFeatures(_.withUseWebAssembly(targetIsWebAssembly))
 
   override def equals(that: Any): Boolean = that match {
     case that: CoreSpec =>
       this.semantics == that.semantics &&
       this.moduleKind == that.moduleKind &&
       this.esFeatures == that.esFeatures &&
-      this.wasmFeatures == that.wasmFeatures &&
-      this.targetIsWebAssembly == that.targetIsWebAssembly
+      this.wasmFeatures == that.wasmFeatures
     case _ =>
       false
   }
@@ -80,9 +87,8 @@ final class CoreSpec private (
     acc = mix(acc, semantics.##)
     acc = mix(acc, moduleKind.##)
     acc = mix(acc, esFeatures.##)
-    acc = mix(acc, wasmFeatures.##)
-    acc = mixLast(acc, targetIsWebAssembly.##)
-    finalizeHash(acc, 5)
+    acc = mixLast(acc, wasmFeatures.##)
+    finalizeHash(acc, 4)
   }
 
   override def toString(): String = {
@@ -91,7 +97,6 @@ final class CoreSpec private (
        |  moduleKind = $moduleKind,
        |  esFeatures = $esFeatures,
        |  wasmFeatures = $wasmFeatures,
-       |  targetIsWebAssembly = $targetIsWebAssembly
        |)""".stripMargin
   }
 
@@ -99,15 +104,13 @@ final class CoreSpec private (
       semantics: Semantics = semantics,
       moduleKind: ModuleKind = moduleKind,
       esFeatures: ESFeatures = esFeatures,
-      wasmFeatures: WasmFeatures = wasmFeatures,
-      targetIsWebAssembly: Boolean = targetIsWebAssembly
+      wasmFeatures: WasmFeatures = wasmFeatures
   ): CoreSpec = {
     new CoreSpec(
       semantics,
       moduleKind,
       esFeatures,
-      wasmFeatures,
-      targetIsWebAssembly
+      wasmFeatures
     )
   }
 }
@@ -123,8 +126,7 @@ private[linker] object CoreSpec {
       config.semantics,
       config.moduleKind,
       config.esFeatures,
-      config.wasmFeatures,
-      config.experimentalUseWebAssembly
+      config.wasmFeatures
     )
   }
 }

--- a/linker/shared/src/main/scala/org/scalajs/linker/standard/StandardLinkerBackend.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/standard/StandardLinkerBackend.scala
@@ -27,7 +27,6 @@ object StandardLinkerBackend {
       .withClosureCompilerIfAvailableInternal(config.closureCompilerIfAvailable)
       .withPrettyPrint(config.prettyPrint)
       .withMaxConcurrentWrites(config.maxConcurrentWrites)
-      .withExperimentalUseWebAssembly(config.experimentalUseWebAssembly)
 
     LinkerBackendImpl(backendConfig)
   }

--- a/linker/shared/src/test/scala/org/scalajs/linker/AnalyzerTest.scala
+++ b/linker/shared/src/test/scala/org/scalajs/linker/AnalyzerTest.scala
@@ -759,8 +759,7 @@ class AnalyzerTest {
 
       val config = StandardConfig()
         .withModuleKind(ModuleKind.ESModule)
-        .withESFeatures(_.withESVersion(ESVersion.ES2022))
-        .withExperimentalUseWebAssembly(true)
+        .withESFeatures(_.withESVersion(ESVersion.ES2022).withUseWebAssembly(true))
 
       val analysis = computeAnalysis(classDefs,
           moduleInitializers = MainTestModuleInitializers,

--- a/linker/shared/src/test/scala/org/scalajs/linker/IncompatibleConfigTest.scala
+++ b/linker/shared/src/test/scala/org/scalajs/linker/IncompatibleConfigTest.scala
@@ -37,9 +37,8 @@ class IncompatibleConfigTest {
 
   @Test def configNotSupportedByWasmBackend(): Unit = {
     val wasmC = baseC
-      .withExperimentalUseWebAssembly(true)
       .withModuleKind(ModuleKind.ESModule)
-      .withESFeatures(_.withESVersion(ESVersion.ES2022))
+      .withESFeatures(_.withESVersion(ESVersion.ES2022).withUseWebAssembly(true))
 
     // Unsupported ModuleKind
     val supportedModuleKinds = Set[ModuleKind](ModuleKind.ESModule)

--- a/linker/shared/src/test/scala/org/scalajs/linker/frontend/modulesplitter/LinkTimeEvaluatorTest.scala
+++ b/linker/shared/src/test/scala/org/scalajs/linker/frontend/modulesplitter/LinkTimeEvaluatorTest.scala
@@ -27,13 +27,11 @@ class LinkTimeEvaluatorTest {
   /** Convenience builder for `LinkTimeProperties` with mostly-default configs. */
   private def make(
       semantics: Semantics => Semantics = identity,
-      esFeatures: ESFeatures => ESFeatures = identity,
-      isWebAssembly: Boolean = false
+      esFeatures: ESFeatures => ESFeatures = identity
   ): LinkTimeProperties = {
     val config = StandardConfig()
       .withSemantics(semantics)
       .withESFeatures(esFeatures)
-      .withExperimentalUseWebAssembly(isWebAssembly)
     LinkTimeProperties.fromCoreSpec(CoreSpec.fromStandardConfig(config))
   }
 
@@ -59,7 +57,8 @@ class LinkTimeEvaluatorTest {
 
     // Boolean link-time property
     testFalse(LinkTimeProperty("core/isWebAssembly")(BooleanType))
-    testTrue(LinkTimeProperty("core/isWebAssembly")(BooleanType), make(isWebAssembly = true))
+    testTrue(LinkTimeProperty("core/isWebAssembly")(BooleanType),
+        make(esFeatures = _.withUseWebAssembly(true)))
     testFail(LinkTimeProperty("core/missing")(BooleanType))
     testFail(LinkTimeProperty("core/esVersion")(BooleanType))
 

--- a/partest/src/main/scala/scala/tools/nsc/MainGenericRunner.scala
+++ b/partest/src/main/scala/scala/tools/nsc/MainGenericRunner.scala
@@ -98,7 +98,7 @@ class MainGenericRunner {
     val linkerConfig = StandardConfig()
       .withCheckIR(true)
       .withSemantics(semantics)
-      .withExperimentalUseWebAssembly(useWasm)
+      .withESFeatures(_.withUseWebAssembly(useWasm))
       .withModuleKind(if (useESModule) ModuleKind.ESModule else ModuleKind.NoModule)
       .withESFeatures(f => if (useWasm) f.withESVersion(ESVersion.ES2022) else f)
       .withSourceMap(false)

--- a/project/BinaryIncompatibilities.scala
+++ b/project/BinaryIncompatibilities.scala
@@ -11,7 +11,7 @@ object BinaryIncompatibilities {
 
   val Linker = Seq(
     // private, not an issue
-    ProblemFilters.exclude[DirectMissingMethodProblem]("org.scalajs.linker.standard.CoreSpec.this"),
+    ProblemFilters.exclude[IncompatibleMethTypeProblem]("org.scalajs.linker.standard.CoreSpec.this"),
   )
 
   val LinkerInterface = Seq(

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -184,9 +184,8 @@ object MyScalaJSPlugin extends AutoPlugin {
 
         if (enableWasmEverywhere.value) {
           config = config
-            .withExperimentalUseWebAssembly(true)
             .withModuleKind(ModuleKind.ESModule)
-            .withESFeatures(_.withESVersion(ESVersion.ES2022))
+            .withESFeatures(_.withESVersion(ESVersion.ES2022).withUseWebAssembly(true))
         }
 
         config
@@ -2354,7 +2353,7 @@ object Build {
         val esVersion = linkerConfig.esFeatures.esVersion
         val moduleKind = linkerConfig.moduleKind
         val hasModules = moduleKind != ModuleKind.NoModule
-        val isWebAssembly = linkerConfig.experimentalUseWebAssembly
+        val isWebAssembly = linkerConfig.esFeatures.useWebAssembly
 
         val hasAsyncAwait =
           if (isWebAssembly) linkerConfig.wasmFeatures.useJSPI
@@ -2438,7 +2437,7 @@ object Build {
           "productionMode" -> sems.productionMode,
           "esVersion" -> linkerConfig.esFeatures.esVersion.edition,
           "useECMAScript2015Semantics" -> linkerConfig.esFeatures.useECMAScript2015Semantics,
-          "isWebAssembly" -> linkerConfig.experimentalUseWebAssembly,
+          "isWebAssembly" -> linkerConfig.esFeatures.useWebAssembly,
         )
       },
 


### PR DESCRIPTION
At this point, it is pretty clear that it is here to stay. Its current feature set relies on standardized Wasm 3.0.

We will optionally add support for custom descriptors to complete the feature set. However, supporting earlier versions without it should be straightforward.