### PR TITLE
Opt: Handle PreTransBlock in pretransformSelectCommon.

### DIFF
--- a/linker/shared/src/main/scala/org/scalajs/linker/frontend/optimizer/OptimizerCore.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/frontend/optimizer/OptimizerCore.scala
@@ -1393,11 +1393,21 @@ private[optimizer] abstract class OptimizerCore(
           cancelFun()
         }
 
-      case PreTransLocalDef(LocalDef(_, _,
-              InlineClassInstanceReplacement(_, fieldLocalDefs, cancelFun))) =>
+      case PreTransMaybeBlock(bindingsAndStats,
+              PreTransLocalDef(
+                  LocalDef(_, _, InlineClassInstanceReplacement(_, fieldLocalDefs, cancelFun)))) =>
         val fieldLocalDef = fieldLocalDefs(field.name)
         assert(!isLhsOfAssign || fieldLocalDef.mutable, s"assign to immutable field at $pos")
-        cont(fieldLocalDef.toPreTransform)
+        val fullResult = fieldLocalDef.toPreTransform match {
+          case result if bindingsAndStats.isEmpty =>
+            result
+          case result: PreTransResult =>
+            PreTransBlock(bindingsAndStats, result)
+          case result =>
+            Block(finishTransformBindings(bindingsAndStats, finishTransformExpr(result)))
+              .toPreTransform
+        }
+        cont(fullResult)
 
       case _ =>
         def default: TailRec[Tree] = {


### PR DESCRIPTION
Previously, we produced bad code for shapes like
```scala
foo().bar
```
where foo() returned a `PreTransBlock` with a inlineable result. We would systematically reify the record, which is particularly bad since the `Select` would only reach one field; not all of them.

It was also not equivalent to
```scala
val f = foo()
f.bar
```
That shape would actually avoid reifying the record.

We now handle `PreTransBlock`s in `pretransformSelectCommon`, which makes the first shape produce good code, like the second shape.

---

When applied on top of #5341, this change produces the following diff on the test suite:
https://gist.github.com/sjrd/7d09c7c61f6b285a888dfd0358b3de77