### PR TITLE
Wasm: Remove polyfill for JS string builtins; Wasm 3.0 is our baseline.

### DIFF
--- a/linker/shared/src/main/scala/org/scalajs/linker/backend/wasmemitter/LoaderContent.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/backend/wasmemitter/LoaderContent.scala
@@ -151,12 +151,13 @@ const scalaJSHelpers = {
   jsNewNoArg: (constr) => new constr(),
   jsImportMeta: () => import.meta,
   jsAwait: (WebAssembly.Suspending ? new WebAssembly.Suspending((x) => x) : ((x) => {
-    /* This should not happen. We cannot get here without going through a
-     * `WebAssembly.promising()` function. If that one succeeded,
-     * `WebAssembly.Suspending` should also exist.
-     * TODO Remove this fallback when JSPI support is widespread.
+    /* If we get here, we tried to perform a js.await call, but the engine does
+     * not support JSPI. This means we are not in a js.async context (trying
+     * to enter js.async would have already failed without JSPI support).
+     * If we had JSPI, this situation would throw a SuspendError.
+     * TODO Do not include jsAwait at all if we do not use js.await.
      */
-    throw new Error("Unexpected js.await() without JSPI support.");
+    throw new Error("Cannot perform js.await() without a js.async {...} block on the stack.");
   })),
   jsDelete: (o, p) => { delete o[p]; },
   jsForInStart: function*(o) { for (var k in o) yield k; },
@@ -167,24 +168,6 @@ const scalaJSHelpers = {
   jsSuperSelect: superSelect,
   jsSuperSelectSet: superSelectSet,
 }
-
-const stringBuiltinPolyfills = {
-  test: (x) => typeof x === 'string',
-  fromCharCode: (c) => String.fromCharCode(c),
-  fromCodePoint: (cp) => String.fromCodePoint(cp),
-  charCodeAt: (s, i) => s.charCodeAt(i),
-  codePointAt: (s, i) => s.codePointAt(i),
-  length: (s) => s.length,
-  concat: (a, b) => "" + a + b, // "" tells the JIT that this is *always* a string concat operation
-  substring: (str, start, end) => str.substring(start >>> 0, end >>> 0),
-  equals: (a, b) => a === b,
-};
-
-const stringConstantsPolyfills = new Proxy({}, {
-  get(target, property, receiver) {
-    return property;
-  },
-});
 
 export async function load(wasmFileURL, exportSetters, privateJSFieldGetters,
     privateJSFieldSetters, customJSHelpers, wtf16Strings) {
@@ -199,8 +182,6 @@ export async function load(wasmFileURL, exportSetters, privateJSFieldGetters,
     "$PrivateJSFieldSetters": privateJSFieldSetters,
     "$CustomHelpersModule": customJSHelpers,
     "$WTF16StringConstantsModule": wtf16Strings,
-    "$JSStringBuiltinsModule": stringBuiltinPolyfills,
-    "$UTF8StringConstantsModule": stringConstantsPolyfills,
   };
   const options = {
     builtins: ["js-string"],

--- a/linker/shared/src/main/scala/org/scalajs/linker/backend/wasmemitter/README.md
+++ b/linker/shared/src/main/scala/org/scalajs/linker/backend/wasmemitter/README.md
@@ -9,9 +9,18 @@ This readme gives an overview of the compilation scheme.
 
 ## WebAssembly features that we use
 
-* The [GC extension](https://github.com/WebAssembly/gc)
-* The [exception handling proposal](https://github.com/WebAssembly/exception-handling)
-* The [JS string builtins proposal](https://github.com/WebAssembly/js-string-builtins) (currently with polyfills, so it is not required)
+Our baseline is [WebAssembly 3.0](https://webassembly.org/news/2025-09-17-wasm-3.0/).
+This edition introduced, among others: garbage collection, exception handling, tail calls and JS string builtins.
+
+The following versions of main engines are known to support the required features out of the box:
+
+* Node.js 25
+* Firefox 134
+* Chrome 137
+* Safari 26
+
+When using `js.async/js.await` (which requires to set the `esVersion` to `ES2017` or later), we additionally require [the JavaScript Promise Integration (JSPI) proposal](https://github.com/WebAssembly/js-promise-integration/tree/main).
+It has reached Stage 4 (standardized) but is not part of Wasm 3.0.
 
 All our heap values are allocated as GC data structures.
 We do not use the linear memory of WebAssembly at all.
@@ -630,7 +639,6 @@ This is implemented in the function `identityHashCode` in `CoreWasmLib`.
 
 As mentioned above, strings are represented as JS `string`s.
 Primitive operations on strings are implemented using [JS String Builtins](https://github.com/WebAssembly/js-string-builtins).
-Since the latter are not yet fully supported, notably by Safari, we polyfill the functions we use.
 Some conversions to strings, which are part of the semantics of string concatenation, are performed by helper JS functions.
 
 For string constants, we use the builtin imports for string literals offered by the JS string builtins proposal.
@@ -639,8 +647,6 @@ The import name is the string value.
 
 That means that only valid Unicode strings can be imported that way (import names must be valid UTF-8).
 For string constants that are not valid Unicode strings, we generate a dedicated dictionary from our JavaScript loader, in yet another (regular) imported module.
-
-We polyfill the string constants module with a JavaScript `Proxy`.
 
 ## JavaScript interoperability
 


### PR DESCRIPTION
Clarify that Wasm 3.0 is our baseline for the Wasm target. Since it contains the JS string builtins, we remove their polyfill.

The feature set we need is supported out of the box by Node.js 25, Firefox 134, Chrome 137 and Safari 26.