### PR TITLE
Upgrade to sbt 2.0.0 final.

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -1458,14 +1458,14 @@ object Build {
       pluginCrossBuild / sbtVersion := {
         scalaBinaryVersion.value match {
           case "2.12" => "1.9.0"
-          case _      => "2.0.0-RC14"
+          case _      => "2.0.0"
         }
       },
 
       scriptedSbt := {
         scalaBinaryVersion.value match {
           case "2.12" => "1.9.0"
-          case _      => "2.0.0-RC14"
+          case _      => "2.0.0"
         }
       },
 

--- a/sbt-plugin/src/sbt-test/linker/no-root-dependency-resolution/build.sbt
+++ b/sbt-plugin/src/sbt-test/linker/no-root-dependency-resolution/build.sbt
@@ -1,5 +1,5 @@
 /* This scripted test is pinned to sbt 1.x in project/build.properties.
- * sbt 2.0.0-RC9+ requires LocalRootProject / dependencyResolution,
+ * sbt 2.0.0+ requires LocalRootProject / dependencyResolution,
  * for https://github.com/sbt/sbt/pull/8459.
  * otherwise, the build fails earlier in sbt startup.
  */

--- a/sbt-plugin/src/sbt-test/sbt2/helloworld-scalajs-dom/project/build.properties
+++ b/sbt-plugin/src/sbt-test/sbt2/helloworld-scalajs-dom/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=2.0.0-RC14
+sbt.version=2.0.0

--- a/sbt-plugin/src/sbt-test/sbt2/scala3-basic/project/build.properties
+++ b/sbt-plugin/src/sbt-test/sbt2/scala3-basic/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=2.0.0-RC14
+sbt.version=2.0.0


### PR DESCRIPTION
I thought they were waiting Scala 3.9.0, but apparently not :man_shrugging:, so we might as well use the stable version.