### PR TITLE
Wasm: Move function type de-duplication to ModuleBuilder

### DIFF
--- a/linker/shared/src/main/scala/org/scalajs/linker/backend/wasmemitter/VarGen.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/backend/wasmemitter/VarGen.scala
@@ -385,7 +385,6 @@ object VarGen {
     final case class captureData(index: Int) extends TypeID
     final case class forVTable(className: ClassName) extends TypeID
     final case class forITable(className: ClassName) extends TypeID
-    final case class forFunction(index: Int) extends TypeID
     final case class forTableFunctionType(methodName: MethodName) extends TypeID
     final case class forClosureFunType(closureType: ClosureType) extends TypeID
     final case class forClosureType(closureType: ClosureType) extends TypeID

--- a/linker/shared/src/main/scala/org/scalajs/linker/backend/wasmemitter/WasmContext.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/backend/wasmemitter/WasmContext.scala
@@ -54,7 +54,6 @@ final class WasmContext(
 
   val useCustomDescriptors = coreSpec.wasmFeatures.experimentalUseCustomDescriptors
 
-  private val functionTypes = LinkedHashMap.empty[watpe.FunctionType, wanme.TypeID]
   private val tableFunctionTypes = mutable.HashMap.empty[MethodName, wanme.TypeID]
   private val closureDataTypes = LinkedHashMap.empty[List[Type], wanme.TypeID]
   private val typedClosureTypes = LinkedHashMap.empty[ClosureType, (wanme.TypeID, wanme.TypeID)]
@@ -63,19 +62,7 @@ final class WasmContext(
 
   private val customJSHelpers = mutable.ListBuffer.empty[(String, js.Function)]
 
-  val moduleBuilder: ModuleBuilder = {
-    new ModuleBuilder(new ModuleBuilder.FunctionTypeProvider {
-      def functionTypeToTypeID(sig: watpe.FunctionType): wanme.TypeID = {
-        functionTypes.getOrElseUpdate(
-          sig, {
-            val typeID = genTypeID.forFunction(functionTypes.size)
-            moduleBuilder.addRecType(typeID, NoOriginalName, sig)
-            typeID
-          }
-        )
-      }
-    })
-  }
+  val moduleBuilder: ModuleBuilder = new ModuleBuilder
 
   def addCustomJSHelper(jsFunction: js.Function, wasmType: watpe.FunctionType): wanme.FunctionID = {
     val id = CustomJSHelperFunctionID(customJSHelpers.size)

--- a/linker/shared/src/main/scala/org/scalajs/linker/backend/webassembly/ModuleBuilder.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/backend/webassembly/ModuleBuilder.scala
@@ -20,11 +20,14 @@ import Identitities._
 import Modules._
 import Types._
 
-final class ModuleBuilder(functionSignatureProvider: ModuleBuilder.FunctionTypeProvider) {
+final class ModuleBuilder {
   import ModuleBuilder._
 
   /** Items are `RecType | RecTypeBuilder`. */
   private val types: mutable.ListBuffer[AnyRef] = new mutable.ListBuffer()
+
+  /** For de-duplication of free standing function types. */
+  private val functionTypes = mutable.HashMap.empty[FunctionType, TypeID]
 
   private val imports: mutable.ListBuffer[Import] = new mutable.ListBuffer()
   private val funcs: mutable.ListBuffer[Function] = new mutable.ListBuffer()
@@ -35,9 +38,6 @@ final class ModuleBuilder(functionSignatureProvider: ModuleBuilder.FunctionTypeP
   private val elems: mutable.ListBuffer[Element] = new mutable.ListBuffer()
   private val datas: mutable.ListBuffer[Data] = new mutable.ListBuffer()
 
-  def functionTypeToTypeID(sig: FunctionType): TypeID =
-    functionSignatureProvider.functionTypeToTypeID(sig)
-
   def addRecType(recType: RecType): Unit = types += recType
   def addRecType(subType: SubType): Unit = addRecType(RecType(subType))
 
@@ -46,6 +46,16 @@ final class ModuleBuilder(functionSignatureProvider: ModuleBuilder.FunctionTypeP
 
   def addRecTypeBuilder(recTypeBuilder: RecTypeBuilder): Unit =
     types += recTypeBuilder
+
+  def functionTypeToTypeID(sig: FunctionType): TypeID = {
+    functionTypes.getOrElseUpdate(
+      sig, {
+        val typeID = FunctionTypeID(functionTypes.size)
+        addRecType(typeID, OriginalName.NoOriginalName, sig)
+        typeID
+      }
+    )
+  }
 
   def addImport(imprt: Import): Unit = imports += imprt
   def addFunction(function: Function): Unit = funcs += function
@@ -77,9 +87,7 @@ final class ModuleBuilder(functionSignatureProvider: ModuleBuilder.FunctionTypeP
 }
 
 object ModuleBuilder {
-  trait FunctionTypeProvider {
-    def functionTypeToTypeID(sig: FunctionType): TypeID
-  }
+  private final case class FunctionTypeID(index: Int) extends TypeID
 
   final class RecTypeBuilder {
     private val subTypes = mutable.ListBuffer.empty[SubType]


### PR DESCRIPTION
Discovered while working on multi module support (https://github.com/scala-js/scala-js/issues/5390).

The behavior of functionTypeToTypeID is (essentially) specified by
`FunctionBuilder#setFunctionType`:

https://github.com/scala-js/scala-js/blob/18a6d37f28f094c6fb5ea9b3481c64dc2cc5eed3/linker/shared/src/main/scala/org/scalajs/linker/backend/webassembly/FunctionBuilder.scala#L93-L110

As such, the implementation can reasonably live in `webassembly`,
simplifying the API surface of ModuleBuilder.

Regarding the move of the `forFunction` TypeID subtype:
- There is precedent for *IDs in webassembly for LocalID/LabelID
- No such precedent for TypeID, but there is not really a reason not to.

Lastly, we take the opportunity to remove the linked-ness of the hash map: We only ever retrieve by key, so its iteration order does not matter.