### PR TITLE
Fix #5383: Handle `lhs: Block` in `pretransformAssign`.

### DIFF
--- a/linker/shared/src/main/scala/org/scalajs/linker/frontend/optimizer/OptimizerCore.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/frontend/optimizer/OptimizerCore.scala
@@ -1358,6 +1358,14 @@ private[optimizer] abstract class OptimizerCore(
     }
   }
 
+  /** Pretransforms a `Select`.
+   *
+   *  When `isLhsOfAssign = true`, the resulting `PreTransform` may resolve to
+   *  a tree that is not directly an `AssignLhs`. It may be a `Block` or
+   *  `PreTransBlock` instead. This is an abuse of the sytem.
+   *  The pretransformed lhs must be given to `pretransformAssign`, which is
+   *  the only method who can deal with that.
+   */
   private def pretransformSelectCommon(tree: Select, isLhsOfAssign: Boolean)(
       cont: PreTransCont)(
       implicit scope: Scope): TailRec[Tree] = {
@@ -1369,6 +1377,14 @@ private[optimizer] abstract class OptimizerCore(
     }
   }
 
+  /** Pretransforms a `Select`-style field section.
+   *
+   *  When `isLhsOfAssign = true`, the resulting `PreTransform` may resolve to
+   *  a tree that is not directly an `AssignLhs`. It may be a `Block` or
+   *  `PreTransBlock` instead. This is an abuse of the sytem.
+   *  The pretransformed lhs must be given to `pretransformAssign`, which is
+   *  the only method who can deal with that.
+   */
   private def pretransformSelectCommon(expectedType: Type,
       preTransQual: PreTransform, optQualDeclaredType: Option[Type],
       field: FieldIdent, isLhsOfAssign: Boolean)(
@@ -1531,8 +1547,22 @@ private[optimizer] abstract class OptimizerCore(
 
   private def pretransformAssign(tlhs: PreTransform, trhs: PreTransform)(
       cont: PreTransCont)(implicit scope: Scope, pos: Position): TailRec[Tree] = {
-    def contAssign(lhs: Tree, rhs: Tree) =
-      cont(PreTransTree(Assign(lhs.asInstanceOf[AssignLhs], rhs)))
+    def contAssign(lhs: Tree, rhs: Tree): TailRec[Tree] = {
+      val assignTree = lhs match {
+        case lhs: AssignLhs =>
+          Assign(lhs, rhs)
+        case Block(stats :+ (expr: AssignLhs)) =>
+          /* See the doc of pretransformSelectCommon. We recover here from the
+           * fact that it produces Blocks ending in an AssignLhs, which is
+           * normally not allowed.
+           */
+          Block(stats, Assign(expr, rhs))
+        case _ =>
+          throw new AssertionError(
+              s"unexpected non-lhs for Assign after optimizing at ${lhs.pos}:\n$lhs")
+      }
+      cont(PreTransTree(assignTree))
+    }
 
     resolvePreTransform(tlhs) match {
       case PreTransRecordTree(lhsTree, lhsStructure, lhsCancelFun) =>

--- a/test-suite/js/src/test/scala/org/scalajs/testsuite/compiler/OptimizerTest.scala
+++ b/test-suite/js/src/test/scala/org/scalajs/testsuite/compiler/OptimizerTest.scala
@@ -637,6 +637,46 @@ class OptimizerTest {
     assertTrue(called)
   }
 
+  @Test def keepQualifierSideEffectsOfKeptFieldOfInlineClass_Issue5383(): Unit = {
+    @inline
+    class Foo(var x: Int)
+
+    val foo = new Foo(2)
+
+    var called = false
+
+    @inline
+    def getFoo(): Foo = {
+      called = true
+      foo
+    }
+
+    getFoo().x = 1
+
+    assertTrue(called)
+    assertEquals(1, foo.x) // keep x
+  }
+
+  @Test def keepQualifierSideEffectsOfKeptFieldOfNoinlineClass(): Unit = {
+    @noinline
+    class Foo(var x: Int)
+
+    val foo = new Foo(2)
+
+    var called = false
+
+    @inline // the method is inline regardless, to create a selection from a block
+    def getFoo(): Foo = {
+      called = true
+      foo
+    }
+
+    getFoo().x = 1
+
+    assertTrue(called)
+    assertEquals(1, foo.x) // keep x
+  }
+
   @Test def keepQualifierSideEffectsOfEliminatedJSField(): Unit = {
     class Foo extends js.Object {
       private[this] var x: Int = 1


### PR DESCRIPTION
Follow-up to 516b9c57c2a09623771bd5026cefdd41bbaa00d9.