### PR TITLE
Fix duplicated Scala.js platform suffix for sbt2 (`_sjs1_sjs1_3`)

### DIFF
--- a/sbt-plugin/src/main/scala-2.12/org/scalajs/sbtplugin/PluginCompat.scala
+++ b/sbt-plugin/src/main/scala-2.12/org/scalajs/sbtplugin/PluginCompat.scala
@@ -68,6 +68,7 @@ private[sbtplugin] object PluginCompat {
   }
 
   def platformDepsCrossVersionSetting: Seq[Setting[_]] = Seq(
+    crossVersion := ScalaJSCrossVersion.binary,
     platformDepsCrossVersion := ScalaJSCrossVersion.binary
   )
 

--- a/sbt-plugin/src/main/scala/org/scalajs/sbtplugin/ScalaJSPluginInternal.scala
+++ b/sbt-plugin/src/main/scala/org/scalajs/sbtplugin/ScalaJSPluginInternal.scala
@@ -803,9 +803,8 @@ private[sbtplugin] object ScalaJSPluginInternal {
   private def isScala3(scalaV: String): Boolean =
     scalaV.startsWith("3.")
 
-  private val scalaJSProjectBaseSettings = Seq(
-      crossVersion := ScalaJSCrossVersion.binary
-  ) ++ PluginCompat.platformDepsCrossVersionSetting ++ Seq(
+  private val scalaJSProjectBaseSettings = Def.settings(
+      PluginCompat.platformDepsCrossVersionSetting,
       scalaJSModuleInitializers := Def.uncached {
         Seq()
       },

--- a/sbt-plugin/src/sbt-test/cross-version/artifact-path/build.sbt
+++ b/sbt-plugin/src/sbt-test/cross-version/artifact-path/build.sbt
@@ -1,0 +1,15 @@
+val checkArtifactPath = taskKey[Unit]("Checks the Scala.js artifact path")
+
+lazy val library = project
+  .enablePlugins(ScalaJSPlugin)
+  .settings(
+    scalaVersion := "3.8.3",
+    version := "0.1.0-SNAPSHOT",
+    checkArtifactPath := {
+      val actual = (Compile / packageBin / artifactPath).value.toString()
+      val expected = "library_sjs1_3-0.1.0-SNAPSHOT.jar"
+
+      if (!actual.endsWith(expected))
+        sys.error(s"Expected path to end with $expected, got $actual")
+    }
+  )

--- a/sbt-plugin/src/sbt-test/cross-version/artifact-path/project/plugins.sbt
+++ b/sbt-plugin/src/sbt-test/cross-version/artifact-path/project/plugins.sbt
@@ -1,0 +1,1 @@
+addSbtPlugin("org.scala-js" % "sbt-scalajs" % sys.props("plugin.version"))

--- a/sbt-plugin/src/sbt-test/cross-version/artifact-path/test
+++ b/sbt-plugin/src/sbt-test/cross-version/artifact-path/test
@@ -1,0 +1,1 @@
+> library / checkArtifactPath


### PR DESCRIPTION
Previously, Scala.js projects with sbt2 publish artifacts has the platform suffix twice like `foo_sjs1_sjs1_3-x.x.x`. This commit fix the duplication and make it `foo_sjs1_3-x.x.x`

(I tested linking apps and downstream sbt-plugins, but didn't tested libraries 😓 )

**background**
In sbt 1.x, Scala.js (and native) provided its own cross-versioning scheme using `ScalaJSCrossVersion.binary`.
However in sbt 2.x, it introduces `platform` setting in addition to `crossVersion`, when we set `platform := "sjs1"`, and `crossVersion := CrossVersion.binary`, sbt will add suffix like `_sjs1_3`.

**problem**
Scala.js plugin for sbt2 previously set both `platform`, which appends `_sjs1`, and `crossVersion = ScalaJSCrossVersion.binary` that appends `sjs1_3`.
As a result, we had a duplicated `_sjs1_sjs1_3` suffix.

---

In sbt 2.x, we use the default `crossVersion` (`CrossVersion.binary`) https://github.com/sbt/sbt/blob/73d164fa84375ef6a7444675dd7c2360bf7f9787/main/src/main/scala/sbt/Defaults.scala#L727 and `platform := "sjs1"`,
instead of `ScalaJSCrossVersion.binary`

native does the same thing
- https://github.com/scala-native/scala-native/blob/04d319154afc196b985724645c07d4c0d82067df/sbt-scala-native/src/main/scala-sbt-1.0/scala/scalanative/sbtplugin/PluginCompat.scala#L23-L26
- https://github.com/scala-native/scala-native/blob/04d319154afc196b985724645c07d4c0d82067df/sbt-scala-native/src/main/scala-sbt-2/scala/scalanative/sbtplugin/PluginCompat.scala#L81-L83

