### PR TITLE
Fix #5389: Opt: Teach the optimizer that arrays of prims are final.

### DIFF
--- a/linker/shared/src/main/scala/org/scalajs/linker/frontend/optimizer/OptimizerCore.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/frontend/optimizer/OptimizerCore.scala
@@ -305,6 +305,8 @@ private[optimizer] abstract class OptimizerCore(
       val canRuleOutBasedOnExactness = exprType match {
         case ClassType(_, _, exact) =>
           exact
+        case ArrayType(ArrayTypeRef(_: PrimRef, _), _, _) =>
+          true // arrays of primitive types (of any depth) are effectively final
         case ArrayType(_, _, exact) =>
           exact
         case AnyType | AnyNotNullType =>
@@ -334,9 +336,18 @@ private[optimizer] abstract class OptimizerCore(
           true
       }
 
+      def isTestTypeFinal: Boolean = testType match {
+        case _ if testTypeKnownToBeFinal =>
+          true
+        case ArrayType(ArrayTypeRef(_: PrimRef, _), _, _) =>
+          true
+        case _ =>
+          false
+      }
+
       if (canRuleOutBasedOnExactness)
         notANonNullInstance
-      else if (testTypeKnownToBeFinal && !isSubtype(testType.toNonNullable, exprType))
+      else if (isTestTypeFinal && !isSubtype(testType.toNonNullable, exprType))
         notANonNullInstance
       else
         TypeTestResult.Unknown

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -2179,17 +2179,17 @@ object Build {
           case `default213Version` =>
             if (!useMinifySizes) {
               Some(ExpectedSizes(
-                  fastLink = 440000 to 441000,
-                  fullLink = 263000 to 264000,
-                  fastLinkGz = 58000 to 59000,
-                  fullLinkGz = 43000 to 44000,
+                  fastLink = 425000 to 426000,
+                  fullLink = 252000 to 253000,
+                  fastLinkGz = 56000 to 57000,
+                  fullLinkGz = 42000 to 43000,
               ))
             } else {
               Some(ExpectedSizes(
-                  fastLink = 305000 to 307000,
-                  fullLink = 263000 to 264000,
-                  fastLinkGz = 48000 to 49000,
-                  fullLinkGz = 43000 to 44000,
+                  fastLink = 291000 to 392000,
+                  fullLink = 252000 to 253000,
+                  fastLinkGz = 46000 to 47000,
+                  fullLinkGz = 42000 to 43000,
               ))
             }
 


### PR DESCRIPTION
And therefore, are known to be disjoint from any type that they are not a subtype of.

This is very useful for collection operations on Arrays in Scala 2.13+. Most of the operations are implemented with an initial match over the 9 types of arrays. After inlining, we typically know the type of the input array. With the new optimization, we can entirely resolve the match away, and keep a single, monomorphic path.

---

Not sure how I'm going to test this yet. But on the following functions:
```scala
  def intArray(xs: Array[Int]): Unit = {
    for (x <- xs) {
      println(x + 1)
    }
  }

  def stringArray(xs: Array[String]): Unit = {
    for (x <- xs) {
      println(x + " foo")
    }
  }

  def anyrefArray(xs: Array[Object]): Unit = {
    for (x <- xs) {
      println(x.hashCode())
    }
  }
```
when compiled and linked with Scala 2.13, this PR brings the following diff:
https://gist.github.com/sjrd/6e5c0ec5affae0b8852dec70f2c49da0
New generated code:
```js
$c_Lhelloworld_HelloWorld$.prototype.intArray__AI__V = (function(xs) {
  var len = $n(xs).u.length;
  var i = 0;
  if ((xs !== null)) {
    while ((i < len)) {
      var x0 = $n(xs).get(i);
      var x = ((1 + x0) | 0);
      var this$4 = $m_s_Console$();
      var this$5 = $n(this$4.out__Ljava_io_PrintStream());
      this$5.java$lang$JSConsoleBasedPrintStream$$printString__T__V((x + "\n"));
      i = ((1 + i) | 0);
    }
  } else {
    throw new $c_s_MatchError(xs);
  }
});
$c_Lhelloworld_HelloWorld$.prototype.stringArray__AT__V = (function(xs) {
  var len = $n(xs).u.length;
  var i = 0;
  if ((xs !== null)) {
    while ((i < len)) {
      var x0 = $n(xs).get(i);
      var x = (x0 + " foo");
      var this$4 = $m_s_Console$();
      var this$5 = $n(this$4.out__Ljava_io_PrintStream());
      this$5.java$lang$JSConsoleBasedPrintStream$$printString__T__V((x + "\n"));
      i = ((1 + i) | 0);
    }
  } else {
    throw new $c_s_MatchError(xs);
  }
});
$c_Lhelloworld_HelloWorld$.prototype.anyrefArray__AO__V = (function(xs) {
  var len = $n(xs).u.length;
  var i = 0;
  if ((xs !== null)) {
    while ((i < len)) {
      var x0 = $n(xs).get(i);
      var x = $dp_hashCode__I($n(x0));
      var this$4 = $m_s_Console$();
      var this$5 = $n(this$4.out__Ljava_io_PrintStream());
      this$5.java$lang$JSConsoleBasedPrintStream$$printString__T__V((x + "\n"));
      i = ((1 + i) | 0);
    }
  } else {
    throw new $c_s_MatchError(xs);
  }
});
```
which is basically as good as it gets.