### PR TITLE
Add ESVersion constants up to ES2026.

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -592,7 +592,9 @@ def allESVersions = [
   "ES2018",
   // "ES2019", // We do not use anything specifically from ES2019
   "ES2020",
-  "ES2026" // We do not use anything specifically from ES2021-ES2026, but always test the latest to avoid #4675
+  // "ES2021", // We do not use anything specifically from ES2021
+  "ES2022", // the 'd' flag for RegExp
+  "ES2026" // We do not use anything specifically from ES2023-ES2026, but always test the latest to avoid #4675
 ]
 def defaultESVersion = "ES2015"
 def latestESVersion = "ES2026"

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -592,10 +592,10 @@ def allESVersions = [
   "ES2018",
   // "ES2019", // We do not use anything specifically from ES2019
   "ES2020",
-  "ES2021" // We do not use anything specifically from ES2021, but always test the latest to avoid #4675
+  "ES2026" // We do not use anything specifically from ES2021-ES2026, but always test the latest to avoid #4675
 ]
 def defaultESVersion = "ES2015"
-def latestESVersion = "ES2021"
+def latestESVersion = "ES2026"
 
 // The 'quick' matrix
 def quickMatrix = []

--- a/javalib/src/main/scala/java/util/regex/PatternCompiler.scala
+++ b/javalib/src/main/scala/java/util/regex/PatternCompiler.scala
@@ -95,7 +95,7 @@ private[regex] object PatternCompiler {
 
   /** Cache for `Support.supportsIndices`. */
   private val _supportsIndices =
-    featureTest("d")
+    (LinkingInfo.esVersion >= ESVersion.ES2022) || featureTest("d")
 
   /** Feature-test methods.
    *
@@ -123,7 +123,7 @@ private[regex] object PatternCompiler {
     /** Tests whether the underlying JS RegExp supports the 'd' flag. */
     @inline
     def supportsIndices: Boolean =
-      _supportsIndices
+      (LinkingInfo.esVersion >= ESVersion.ES2022) || _supportsIndices
 
     /** Tests whether features requiring support for the 'u' flag are enabled.
      *

--- a/library/src/main/scala/scala/scalajs/LinkingInfo.scala
+++ b/library/src/main/scala/scala/scalajs/LinkingInfo.scala
@@ -371,6 +371,57 @@ object LinkingInfo {
      *  - Separators for numeric literals (e.g., `1_000`)
      */
     final val ES2021 = 12
+
+    /** ECMAScript 2022 (13th edition).
+     *
+     *  Contains the following notable features:
+     *
+     *  - Top-level `await`
+     *  - New class elements: public/private instance/static fields/methods/accessors
+     *  - `RegExp` match indices with the `/d` flag
+     *  - `Error.cause`
+     *  - `Object.hasOwn`
+     */
+    final val ES2022 = 13
+
+    /** ECMAScript 2023 (14th edition).
+     *
+     *  Contains the following notable features:
+     *
+     *  - New methods on Arrays and TypedArrays
+     *  - `#!` comments at the top of the file
+     *  - Most Symbols in weak collections
+     */
+    final val ES2023 = 14
+
+    /** ECMAScript 2024 (15th edition).
+     *
+     *  Contains the following notable features:
+     *
+     *  - `RegExp` advanced features for sets of strings with the `/v` flag
+     *  - `Atomics.waitAsync`
+     */
+    final val ES2024 = 15
+
+    /** ECMAScript 2025 (16th edition).
+     *
+     *  Contains the following notable features:
+     *
+     *  - 16-bit floating point: `Math.f16round`, `Float16Array`, `DataView.{get,set}Float16`
+     *  - `Iterator` global
+     *  - `RegExp.escape`
+     *  - `Promise.try`
+     */
+    final val ES2025 = 16
+
+    /** ECMAScript 2026 (17th edition).
+     *
+     *  Contains the following notable features:
+     *
+     *  - `Uint8Array` methods for converting to/from hex and base64 strings
+     *  - `Math.sumPrecise`
+     */
+    final val ES2026 = 17
   }
 
   /** Constants for the value of `moduleKind`. */

--- a/linker-interface/shared/src/main/scala/org/scalajs/linker/interface/ESVersion.scala
+++ b/linker-interface/shared/src/main/scala/org/scalajs/linker/interface/ESVersion.scala
@@ -99,6 +99,57 @@ object ESVersion {
    */
   val ES2021: ESVersion = new ESVersion(12, "ECMAScript 2021")
 
+  /** ECMAScript 2022 (13th edition).
+   *
+   *  Contains the following notable features:
+   *
+   *  - Top-level `await`
+   *  - New class elements: public/private instance/static fields/methods/accessors
+   *  - `RegExp` match indices with the `/d` flag
+   *  - `Error.cause`
+   *  - `Object.hasOwn`
+   */
+  val ES2022: ESVersion = new ESVersion(13, "ECMAScript 2022")
+
+  /** ECMAScript 2023 (14th edition).
+   *
+   *  Contains the following notable features:
+   *
+   *  - New methods on Arrays and TypedArrays
+   *  - `#!` comments at the top of the file
+   *  - Most Symbols in weak collections
+   */
+  val ES2023: ESVersion = new ESVersion(14, "ECMAScript 2023")
+
+  /** ECMAScript 2024 (15th edition).
+   *
+   *  Contains the following notable features:
+   *
+   *  - `RegExp` advanced features for sets of strings with the `/v` flag
+   *  - `Atomics.waitAsync`
+   */
+  val ES2024: ESVersion = new ESVersion(15, "ECMAScript 2024")
+
+  /** ECMAScript 2025 (16th edition).
+   *
+   *  Contains the following notable features:
+   *
+   *  - 16-bit floating point: `Math.f16round`, `Float16Array`, `DataView.{get,set}Float16`
+   *  - `Iterator` global
+   *  - `RegExp.escape`
+   *  - `Promise.try`
+   */
+  val ES2025: ESVersion = new ESVersion(16, "ECMAScript 2025")
+
+  /** ECMAScript 2026 (17th edition).
+   *
+   *  Contains the following notable features:
+   *
+   *  - `Uint8Array` methods for converting to/from hex and base64 strings
+   *  - `Math.sumPrecise`
+   */
+  val ES2026: ESVersion = new ESVersion(17, "ECMAScript 2026")
+
   private[interface] implicit object ESVersionFingerprint extends Fingerprint[ESVersion] {
 
     override def fingerprint(esVersion: ESVersion): String = {

--- a/linker/jvm/src/main/scala/org/scalajs/linker/backend/closure/ClosureLinkerBackend.scala
+++ b/linker/jvm/src/main/scala/org/scalajs/linker/backend/closure/ClosureLinkerBackend.scala
@@ -85,6 +85,9 @@ final class ClosureLinkerBackend(config: LinkerBackendImpl.Config) extends Linke
       case ESVersion.ES2020 => ECMASCRIPT_2020
       case ESVersion.ES2021 => ECMASCRIPT_2021
 
+      // GCC does not have constants for later versions of ECMAScript
+      case esVersion if esVersion > ESVersion.ES2021 => ECMASCRIPT_2021
+
       // Test for ESVersion.ES5_1 without triggering the deprecation warning
       case esVersion if esVersion.edition == 5 =>
         ECMASCRIPT5_STRICT

--- a/project/NodeJSEnvForcePolyfills.scala
+++ b/project/NodeJSEnvForcePolyfills.scala
@@ -101,8 +101,10 @@ final class NodeJSEnvForcePolyfills(esVersion: ESVersion, config: NodeJSEnv.Conf
         |      if (flags.indexOf('s') >= 0)
         |        throw new SyntaxError("unsupported flag 's'");
         |""".stripMargin)}
+        |${cond(ES2022, """
         |      if (flags.indexOf('d') >= 0)
         |        throw new SyntaxError("unsupported flag 'd'");
+        |""".stripMargin)}
         |    }
         |
         |${cond(ES2018, """

--- a/test-suite/js/src/test/scala/org/scalajs/testsuite/library/LinkingInfoTest.scala
+++ b/test-suite/js/src/test/scala/org/scalajs/testsuite/library/LinkingInfoTest.scala
@@ -59,6 +59,11 @@ class LinkingInfoTest {
     assertEquals(10, ESVersion.ES2019)
     assertEquals(11, ESVersion.ES2020)
     assertEquals(12, ESVersion.ES2021)
+    assertEquals(13, ESVersion.ES2022)
+    assertEquals(14, ESVersion.ES2023)
+    assertEquals(15, ESVersion.ES2024)
+    assertEquals(16, ESVersion.ES2025)
+    assertEquals(17, ESVersion.ES2026)
   }
 
   @Test def moduleKindConstants(): Unit = {


### PR DESCRIPTION
And allow to dce the polyfill for the RegExp 'd' flag with ES2022+.