### PR TITLE
Add Java 17 java.util.HexFormat (port from scala-native)

### DIFF
--- a/javalib/src/main/scala/java/io/Throwables.scala
+++ b/javalib/src/main/scala/java/io/Throwables.scala
@@ -30,6 +30,14 @@ class UnsupportedEncodingException(s: String) extends IOException(s) {
   def this() = this(null)
 }
 
+class UncheckedIOException(message: String, cause: IOException)
+    extends RuntimeException(message, cause) {
+  def this(cause: IOException) =
+    this(if (cause == null) null else cause.toString, cause)
+
+  override def getCause(): IOException = super.getCause().asInstanceOf[IOException]
+}
+
 abstract class ObjectStreamException protected (s: String) extends IOException(s) {
   protected def this() = this(null)
 }

--- a/javalib/src/main/scala/java/util/HexFormat.scala
+++ b/javalib/src/main/scala/java/util/HexFormat.scala
@@ -1,0 +1,600 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
+package java.util
+
+import java.io.{IOException, UncheckedIOException}
+import java.{lang => jl}
+
+final class HexFormat private (
+    private val delimiterString: String,
+    private val prefixString: String,
+    private val suffixString: String,
+    private val uppercase: Boolean
+) {
+
+  private val digits: Array[Char] =
+    if (uppercase) HexFormat.UpperCaseDigits else HexFormat.LowerCaseDigits
+
+  def withDelimiter(delimiter: String): HexFormat = {
+    Objects.requireNonNull(delimiter, "delimiter")
+    new HexFormat(delimiter, prefixString, suffixString, uppercase)
+  }
+
+  def withPrefix(prefix: String): HexFormat = {
+    Objects.requireNonNull(prefix, "prefix")
+    new HexFormat(delimiterString, prefix, suffixString, uppercase)
+  }
+
+  def withSuffix(suffix: String): HexFormat = {
+    Objects.requireNonNull(suffix, "suffix")
+    new HexFormat(delimiterString, prefixString, suffix, uppercase)
+  }
+
+  def withUpperCase(): HexFormat =
+    if (uppercase) this
+    else new HexFormat(delimiterString, prefixString, suffixString, true)
+
+  def withLowerCase(): HexFormat =
+    if (!uppercase) this
+    else new HexFormat(delimiterString, prefixString, suffixString, false)
+
+  def delimiter(): String = delimiterString
+
+  def prefix(): String = prefixString
+
+  def suffix(): String = suffixString
+
+  def isUpperCase(): Boolean = uppercase
+
+  def formatHex(bytes: Array[Byte]): String =
+    formatHex(bytes, 0, bytes.length)
+
+  def formatHex(bytes: Array[Byte], fromIndex: Int, toIndex: Int): String = {
+    HexFormat.checkFromToIndex(fromIndex, toIndex, bytes.length)
+
+    val length = toIndex - fromIndex
+    if (length == 0) ""
+    else if (hasNoMarkup) {
+      val table = digits
+      val sb = new jl.StringBuilder(length << 1)
+      var byteIndex = fromIndex
+      while (byteIndex < toIndex) {
+        val value = bytes(byteIndex) & 0xff
+        sb.append(table(value >>> 4))
+        sb.append(table(value & 0x0f))
+        byteIndex += 1
+      }
+      sb.toString()
+    } else {
+      val table = digits
+      val sb = new jl.StringBuilder(formattedLength(length))
+      var byteIndex = fromIndex
+      while (byteIndex < toIndex) {
+        if (byteIndex != fromIndex) sb.append(delimiterString)
+        sb.append(prefixString)
+        val value = bytes(byteIndex) & 0xff
+        sb.append(table(value >>> 4))
+        sb.append(table(value & 0x0f))
+        sb.append(suffixString)
+        byteIndex += 1
+      }
+      sb.toString()
+    }
+  }
+
+  def formatHex[A <: jl.Appendable](out: A, bytes: Array[Byte]): A =
+    formatHex(out, bytes, 0, bytes.length)
+
+  def formatHex[A <: jl.Appendable](
+      out: A,
+      bytes: Array[Byte],
+      fromIndex: Int,
+      toIndex: Int
+  ): A = {
+    Objects.requireNonNull(out, "out")
+    HexFormat.checkFromToIndex(fromIndex, toIndex, bytes.length)
+
+    val table = digits
+    try {
+      if (hasNoMarkup) {
+        var byteIndex = fromIndex
+        while (byteIndex < toIndex) {
+          val value = bytes(byteIndex) & 0xff
+          out.append(table(value >>> 4))
+          out.append(table(value & 0x0f))
+          byteIndex += 1
+        }
+      } else {
+        val prefix = prefixString
+        val suffix = suffixString
+        val delimiter = delimiterString
+        val hasPrefix = !prefix.isEmpty()
+        val hasSuffix = !suffix.isEmpty()
+        val hasDelimiter = !delimiter.isEmpty()
+        var byteIndex = fromIndex
+        while (byteIndex < toIndex) {
+          if (byteIndex != fromIndex && hasDelimiter)
+            out.append(delimiter)
+          if (hasPrefix)
+            out.append(prefix)
+          val value = bytes(byteIndex) & 0xff
+          out.append(table(value >>> 4))
+          out.append(table(value & 0x0f))
+          if (hasSuffix)
+            out.append(suffix)
+          byteIndex += 1
+        }
+      }
+    } catch {
+      case e: IOException => throw new UncheckedIOException(e.getMessage(), e)
+    }
+
+    out
+  }
+
+  def parseHex(string: jl.CharSequence): Array[Byte] =
+    parseHex(string, 0, string.length())
+
+  def parseHex(
+      string: jl.CharSequence,
+      fromIndex: Int,
+      toIndex: Int
+  ): Array[Byte] = {
+    HexFormat.checkFromToIndex(fromIndex, toIndex, string.length())
+
+    val length = toIndex - fromIndex
+    if (hasNoMarkup)
+      parseHexWithoutMarkup(string, fromIndex, length)
+    else
+      parseHexWithMarkup(string, fromIndex, length)
+  }
+
+  def parseHex(
+      chars: Array[Char],
+      fromIndex: Int,
+      toIndex: Int
+  ): Array[Byte] = {
+    HexFormat.checkFromToIndex(fromIndex, toIndex, chars.length)
+
+    val length = toIndex - fromIndex
+    if (hasNoMarkup)
+      parseHexWithoutMarkup(chars, fromIndex, length)
+    else
+      parseHexWithMarkup(chars, fromIndex, length)
+  }
+
+  def toLowHexDigit(value: Int): Char =
+    digits(value & 0x0f)
+
+  def toHighHexDigit(value: Int): Char =
+    digits((value >>> 4) & 0x0f)
+
+  def toHexDigits[A <: jl.Appendable](out: A, value: Byte): A = {
+    Objects.requireNonNull(out, "out")
+    try {
+      val intValue = value & 0xff
+      out.append(digits(intValue >>> 4))
+      out.append(digits(intValue & 0x0f))
+    } catch {
+      case e: IOException => throw new UncheckedIOException(e.getMessage(), e)
+    }
+    out
+  }
+
+  def toHexDigits(value: Byte): String =
+    twoDigits(value & 0xff)
+
+  def toHexDigits(value: Char): String =
+    toHexDigits(value.toInt.toLong, 4)
+
+  def toHexDigits(value: Short): String =
+    toHexDigits((value.toInt & 0xffff).toLong, 4)
+
+  def toHexDigits(value: Int): String =
+    toHexDigits(value.toLong, 8)
+
+  def toHexDigits(value: Long): String =
+    toHexDigits(value, 16)
+
+  def toHexDigits(value: Long, digits: Int): String = {
+    if (digits < 0 || digits > 16)
+      throw new IllegalArgumentException("number of digits: " + digits)
+
+    val sb = new jl.StringBuilder(digits)
+    var i = 0
+    var shift = (digits - 1) << 2
+    while (i < digits) {
+      sb.append(this.digits(((value >>> shift) & 0x0fL).toInt))
+      i += 1
+      shift -= 4
+    }
+    sb.toString()
+  }
+
+  override def equals(obj: Any): Boolean = obj match {
+    case that: HexFormat =>
+      uppercase == that.uppercase &&
+      delimiterString == that.delimiterString &&
+      prefixString == that.prefixString &&
+      suffixString == that.suffixString
+    case _ => false
+  }
+
+  override def hashCode(): Int = {
+    var h = delimiterString.hashCode()
+    h = 31 * h + prefixString.hashCode()
+    h = 31 * h + suffixString.hashCode()
+    h = 31 * h + (if (uppercase) 1231 else 1237)
+    h
+  }
+
+  override def toString(): String =
+    "uppercase: " + uppercase +
+      ", delimiter: \"" + delimiterString +
+      "\", prefix: \"" + prefixString +
+      "\", suffix: \"" + suffixString + "\""
+
+  private def hasNoMarkup: Boolean =
+    delimiterString.isEmpty() && prefixString.isEmpty() && suffixString
+      .isEmpty()
+
+  private def formattedLength(byteCount: Int): Int = {
+    val valueLength = prefixString.length() + 2 + suffixString.length()
+    val total =
+      byteCount.toLong * valueLength.toLong +
+        (byteCount.toLong - 1L) * delimiterString.length().toLong
+
+    if (total > Integer.MAX_VALUE)
+      throw new OutOfMemoryError("Required array size too large")
+    total.toInt
+  }
+
+  private def twoDigits(value: Int): String = {
+    val sb = new jl.StringBuilder(2)
+    sb.append(digits(value >>> 4))
+    sb.append(digits(value & 0x0f))
+    sb.toString()
+  }
+
+  private def parseHexWithoutMarkup(
+      string: jl.CharSequence,
+      fromIndex: Int,
+      length: Int
+  ): Array[Byte] = {
+    if ((length & 1) != 0)
+      throw new IllegalArgumentException("string length not even: " + length)
+
+    val bytes = new Array[Byte](length >>> 1)
+    val table = HexFormat.DigitValues
+    val tableLen = table.length
+    var sourceIndex = fromIndex
+    var destIndex = 0
+    while (destIndex < bytes.length) {
+      val high = string.charAt(sourceIndex)
+      val low = string.charAt(sourceIndex + 1)
+      val hi = if (high < tableLen) table(high).toInt else -1
+      val lo = if (low < tableLen) table(low).toInt else -1
+      if ((hi | lo) < 0)
+        HexFormat.throwBadDigitPair(high, low, hi)
+      bytes(destIndex) = ((hi << 4) | lo).toByte
+      sourceIndex += 2
+      destIndex += 1
+    }
+    bytes
+  }
+
+  private def parseHexWithoutMarkup(
+      chars: Array[Char],
+      fromIndex: Int,
+      length: Int
+  ): Array[Byte] = {
+    if ((length & 1) != 0)
+      throw new IllegalArgumentException("string length not even: " + length)
+
+    val bytes = new Array[Byte](length >>> 1)
+    val table = HexFormat.DigitValues
+    val tableLen = table.length
+    var sourceIndex = fromIndex
+    var destIndex = 0
+    while (destIndex < bytes.length) {
+      val high = chars(sourceIndex)
+      val low = chars(sourceIndex + 1)
+      val hi = if (high < tableLen) table(high).toInt else -1
+      val lo = if (low < tableLen) table(low).toInt else -1
+      if ((hi | lo) < 0)
+        HexFormat.throwBadDigitPair(high, low, hi)
+      bytes(destIndex) = ((hi << 4) | lo).toByte
+      sourceIndex += 2
+      destIndex += 1
+    }
+    bytes
+  }
+
+  private def parseHexWithMarkup(
+      string: jl.CharSequence,
+      fromIndex: Int,
+      length: Int
+  ): Array[Byte] = {
+    val byteCount = parsedByteCount(length)
+    val bytes = new Array[Byte](byteCount)
+    val table = HexFormat.DigitValues
+    val tableLen = table.length
+    val prefix = prefixString
+    val suffix = suffixString
+    val delimiter = delimiterString
+    val prefixLen = prefix.length()
+    val suffixLen = suffix.length()
+    val delimiterLen = delimiter.length()
+    var sourceIndex = fromIndex
+    var destIndex = 0
+    while (destIndex < byteCount) {
+      if (prefixLen != 0)
+        sourceIndex = requireMatch(string, sourceIndex, prefix, prefixLen)
+      val high = string.charAt(sourceIndex)
+      val low = string.charAt(sourceIndex + 1)
+      val hi = if (high < tableLen) table(high).toInt else -1
+      val lo = if (low < tableLen) table(low).toInt else -1
+      if ((hi | lo) < 0)
+        HexFormat.throwBadDigitPair(high, low, hi)
+      bytes(destIndex) = ((hi << 4) | lo).toByte
+      sourceIndex += 2
+      if (suffixLen != 0)
+        sourceIndex = requireMatch(string, sourceIndex, suffix, suffixLen)
+      if (destIndex != byteCount - 1 && delimiterLen != 0)
+        sourceIndex = requireMatch(string, sourceIndex, delimiter, delimiterLen)
+      destIndex += 1
+    }
+    bytes
+  }
+
+  private def parseHexWithMarkup(
+      chars: Array[Char],
+      fromIndex: Int,
+      length: Int
+  ): Array[Byte] = {
+    val byteCount = parsedByteCount(length)
+    val bytes = new Array[Byte](byteCount)
+    val table = HexFormat.DigitValues
+    val tableLen = table.length
+    val prefix = prefixString
+    val suffix = suffixString
+    val delimiter = delimiterString
+    val prefixLen = prefix.length()
+    val suffixLen = suffix.length()
+    val delimiterLen = delimiter.length()
+    var sourceIndex = fromIndex
+    var destIndex = 0
+    while (destIndex < byteCount) {
+      if (prefixLen != 0)
+        sourceIndex = requireMatch(chars, sourceIndex, prefix, prefixLen)
+      val high = chars(sourceIndex)
+      val low = chars(sourceIndex + 1)
+      val hi = if (high < tableLen) table(high).toInt else -1
+      val lo = if (low < tableLen) table(low).toInt else -1
+      if ((hi | lo) < 0)
+        HexFormat.throwBadDigitPair(high, low, hi)
+      bytes(destIndex) = ((hi << 4) | lo).toByte
+      sourceIndex += 2
+      if (suffixLen != 0)
+        sourceIndex = requireMatch(chars, sourceIndex, suffix, suffixLen)
+      if (destIndex != byteCount - 1 && delimiterLen != 0)
+        sourceIndex = requireMatch(chars, sourceIndex, delimiter, delimiterLen)
+      destIndex += 1
+    }
+    bytes
+  }
+
+  private def parsedByteCount(length: Int): Int = {
+    if (length == 0)
+      0
+    else {
+      val valueLength = prefixString.length() + 2 + suffixString.length()
+      val recordLength = valueLength + delimiterString.length()
+      val adjustedLength = length.toLong + delimiterString.length().toLong
+
+      if (adjustedLength % recordLength != 0L)
+        throw HexFormat.invalidFormatException()
+
+      val count = adjustedLength / recordLength
+      if (count <= 0L || count > Integer.MAX_VALUE)
+        throw HexFormat.invalidFormatException()
+      count.toInt
+    }
+  }
+
+  private def requireMatch(
+      string: jl.CharSequence,
+      index: Int,
+      expected: String,
+      expectedLen: Int
+  ): Int = {
+    var i = 0
+    while (i < expectedLen) {
+      if (string.charAt(index + i) != expected.charAt(i))
+        throw HexFormat.invalidFormatException()
+      i += 1
+    }
+    index + expectedLen
+  }
+
+  private def requireMatch(
+      chars: Array[Char],
+      index: Int,
+      expected: String,
+      expectedLen: Int
+  ): Int = {
+    var i = 0
+    while (i < expectedLen) {
+      if (chars(index + i) != expected.charAt(i))
+        throw HexFormat.invalidFormatException()
+      i += 1
+    }
+    index + expectedLen
+  }
+}
+
+object HexFormat {
+  private[util] val LowerCaseDigits: Array[Char] =
+    "0123456789abcdef".toCharArray()
+
+  private[util] val UpperCaseDigits: Array[Char] =
+    "0123456789ABCDEF".toCharArray()
+
+  /* ASCII -> hex digit value, indexed by char code.
+   * Returns 0..15 for '0'-'9', 'A'-'F', 'a'-'f' and -1 otherwise.
+   * The table stops at 'f' (0x66, the highest valid input); callers must
+   * range-check the index before lookup. Built once at class init; the hot
+   * path reads a plain `Array[Byte]` indexed by char code, identical to a
+   * static literal. (A static `Array[Byte](-1, -1, ...)` literal would pull
+   * in `scala.reflect.ClassTag` and is rejected by the javalib IR check.)
+   */
+  private val DigitValues: Array[Byte] = {
+    val table = new Array[Byte]('f' + 1)
+    var i = 0
+    while (i < table.length) {
+      table(i) = -1
+      i += 1
+    }
+    i = 0
+    while (i < 10) {        // '0'..'9' -> 0..9
+      table('0' + i) = i.toByte
+      i += 1
+    }
+    i = 0
+    while (i < 6) {         // 'A'..'F' and 'a'..'f' -> 10..15
+      val v = (10 + i).toByte
+      table('A' + i) = v
+      table('a' + i) = v
+      i += 1
+    }
+    table
+  }
+
+  private val Default = new HexFormat("", "", "", false)
+
+  def of(): HexFormat = Default
+
+  def ofDelimiter(delimiter: String): HexFormat = {
+    Objects.requireNonNull(delimiter, "delimiter")
+    new HexFormat(delimiter, "", "", false)
+  }
+
+  def isHexDigit(ch: Int): Boolean =
+    ch >= 0 && ch < DigitValues.length && DigitValues(ch) >= 0
+
+  def fromHexDigit(ch: Int): Int = {
+    if (ch >= 0 && ch < DigitValues.length) {
+      val value = DigitValues(ch).toInt
+      if (value >= 0) return value
+    }
+
+    val value =
+      if (ch >= 0 && ch <= Character.MAX_CODE_POINT)
+        new String(Character.toChars(ch))
+      else Integer.toString(ch)
+    throw new NumberFormatException(
+      "not a hexadecimal digit: \"" + value + "\" = " + ch
+    )
+  }
+
+  def fromHexDigits(string: jl.CharSequence): Int =
+    fromHexDigits(string, 0, string.length())
+
+  def fromHexDigits(
+      string: jl.CharSequence,
+      fromIndex: Int,
+      toIndex: Int
+  ): Int = {
+    checkFromToIndex(fromIndex, toIndex, string.length())
+    val length = toIndex - fromIndex
+    if (length > 8)
+      throw new IllegalArgumentException(
+        "string length greater than 8: " + length
+      )
+
+    val table = DigitValues
+    val tableLen = table.length
+    var value = 0
+    var i = fromIndex
+    while (i < toIndex) {
+      val ch = string.charAt(i)
+      val v = if (ch < tableLen) table(ch).toInt else -1
+      if (v < 0) fromHexDigit(ch.toInt)
+      value = (value << 4) | v
+      i += 1
+    }
+    value
+  }
+
+  def fromHexDigitsToLong(string: jl.CharSequence): Long =
+    fromHexDigitsToLong(string, 0, string.length())
+
+  def fromHexDigitsToLong(
+      string: jl.CharSequence,
+      fromIndex: Int,
+      toIndex: Int
+  ): Long = {
+    checkFromToIndex(fromIndex, toIndex, string.length())
+    val length = toIndex - fromIndex
+    if (length > 16)
+      throw new IllegalArgumentException(
+        "string length greater than 16: " + length
+      )
+
+    val table = DigitValues
+    val tableLen = table.length
+    var value = 0L
+    var i = fromIndex
+    while (i < toIndex) {
+      val ch = string.charAt(i)
+      val v = if (ch < tableLen) table(ch).toInt else -1
+      if (v < 0) fromHexDigit(ch.toInt)
+      value = (value << 4) | v.toLong
+      i += 1
+    }
+    value
+  }
+
+  // JDK 9 java.util.Objects.checkFromToIndex equivalent.
+  // Inlined here because scala-js's java.util.Objects targets JDK 8.
+  private[util] def checkFromToIndex(
+      fromIndex: Int,
+      toIndex: Int,
+      length: Int
+  ): Int = {
+    if (fromIndex < 0 || fromIndex > toIndex || toIndex > length)
+      throw new IndexOutOfBoundsException(
+        "Range [" + fromIndex + ", " + toIndex + ") out of bounds for length " + length
+      )
+    fromIndex
+  }
+
+  private[util] def throwBadDigitPair(
+      high: Char,
+      low: Char,
+      hi: Int
+  ): Nothing = {
+    if (hi < 0) {
+      fromHexDigit(high.toInt)
+    } else {
+      fromHexDigit(low.toInt)
+    }
+    throw new AssertionError("unreachable")
+  }
+
+  private[util] def invalidFormatException(): IllegalArgumentException =
+    new IllegalArgumentException(
+      "extra or missing delimiters or values consisting of prefix, " +
+        "two hexadecimal digits, and suffix"
+    )
+}

--- a/test-suite/shared/src/test/require-jdk17/org/scalajs/testsuite/javalib/util/HexFormatTestOnJDK17.scala
+++ b/test-suite/shared/src/test/require-jdk17/org/scalajs/testsuite/javalib/util/HexFormatTestOnJDK17.scala
@@ -1,0 +1,333 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
+package org.scalajs.testsuite.javalib.util
+
+import java.io.{IOException, UncheckedIOException}
+import java.nio.CharBuffer
+import java.util.{Arrays, HexFormat}
+import java.{lang => jl}
+
+import org.junit.Assert._
+import org.junit.Test
+
+import org.scalajs.testsuite.utils.AssertThrows.{assertThrows, assertThrowsNPEIfCompliant}
+
+class HexFormatTestOnJDK17 {
+
+  @Test def factoriesWithersAccessorsAndObjectMethods(): Unit = {
+    val default = HexFormat.of()
+    assertEquals("", default.delimiter())
+    assertEquals("", default.prefix())
+    assertEquals("", default.suffix())
+    assertFalse(default.isUpperCase())
+
+    val custom =
+      HexFormat
+        .ofDelimiter(", ")
+        .withPrefix("#")
+        .withSuffix(";")
+        .withUpperCase()
+    assertEquals(", ", custom.delimiter())
+    assertEquals("#", custom.prefix())
+    assertEquals(";", custom.suffix())
+    assertTrue(custom.isUpperCase())
+
+    val same = HexFormat
+      .of()
+      .withDelimiter(", ")
+      .withPrefix("#")
+      .withSuffix(";")
+      .withUpperCase()
+    assertEquals(custom, same)
+    assertEquals(custom.hashCode(), same.hashCode())
+    assertNotEquals(custom, custom.withLowerCase())
+    assertNotEquals(custom, "not a HexFormat")
+
+    val description = custom.toString()
+    assertTrue(description.contains("uppercase: true"))
+    assertTrue(description.contains("delimiter: \", \""))
+    assertTrue(description.contains("prefix: \"#\""))
+    assertTrue(description.contains("suffix: \";\""))
+
+    assertThrowsNPEIfCompliant(HexFormat.ofDelimiter(null))
+    assertThrowsNPEIfCompliant(default.withDelimiter(null))
+    assertThrowsNPEIfCompliant(default.withPrefix(null))
+    assertThrowsNPEIfCompliant(default.withSuffix(null))
+  }
+
+  @Test def formatHexStrings(): Unit = {
+    val bytes = Array[Byte](0, 1, 2, 10, 15, 16, 127, -128, -1)
+
+    assertEquals("0001020a0f107f80ff", HexFormat.of().formatHex(bytes))
+    assertEquals("01020a", HexFormat.of().formatHex(bytes, 1, 4))
+    assertEquals("", HexFormat.of().formatHex(bytes, 2, 2))
+
+    val fingerprint = HexFormat.ofDelimiter(":").withUpperCase()
+    assertEquals("00:01:02:0A:0F:10:7F:80:FF", fingerprint.formatHex(bytes))
+
+    val custom = HexFormat.ofDelimiter(", ").withPrefix("#").withSuffix(";")
+    assertEquals(
+      "#00;, #01;, #02;, #0a;, #0f;, #10;, #7f;, #80;, #ff;",
+      custom.formatHex(bytes)
+    )
+
+    assertThrows(
+      classOf[IndexOutOfBoundsException],
+      HexFormat.of().formatHex(bytes, -1, 1)
+    )
+    assertThrows(
+      classOf[IndexOutOfBoundsException],
+      HexFormat.of().formatHex(bytes, 0, bytes.length + 1)
+    )
+    // Null bytes triggers NPE only via bytes.length dereference; compliant only.
+    assertThrowsNPEIfCompliant(
+      HexFormat.of().formatHex(null.asInstanceOf[Array[Byte]])
+    )
+  }
+
+  @Test def formatHexAppendable(): Unit = {
+    val bytes = Array[Byte](0x0a.toByte, 0x0b.toByte, 0x0c.toByte)
+    val format = HexFormat.ofDelimiter("|").withPrefix("<").withSuffix(">")
+    val builder = new jl.StringBuilder()
+
+    val returned = format.formatHex(builder, bytes, 1, 3)
+    assertSame(builder, returned)
+    assertEquals("<0b>|<0c>", builder.toString())
+
+    val allBuilder = new jl.StringBuilder()
+    assertSame(allBuilder, HexFormat.of().formatHex(allBuilder, bytes))
+    assertEquals("0a0b0c", allBuilder.toString())
+
+    // Null Appendable: explicit Objects.requireNonNull(out); NPE under
+    // scala-js is compliant-mode only.
+    assertThrowsNPEIfCompliant(
+      HexFormat.of().formatHex(null.asInstanceOf[jl.Appendable], bytes)
+    )
+    // Null bytes triggers NPE only via bytes.length dereference; compliant only.
+    assertThrowsNPEIfCompliant(
+      HexFormat
+        .of()
+        .formatHex(new jl.StringBuilder(), null.asInstanceOf[Array[Byte]])
+    )
+
+    val failure = new IOException("boom")
+    val thrown = assertThrows(
+      classOf[UncheckedIOException],
+      HexFormat.of().formatHex(new FailingAppendable(failure), bytes)
+    )
+    assertSame(failure, thrown.getCause())
+  }
+
+  @Test def parseHexStringsAndRanges(): Unit = {
+    assertBytesEquals(Array[Byte](), HexFormat.of().parseHex(""))
+    assertBytesEquals(
+      Array[Byte](0, 1, 2, 10, 15, 16, 127, -128, -1),
+      HexFormat.of().parseHex("0001020A0f107f80ff")
+    )
+    assertBytesEquals(
+      Array[Byte](0, 1),
+      HexFormat.of().parseHex("xx0001yy", 2, 6)
+    )
+
+    val custom = HexFormat.ofDelimiter(":").withPrefix("<").withSuffix(">")
+    assertBytesEquals(Array[Byte](), custom.parseHex(""))
+    assertBytesEquals(Array[Byte](10), custom.parseHex("<0A>"))
+    assertBytesEquals(Array[Byte](10, 11), custom.parseHex("<0a>:<0B>"))
+    assertBytesEquals(
+      Array[Byte](10, 11),
+      custom.parseHex(new jl.StringBuilder("__<0a>:<0B>__"), 2, 11)
+    )
+    assertBytesEquals(
+      Array[Byte](10, 11),
+      custom.parseHex(CharBuffer.wrap("__<0a>:<0B>__"), 2, 11)
+    )
+
+    assertThrows(
+      classOf[IllegalArgumentException],
+      HexFormat.of().parseHex("0")
+    )
+    assertThrows(classOf[IllegalArgumentException], custom.parseHex("<0a><0b>"))
+    assertThrows(classOf[IllegalArgumentException], custom.parseHex("<0g>"))
+    assertThrows(
+      classOf[IllegalArgumentException],
+      HexFormat.ofDelimiter("a").parseHex("1a2a3a")
+    )
+    assertThrows(
+      classOf[IndexOutOfBoundsException],
+      HexFormat.of().parseHex("00", 1, 0)
+    )
+
+    val upperPrefix = HexFormat.of().withPrefix("0X")
+    assertBytesEquals(Array[Byte](10), upperPrefix.parseHex("0X0a"))
+    assertThrows(
+      classOf[IllegalArgumentException],
+      upperPrefix.parseHex("0x0a")
+    )
+  }
+
+  @Test def parseHexCharArrayRange(): Unit = {
+    val format = HexFormat.ofDelimiter(":").withPrefix("<").withSuffix(">")
+    val chars = "__<0a>:<0B>__".toCharArray()
+    assertBytesEquals(Array[Byte](10, 11), format.parseHex(chars, 2, 11))
+
+    assertThrows(
+      classOf[IndexOutOfBoundsException],
+      format.parseHex(chars, -1, 11)
+    )
+    assertThrows(
+      classOf[IllegalArgumentException],
+      format.parseHex("<0a><0b>".toCharArray(), 0, 8)
+    )
+    // Null chars triggers NPE only via chars.length dereference; compliant only.
+    assertThrowsNPEIfCompliant(
+      HexFormat.of().parseHex(null.asInstanceOf[Array[Char]], 0, 0)
+    )
+  }
+
+  @Test def hexDigitFormattingMethods(): Unit = {
+    val lower = HexFormat.of()
+    val upper = lower.withUpperCase()
+
+    assertEquals('a', lower.toLowHexDigit(0x7a))
+    assertEquals('7', lower.toHighHexDigit(0x7a))
+    assertEquals('A', upper.toLowHexDigit(0x7a))
+    assertEquals('F', upper.toHighHexDigit(0xff))
+
+    val builder = new jl.StringBuilder()
+    assertSame(builder, upper.toHexDigits(builder, 0xab.toByte))
+    assertEquals("AB", builder.toString())
+
+    assertEquals("ff", lower.toHexDigits(0xff.toByte))
+    assertEquals("abcd", lower.toHexDigits(0xabcd.toChar))
+    assertEquals("ffff", lower.toHexDigits((-1).toShort))
+    assertEquals("89abcdef", lower.toHexDigits(0x89abcdef))
+    assertEquals("0123456789abcdef", lower.toHexDigits(0x0123456789abcdefL))
+    assertEquals(
+      "23456789abcdef0",
+      lower.toHexDigits(0x123456789abcdef0L, 15)
+    )
+    assertEquals("", lower.toHexDigits(0x123456789abcdef0L, 0))
+    assertEquals("F0", upper.toHexDigits(0x123456789abcdef0L, 2))
+
+    assertThrows(classOf[IllegalArgumentException], lower.toHexDigits(0L, -1))
+    assertThrows(classOf[IllegalArgumentException], lower.toHexDigits(0L, 17))
+    assertThrowsNPEIfCompliant(
+      lower.toHexDigits(null.asInstanceOf[jl.Appendable], 0.toByte)
+    )
+
+    val failure = new IOException("boom")
+    val thrown = assertThrows(
+      classOf[UncheckedIOException],
+      lower.toHexDigits(new FailingAppendable(failure), 0.toByte)
+    )
+    assertSame(failure, thrown.getCause())
+  }
+
+  @Test def hexDigitParsingMethods(): Unit = {
+    for (ch <- '0' to '9') {
+      assertTrue(HexFormat.isHexDigit(ch))
+      assertEquals(ch - '0', HexFormat.fromHexDigit(ch))
+    }
+    for (ch <- 'a' to 'f') {
+      assertTrue(HexFormat.isHexDigit(ch))
+      assertEquals(ch - 'a' + 10, HexFormat.fromHexDigit(ch))
+    }
+    for (ch <- 'A' to 'F') {
+      assertTrue(HexFormat.isHexDigit(ch))
+      assertEquals(ch - 'A' + 10, HexFormat.fromHexDigit(ch))
+    }
+
+    assertFalse(HexFormat.isHexDigit(-1))
+    assertFalse(HexFormat.isHexDigit('g'))
+    assertFalse(HexFormat.isHexDigit(0x10000))
+    assertThrows(classOf[NumberFormatException], HexFormat.fromHexDigit(-1))
+    assertThrows(classOf[NumberFormatException], HexFormat.fromHexDigit('g'))
+    assertThrows(
+      classOf[NumberFormatException],
+      HexFormat.fromHexDigit(0x10000)
+    )
+
+    assertEquals(0, HexFormat.fromHexDigits(""))
+    assertEquals(0x1234abcd, HexFormat.fromHexDigits("xx1234abcdyy", 2, 10))
+    assertEquals(-1, HexFormat.fromHexDigits("ffffffff"))
+    assertEquals(0L, HexFormat.fromHexDigitsToLong(""))
+    assertEquals(
+      0x123456789abcdef0L,
+      HexFormat.fromHexDigitsToLong("xx123456789abcdef0yy", 2, 18)
+    )
+    assertEquals(-1L, HexFormat.fromHexDigitsToLong("ffffffffffffffff"))
+
+    assertThrows(
+      classOf[IllegalArgumentException],
+      HexFormat.fromHexDigits("100000000")
+    )
+    assertThrows(
+      classOf[IllegalArgumentException],
+      HexFormat.fromHexDigitsToLong("10000000000000000")
+    )
+    assertThrows(classOf[NumberFormatException], HexFormat.fromHexDigits("g"))
+    assertThrows(
+      classOf[IndexOutOfBoundsException],
+      HexFormat.fromHexDigits("00", -1, 2)
+    )
+    assertThrows(
+      classOf[IndexOutOfBoundsException],
+      HexFormat.fromHexDigitsToLong("00", 0, 3)
+    )
+    // Null CharSequence triggers NPE only via string.length() dereference; compliant only.
+    assertThrowsNPEIfCompliant(
+      HexFormat.fromHexDigits(null.asInstanceOf[jl.CharSequence])
+    )
+  }
+
+  @Test def roundTripDirectionalCoverage(): Unit = {
+    val bytes = (0 until 256).map(_.toByte).toArray
+    val formats = Seq(
+      HexFormat.of(),
+      HexFormat.of().withUpperCase(),
+      HexFormat.ofDelimiter(":"),
+      HexFormat.ofDelimiter(":").withUpperCase(),
+      HexFormat.of().withPrefix("0x").withSuffix(";"),
+      HexFormat
+        .ofDelimiter(", ")
+        .withPrefix("#")
+        .withSuffix(";")
+        .withUpperCase()
+    )
+
+    for (format <- formats)
+      assertBytesEquals(bytes, format.parseHex(format.formatHex(bytes)))
+  }
+
+  private def assertBytesEquals(
+      expected: Array[Byte],
+      actual: Array[Byte]
+  ): Unit =
+    assertTrue(
+      "expected: " + Arrays.toString(expected) +
+        ", actual: " + Arrays.toString(actual),
+      Arrays.equals(expected, actual)
+    )
+
+  private final class FailingAppendable(failure: IOException)
+      extends jl.Appendable {
+    def append(c: Char): jl.Appendable =
+      throw failure
+
+    def append(csq: jl.CharSequence): jl.Appendable =
+      throw failure
+
+    def append(csq: jl.CharSequence, start: Int, end: Int): jl.Appendable =
+      throw failure
+  }
+}


### PR DESCRIPTION
## Summary

Adds `java.util.HexFormat` (JDK 17) and its implementation dependency
`java.io.UncheckedIOException` (JDK 8) to the Scala.js javalib. Port of
scala-native commit `67dadf28780e201b4ecfa65d1947e986cf1dea12`.

`HexFormat` is a value-based formatter/parser for binary <-> hex with
optional prefix/suffix/delimiter markup and upper/lower case selection;
public surface matches OpenJDK 17 (`of`, `ofDelimiter`, the `withX`
withers, `formatHex` / `parseHex` over `byte[]`, `CharSequence`,
`char[]`, `Appendable`, the primitive `toHexDigits` / `fromHexDigits` /
`fromHexDigitsToLong` helpers, `isHexDigit`, `fromHexDigit`).

`UncheckedIOException` was added because `HexFormat`'s `Appendable`
overloads must wrap `IOException` per the JDK spec; the class is also
useful on its own and is otherwise standard JDK 8 surface that the
javalib had not yet provided.

## Scala.js-specific adaptations vs the scala-native source

- EPFL Apache 2.0 file header on both new files.
- No `@nowarn` pragma — the javalib compiles on Scala 2.12 only, where
  the case-class-private-ctor warning is not emitted. `HexFormat` is a
  plain `final class` with hand-written `equals` / `hashCode` / `toString`.
- A private `checkFromToIndex` helper is inlined inside `HexFormat`
  because `java.util.Objects` here targets JDK 8 and does not expose
  `Objects.checkFromToIndex`.
- The `DigitValues` ASCII -> hex digit lookup table is built once at
  class init. A static `Array[Byte](-1, -1, ...)` literal would pull in
  `scala.reflect.ClassTag`, `scala.collection.Seq`, and `scala.Array$`,
  which the javalib IR check rejects. **The runtime hot path
  (`DigitValues(ch)`) reads the same `Array[Byte]` by char-code index;
  the inner parse / format loops are byte-for-byte identical to the
  scala-native source.**
- Tests live under `test-suite/shared/src/test/require-jdk17/`, so the
  JVM toolchain gates the test on Java 17+ while the Scala.js test
  runner ships its own `java.util.HexFormat` unconditionally.
- Null-pointer assertions in the test use `assertThrowsNPEIfCompliant`
  because scala-js wraps NPEs as `UndefinedBehaviorError` in the
  default (non-compliant) mode.

## Test plan

- [x] `sbt 'testSuite2_12/testOnly *HexFormatTestOnJDK17'` -> 8/8 pass
- [x] `sbt 'testSuite2_13/testOnly *HexFormatTestOnJDK17'` -> 8/8 pass
- [x] `sbt 'testSuiteJVM2_13/testOnly *HexFormatTestOnJDK17'` -> 8/8 pass (validates against the real OpenJDK 17 `HexFormat`)
- [x] `sbt 'javalibInternal/Compile/products'` (IR postprocessing) -> clean
- [x] `scalafmt --test` -> clean
- [ ] CI

cc @sjrd