### PR TITLE
Fix #5381: Fix logic for large negative values in BigDecimal(double).

### DIFF
--- a/javalib/src/main/scala/java/math/BigDecimal.scala
+++ b/javalib/src/main/scala/java/math/BigDecimal.scala
@@ -25,7 +25,7 @@ package java.math
 
 import scala.annotation.tailrec
 
-import java.lang.{Double => JDouble}
+import java.lang.{Double => JDouble, Long => JLong}
 import java.util.Arrays
 import java.util.Objects.requireNonNull
 import java.util.ScalaOps._
@@ -527,14 +527,14 @@ class BigDecimal() extends Number with Comparable[BigDecimal] {
       }
     }
     // Calculating the new unscaled value and the new scale
-    val mantissa3 = if ((bits >> 63) != 0) -mantissa2 else mantissa2
+    val mantissa3 = if (bits < 0L) -mantissa2 else mantissa2
     val mantissaBits = bitLength(mantissa3)
     if (_scale < 0) {
       _bitLength = if (mantissaBits == 0) 0 else mantissaBits - _scale
       if (_bitLength < 64)
         _smallValue = mantissa3 << (-_scale)
       else
-        _intVal = new BigInteger(1, mantissa3).shiftLeft(-_scale)
+        _intVal = new BigInteger(JLong.signum(bits), mantissa2).shiftLeft(-_scale)
       _scale = 0
     } else if (_scale > 0) {
       def mSum = mantissaBits + LongFivePowsBitLength(_scale)
@@ -542,7 +542,7 @@ class BigDecimal() extends Number with Comparable[BigDecimal] {
         _smallValue = mantissa3 * LongFivePows(_scale)
         _bitLength = bitLength(_smallValue)
       } else {
-        setUnscaledValue(multiplyByFivePow(BigInteger.valueOf(mantissa3), _scale))
+        setUnscaledValue(multiplyByFivePow(new BigInteger(JLong.signum(bits), mantissa2), _scale))
       }
     } else {
       _smallValue = mantissa3

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/math/BigDecimalTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/math/BigDecimalTest.scala
@@ -49,6 +49,8 @@ class BigDecimalTest {
   }
 
   @Test def ctorDouble(): Unit = {
+    assertBDExactEquals(new BigInteger("0"), 0, new BigDecimal(0.0))
+    assertBDExactEquals(new BigInteger("15"), 1, new BigDecimal(1.5))
     assertBDExactEquals(
         new BigInteger("329999999999999982236431605997495353221893310546875"), 50,
         new BigDecimal(3.3))
@@ -63,7 +65,10 @@ class BigDecimalTest {
         new BigDecimal(99999999.99999999))
     assertBDExactEquals(new BigInteger("1000000000"), 0, new BigDecimal(999999999.999999999))
     assertBDExactEquals(new BigInteger("10000000000"), 0, new BigDecimal(9999999999.9999999999))
+    assertBDExactEquals(new BigInteger("10000000000000000000"), 0, new BigDecimal(1e19))
 
+    assertBDExactEquals(new BigInteger("0"), 0, new BigDecimal(-0.0))
+    assertBDExactEquals(new BigInteger("-15"), 1, new BigDecimal(-1.5))
     assertBDExactEquals(
         new BigInteger("-329999999999999982236431605997495353221893310546875"), 50,
         new BigDecimal(-3.3))
@@ -78,5 +83,6 @@ class BigDecimalTest {
         new BigDecimal(-99999999.99999999))
     assertBDExactEquals(new BigInteger("-1000000000"), 0, new BigDecimal(-999999999.999999999))
     assertBDExactEquals(new BigInteger("-10000000000"), 0, new BigDecimal(-9999999999.9999999999))
+    assertBDExactEquals(new BigInteger("-10000000000000000000"), 0, new BigDecimal(-1e19)) // #5381
   }
 }

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/math/BigDecimalTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/math/BigDecimalTest.scala
@@ -12,169 +12,71 @@
 
 package org.scalajs.testsuite.javalib.math
 
-import java.math.BigDecimal
+import java.math._
 
 import org.junit.Test
 import org.junit.Assert._
 
 class BigDecimalTest {
 
-  // java.lang.Math.BigDecimal Int/Long Constructors
-
-  @Test def valueOfLong3(): Unit = {
-    val bd = BigDecimal.valueOf(3L)
-    assertEquals(3, bd.intValue())
-    assertTrue(bd.longValue == 3L)
+  @noinline
+  private def assertBDExactEquals(expectedUnscaledValue: BigInteger,
+      expectedScale: Int, actual: BigDecimal): Unit = {
+    assertEquals((expectedUnscaledValue, expectedScale), (actual.unscaledValue(), actual.scale()))
   }
 
-  @Test def valueOfLong999999999(): Unit = {
-    val bd = BigDecimal.valueOf(999999999L)
-    assertEquals(999999999, bd.intValue())
-    assertTrue(bd.longValue == 999999999L)
+  @Test def valueOfLong(): Unit = {
+    assertBDExactEquals(BigInteger.valueOf(3L), 0, BigDecimal.valueOf(3L))
+    assertBDExactEquals(BigInteger.valueOf(999999999L), 0, BigDecimal.valueOf(999999999L))
+    assertBDExactEquals(BigInteger.valueOf(9999999999L), 0, BigDecimal.valueOf(9999999999L))
+    assertBDExactEquals(BigInteger.valueOf(-999999999L), 0, BigDecimal.valueOf(-999999999L))
+    assertBDExactEquals(BigInteger.valueOf(-9999999999L), 0, BigDecimal.valueOf(-9999999999L))
   }
 
-  @Test def valueOfLong9999999999(): Unit = {
-    val bd = BigDecimal.valueOf(9999999999L)
-    assertTrue(bd.longValue == 9999999999L)
+  @Test def ctorString(): Unit = {
+    assertBDExactEquals(BigInteger.valueOf(3L), 0, new BigDecimal("3"))
+    assertBDExactEquals(BigInteger.valueOf(99L), 0, new BigDecimal("99"))
+    assertBDExactEquals(BigInteger.valueOf(999999999L), 0, new BigDecimal("999999999"))
+    assertBDExactEquals(BigInteger.valueOf(9999999999L), 0, new BigDecimal("9999999999"))
+    assertBDExactEquals(BigInteger.valueOf(-99L), 0, new BigDecimal("-99"))
+    assertBDExactEquals(BigInteger.valueOf(-999999999L), 0, new BigDecimal("-999999999"))
+    assertBDExactEquals(BigInteger.valueOf(-9999999999L), 0, new BigDecimal("-9999999999"))
+
+    assertBDExactEquals(BigInteger.valueOf(99L), 1, new BigDecimal("9.9"))
+    assertBDExactEquals(BigInteger.valueOf(9999L), 2, new BigDecimal("99.99"))
+    assertBDExactEquals(BigInteger.valueOf(999999L), 3, new BigDecimal("999.999"))
+    assertBDExactEquals(BigInteger.valueOf(99999999L), 4, new BigDecimal("9999.9999"))
   }
 
-  @Test def valueOfLongNegative999999999(): Unit = {
-    val bd = BigDecimal.valueOf(-999999999L)
-    assertEquals(-999999999, bd.intValue())
-    assertTrue(bd.longValue == -999999999L)
-  }
+  @Test def ctorDouble(): Unit = {
+    assertBDExactEquals(
+        new BigInteger("329999999999999982236431605997495353221893310546875"), 50,
+        new BigDecimal(3.3))
+    assertBDExactEquals(
+        new BigInteger("999899999999999948840923025272786617279052734375"), 46,
+        new BigDecimal(99.99))
+    assertBDExactEquals(
+        new BigInteger("9999999900000000707223080098628997802734375"), 39,
+        new BigDecimal(9999.9999))
+    assertBDExactEquals(
+        new BigInteger("9999999999999998509883880615234375"), 26,
+        new BigDecimal(99999999.99999999))
+    assertBDExactEquals(new BigInteger("1000000000"), 0, new BigDecimal(999999999.999999999))
+    assertBDExactEquals(new BigInteger("10000000000"), 0, new BigDecimal(9999999999.9999999999))
 
-  @Test def valueOfLongNegative9999999999(): Unit = {
-    val bd = BigDecimal.valueOf(-9999999999L)
-    assertTrue(bd.longValue == -9999999999L)
-  }
-
-  @Test def ctorString3(): Unit = {
-    val bd = new BigDecimal("3")
-    assertEquals(3, bd.intValue())
-    assertTrue(bd.longValue == 3L)
-  }
-
-  @Test def ctorString99(): Unit = {
-    val bd = new BigDecimal("99")
-    assertEquals(99, bd.intValue())
-    assertTrue(bd.longValue == 99L)
-  }
-
-  @Test def ctorString999999999(): Unit = {
-    val bd = new BigDecimal("999999999")
-    assertEquals(999999999, bd.intValue())
-    assertTrue(bd.longValue == 999999999L)
-  }
-
-  @Test def ctorString9999999999(): Unit = {
-    val bd = new BigDecimal("9999999999")
-    assertTrue(bd.longValue == 9999999999L)
-  }
-
-  @Test def ctorStringNegative99(): Unit = {
-    val bd = new BigDecimal("-99")
-    assertEquals(-99, bd.intValue())
-    assertTrue(bd.longValue == -99L)
-  }
-
-  @Test def ctorStringNegative999999999(): Unit = {
-    val bd = new BigDecimal("-999999999")
-    assertEquals(-999999999, bd.intValue())
-    assertTrue(bd.longValue == -999999999L)
-  }
-
-  @Test def ctorStringNegative9999999999(): Unit = {
-    val bd = new BigDecimal("-9999999999")
-    assertTrue(bd.longValue == -9999999999L)
-  }
-
-  @Test def ctorString9Point9(): Unit = {
-    val bd = new BigDecimal("9.9")
-    assertEquals("9.9", bd.toString)
-    assertEquals(9.9, bd.doubleValue(), 0.0)
-  }
-
-  @Test def ctorString99Point99(): Unit = {
-    val bd = new BigDecimal("99.99")
-    assertEquals(99.99, bd.doubleValue(), 0.0)
-  }
-
-  @Test def ctorString999Point999(): Unit = {
-    val bd = new BigDecimal("999.999")
-    assertEquals(999.999, bd.doubleValue(), 0.0)
-  }
-
-  @Test def ctorString9999Point9999(): Unit = {
-    val bd = new BigDecimal("9999.9999")
-    assertEquals(9999.9999, bd.doubleValue(), 0.0)
-  }
-
-  // java.lang.Math.BigDecimal double Constructors
-
-  @Test def ctorDouble3Point3(): Unit = {
-    val d = 3.3
-    val bd = new BigDecimal(d)
-    assertEquals(d, bd.doubleValue(), 0.0)
-  }
-
-  @Test def ctorDouble99Point99(): Unit = {
-    val d = 99.99
-    val bd = new BigDecimal(d)
-    assertEquals(d, bd.doubleValue(), 0.0)
-  }
-
-  @Test def ctorDouble9999Point9999: Unit = {
-    val d: Double = 9999.9999
-    val bd = new BigDecimal(d)
-    assertEquals(d, bd.doubleValue(), 0.0)
-  }
-
-  @Test def ctorDouble99999999Point99999999(): Unit = {
-    val d = 99999999.99999999
-    val bd = new BigDecimal(d)
-    assertEquals(d, bd.doubleValue(), 0.0)
-  }
-
-  @Test def ctorDouble999999999Point999999999(): Unit = {
-    val d = 999999999.999999999
-    val bd = new BigDecimal(d)
-    assertEquals(d, bd.doubleValue(), 0.0)
-  }
-
-  @Test def ctorDouble9999999999Point9999999999(): Unit = {
-    val d = 9999999999.9999999999
-    val bd = new BigDecimal(d)
-    assertEquals(d, bd.doubleValue(), 0.0)
-  }
-
-  @Test def ctorDoubleNegative3Point3(): Unit = {
-    val d = -3.3
-    val bd = new BigDecimal(d)
-    assertEquals(d, bd.doubleValue(), 0.0)
-  }
-
-  @Test def ctorDoubleNegative99Point99(): Unit = {
-    val d = -99.99
-    val bd = new BigDecimal(d)
-    assertEquals(d, bd.doubleValue(), 0.0)
-  }
-
-  @Test def ctorDoubleNegative99999999Point99999999(): Unit = {
-    val d = -99999999.99999999
-    val bd = new BigDecimal(d)
-    assertEquals(d, bd.doubleValue(), 0.0)
-  }
-
-  @Test def ctorDoubleNegative999999999Point999999999(): Unit = {
-    val d = -999999999.999999999
-    val bd = new BigDecimal(d)
-    assertEquals(d, bd.doubleValue(), 0.0)
-  }
-
-  @Test def ctorDoubleNegative9999999999Point9999999999(): Unit = {
-    val d = -9999999999.9999999999
-    val bd = new BigDecimal(d)
-    assertEquals(d, bd.doubleValue(), 0.0)
+    assertBDExactEquals(
+        new BigInteger("-329999999999999982236431605997495353221893310546875"), 50,
+        new BigDecimal(-3.3))
+    assertBDExactEquals(
+        new BigInteger("-999899999999999948840923025272786617279052734375"), 46,
+        new BigDecimal(-99.99))
+    assertBDExactEquals(
+        new BigInteger("-9999999900000000707223080098628997802734375"), 39,
+        new BigDecimal(-9999.9999))
+    assertBDExactEquals(
+        new BigInteger("-9999999999999998509883880615234375"), 26,
+        new BigDecimal(-99999999.99999999))
+    assertBDExactEquals(new BigInteger("-1000000000"), 0, new BigDecimal(-999999999.999999999))
+    assertBDExactEquals(new BigInteger("-10000000000"), 0, new BigDecimal(-9999999999.9999999999))
   }
 }


### PR DESCRIPTION
One code path insisted on building a `BigInteger` with an explicit positive sign but a negative absolute value, which is nonsensical.