### PR TITLE
CI ONLY WiP Upgrade to Scala 3.9.

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -584,6 +584,7 @@ def otherScalaVersions = [
   "2.13.16",
   "2.13.17"
 ]
+def scala3Version = "3.9.0-RC1"
 
 def allESVersions = [
   "ES5_1",
@@ -636,6 +637,7 @@ allJavaVersions.each { javaVersion ->
     quickMatrix.add([task: "sbt-plugin-and-scalastyle-linker-profile", scala: mainScalaVersion, java: javaVersion, sbtPluginProject: "sbtPlugin3"])
   }
 }
+quickMatrix.add([task: "tools", scala: scala3Version, java: "17"])
 
 // The 'full' matrix
 def fullMatrix = quickMatrix.clone()
@@ -680,6 +682,9 @@ matrix.each { taskDef ->
   }
 
   def suffix = taskDef.scala.split('\\.')[0..1].join('_')
+  if (suffix.startsWith("3_")) {
+    suffix = "3"
+  }
   taskStr = taskStr.replace('$v', suffix)
 
   def ciScript = CIScriptPrelude + taskStr

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -572,6 +572,7 @@ def otherScalaVersions = [
   "2.13.16",
   "2.13.17"
 ]
+def scala3Version = "3.9.0"
 
 def allESVersions = [
   "ES5_1",
@@ -627,6 +628,7 @@ allJavaVersions.each { javaVersion ->
   }
   quickMatrix.add([task: "sbt-plugin-and-scalastyle-linker-profile", scala: mainScalaVersion, java: javaVersion, sbtPluginProject: "sbtPlugin3"])
 }
+quickMatrix.add([task: "tools", scala: scala3Version, java: "17"])
 
 // The 'full' matrix
 def fullMatrix = quickMatrix.clone()
@@ -671,6 +673,9 @@ matrix.each { taskDef ->
   }
 
   def suffix = taskDef.scala.split('\\.')[0..1].join('_')
+  if (suffix.startsWith("3_")) {
+    suffix = "3"
+  }
   taskStr = taskStr.replace('$v', suffix)
 
   def ciScript = CIScriptPrelude + taskStr

--- a/linker/shared/src/test/scala/org/scalajs/linker/AnalyzerTest.scala
+++ b/linker/shared/src/test/scala/org/scalajs/linker/AnalyzerTest.scala
@@ -855,12 +855,13 @@ class AnalyzerTest {
     } yield {
       assertNoError(analysis)
 
-      val MethodSyntheticKind.ReflectiveProxy(target) = {
+      val syntheticKind = {
         analysis.classInfos("X")
           .methodInfos(MemberNamespace.Public)(fooReflProxyName)
           .syntheticKind
       }
 
+      val MethodSyntheticKind.ReflectiveProxy(target) = syntheticKind: @unchecked
       assertEquals(fooBMethodName, target)
     }
   }

--- a/linker/shared/src/test/scala/org/scalajs/linker/AnalyzerTest.scala
+++ b/linker/shared/src/test/scala/org/scalajs/linker/AnalyzerTest.scala
@@ -856,12 +856,13 @@ class AnalyzerTest {
     } yield {
       assertNoError(analysis)
 
-      val MethodSyntheticKind.ReflectiveProxy(target) = {
+      val syntheticKind = {
         analysis.classInfos("X")
           .methodInfos(MemberNamespace.Public)(fooReflProxyName)
           .syntheticKind
       }
 
+      val MethodSyntheticKind.ReflectiveProxy(target) = syntheticKind: @unchecked
       assertEquals(fooBMethodName, target)
     }
   }

--- a/linker/shared/src/test/scala/org/scalajs/linker/LinkerTest.scala
+++ b/linker/shared/src/test/scala/org/scalajs/linker/LinkerTest.scala
@@ -76,12 +76,12 @@ class LinkerTest {
     }
   }
 
+  private class DummyException extends Exception
+
   /** This test exposes a problem where a linker in error state is called
    *  multiple times and ends up thinking it is being used concurrently.
    */
   @Test def cleanLinkingState(): AsyncResult = await {
-    class DummyException extends Exception
-
     val badSeq = new IndexedSeq[IRFile] {
       def apply(x: Int): IRFile = throw new DummyException()
       def length: Int = throw new DummyException()

--- a/linker/shared/src/test/scala/org/scalajs/linker/frontend/optimizer/IntegerDivisionsFuzzTest.scala
+++ b/linker/shared/src/test/scala/org/scalajs/linker/frontend/optimizer/IntegerDivisionsFuzzTest.scala
@@ -134,7 +134,7 @@ class IntegerDivisionsFuzzTest {
     val optimized = integerDivisions.makeOptimizedDivision(op, divisor)
 
     if (divisor == 0) {
-      val UnaryOp(UnaryOp.Throw, _) = optimized // meant as an assertion
+      val UnaryOp(UnaryOp.Throw, _) = optimized: @unchecked // meant as an assertion
     } else {
       def test(numValue: Int): Unit =
         assertEvalEquals(reference, optimized, IntLiteral(numValue))
@@ -174,7 +174,7 @@ class IntegerDivisionsFuzzTest {
     val optimized = integerDivisions.makeOptimizedDivision(op, divisor)
 
     if (divisor == 0L) {
-      val UnaryOp(UnaryOp.Throw, _) = optimized // meant as an assertion
+      val UnaryOp(UnaryOp.Throw, _) = optimized: @unchecked // meant as an assertion
     } else {
       def test(numValue: Long): Unit =
         assertEvalEquals(reference, optimized, LongLiteral(numValue))

--- a/linker/shared/src/test/scala/org/scalajs/linker/testutils/CapturingLogger.scala
+++ b/linker/shared/src/test/scala/org/scalajs/linker/testutils/CapturingLogger.scala
@@ -17,6 +17,8 @@ import scala.util.matching.Regex
 
 import org.scalajs.logging._
 
+import org.scalajs.linker.Nullables._
+
 import org.junit.Assert._
 
 final class CapturingLogger extends Logger {
@@ -81,7 +83,8 @@ object CapturingLogger {
 
     def assertContainsMatch(messageRegex: Regex): Seq[String] = {
       lines.collectFirst {
-        case LogLine(_, messageRegex(captures @ _*)) => captures
+        case LogLine(_, messageRegex(captures @ _*)) =>
+          captures.map(_.nn)
       }.getOrElse {
         throw new AssertionError(s"expected a log line matching '$messageRegex', but got \n${this}")
       }

--- a/linker/shared/src/test/scala/org/scalajs/linker/testutils/TestIRRepo.scala
+++ b/linker/shared/src/test/scala/org/scalajs/linker/testutils/TestIRRepo.scala
@@ -28,7 +28,7 @@ object TestIRRepo {
     import scala.concurrent.ExecutionContext.Implicits.global
 
     Platform.loadJar(stdlibPath)
-      .flatMap(globalIRCache.newCache.cached _)
+      .flatMap(globalIRCache.newCache.cached(_))
   }
 
   /** For each previous lib, calls `f(version, irFiles)`, and combines the result.

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -1017,7 +1017,7 @@ object Build {
         "2.13.17",
         "2.13.18",
       ),
-      cross3ScalaVersions := Seq("3.8.3"),
+      cross3ScalaVersions := Seq("3.9.0-RC1"),
 
       default212ScalaVersion := cross212ScalaVersions.value.last,
       default213ScalaVersion := cross213ScalaVersions.value.last,
@@ -1300,7 +1300,9 @@ object Build {
           val s = streams.value
           val log = s.log
           val lm = dependencyResolution.value
-          val binVer = scalaBinaryVersion.value
+
+          val binVer0 = scalaBinaryVersion.value
+          val binVer = if (binVer0 == "3") "2.13" else binVer0
 
           val retrieveDir = s.cacheDirectory / "previous-stdlibs"
 

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -1000,7 +1000,7 @@ object Build {
         "2.13.17",
         "2.13.18",
       ),
-      cross3ScalaVersions := Seq("3.8.3"),
+      cross3ScalaVersions := Seq("3.9.0"),
 
       default212ScalaVersion := cross212ScalaVersions.value.last,
       default213ScalaVersion := cross213ScalaVersions.value.last,
@@ -1283,7 +1283,9 @@ object Build {
           val s = streams.value
           val log = s.log
           val lm = dependencyResolution.value
-          val binVer = scalaBinaryVersion.value
+
+          val binVer0 = scalaBinaryVersion.value
+          val binVer = if (binVer0 == "3") "2.13" else binVer0
 
           val retrieveDir = s.cacheDirectory / "previous-stdlibs"
 

--- a/sbt-plugin/src/sbt-test/linker/custom-linker/build.sbt
+++ b/sbt-plugin/src/sbt-test/linker/custom-linker/build.sbt
@@ -23,7 +23,7 @@ lazy val customLinker = project.in(file("custom-linker"))
     name := "custom-linker-impl",
     scalaVersion := {
       if (sbtVersion.value.startsWith("1.")) "2.12.21"
-      else "3.8.3"
+      else "3.9.0-RC1"
     },
     libraryDependencies += "org.scala-js" %% "scalajs-linker" % scalaJSVersion,
   )

--- a/sbt-plugin/src/sbt-test/linker/custom-linker/build.sbt
+++ b/sbt-plugin/src/sbt-test/linker/custom-linker/build.sbt
@@ -23,7 +23,7 @@ lazy val customLinker = project.in(file("custom-linker"))
     name := "custom-linker-impl",
     scalaVersion := {
       if (sbtVersion.value.startsWith("1.")) "2.12.21"
-      else "3.8.3"
+      else "3.9.0"
     },
     libraryDependencies += "org.scala-js" %% "scalajs-linker" % scalaJSVersion,
   )

--- a/test-common/src/test/scala/org/scalajs/testing/common/RunMuxRPCTest.scala
+++ b/test-common/src/test/scala/org/scalajs/testing/common/RunMuxRPCTest.scala
@@ -49,8 +49,8 @@ class RunMuxRPCTest {
         _ <- y.call(eps.call, i)(())
       } yield {
         val (needTrue, needFalse) = called.splitAt(i + 1)
-        needTrue.foreach(assertTrue _)
-        needFalse.foreach(assertFalse _)
+        needTrue.foreach(assertTrue(_))
+        needFalse.foreach(assertFalse(_))
       }
     }
   }
@@ -65,8 +65,8 @@ class RunMuxRPCTest {
     for (i <- got.indices) {
       y.send(eps.msg, i)(())
       val (needTrue, needFalse) = got.splitAt(i + 1)
-      needTrue.foreach(assertTrue _)
-      needFalse.foreach(assertFalse _)
+      needTrue.foreach(assertTrue(_))
+      needFalse.foreach(assertFalse(_))
     }
   }
 


### PR DESCRIPTION
CI only for now.

The sbt plugin tests will fail because sbt 2 uses Scala 3.8.x so far. We will have to wait until they publish a version based on Scala 3.9.x.

However, this allows to run linker unit tests on Scala 3. Prior to 3.9.x, there was an erasure bug that prevented our `AsyncResult`s to be recognized as `void` by JUnit.

---

Note that we can't just temporarily ignore the sbt plugin tests. The fact that they fail is a very real problem: users would not be able to use our artifacts if we actually build and ship them with 3.9.x.