### PR TITLE
Refactor: Introduce TopLevelImportDef as parent of JSNativeMemberDef.

### DIFF
--- a/compiler/src/main/scala/org/scalajs/nscplugin/GenJSCode.scala
+++ b/compiler/src/main/scala/org/scalajs/nscplugin/GenJSCode.scala
@@ -661,18 +661,18 @@ abstract class GenJSCode[G <: Global with Singleton](val global: G)
       // Generate members (constructor + methods)
 
       val methodsBuilder = List.newBuilder[js.MethodDef]
-      val jsNativeMembersBuilder = List.newBuilder[js.JSNativeMemberDef]
+      val topLevelImportDefsBuilder = List.newBuilder[js.TopLevelImportDef]
 
       for (dd <- collectDefDefs(impl)) {
         if (dd.symbol.hasAnnotation(JSNativeAnnotation))
-          jsNativeMembersBuilder += genJSNativeMemberDef(dd)
+          topLevelImportDefsBuilder += genJSNativeMemberDef(dd)
         else
           methodsBuilder ++= genMethod(dd)
       }
 
       val fields = if (!isHijacked) genClassFields(cd) else Nil
 
-      val jsNativeMembers = jsNativeMembersBuilder.result()
+      val topLevelImportDefs = topLevelImportDefsBuilder.result()
       val generatedMethods = methodsBuilder.result()
 
       val memberExports = genMemberExports(sym)
@@ -744,7 +744,7 @@ abstract class GenJSCode[G <: Global with Singleton](val global: G)
                 methods = forwarders,
                 jsConstructor = None,
                 jsMethodProps = Nil,
-                jsNativeMembers = Nil,
+                topLevelImportDefs = Nil,
                 topLevelExportDefs = Nil
               )(js.OptimizerHints.empty)
               generatedStaticForwarderClasses += sym -> forwardersClassDef
@@ -778,7 +778,7 @@ abstract class GenJSCode[G <: Global with Singleton](val global: G)
           allMethods,
           jsConstructor = None,
           memberExports,
-          jsNativeMembers,
+          topLevelImportDefs,
           topLevelExportDefs)(
           optimizerHints)
     }
@@ -911,7 +911,7 @@ abstract class GenJSCode[G <: Global with Singleton](val global: G)
           generatedMethods.toList,
           Some(generatedCtor),
           jsMethodProps,
-          jsNativeMembers = Nil,
+          topLevelImportDefs = Nil,
           topLevelExports)(
           OptimizerHints.empty)
     }
@@ -948,8 +948,8 @@ abstract class GenJSCode[G <: Global with Singleton](val global: G)
           jsFieldDefs += fdef
       }
 
-      assert(origJsClass.jsNativeMembers.isEmpty,
-          "Found JS native members in anonymous JS class at " + pos)
+      assert(origJsClass.topLevelImportDefs.isEmpty,
+          "Found top-level imports in anonymous JS class at " + pos)
 
       assert(origJsClass.topLevelExportDefs.isEmpty,
           "Found top-level exports in anonymous JS class at " + pos)
@@ -962,7 +962,7 @@ abstract class GenJSCode[G <: Global with Singleton](val global: G)
             ClassKind.AbstractJSType, None, Some(parent), interfaces = Nil,
             jsSuperClass = None, jsNativeLoadSpec = None, fields = Nil,
             methods = origJsClass.methods, jsConstructor = None, jsMethodProps = Nil,
-            jsNativeMembers = Nil, topLevelExportDefs = Nil)(
+            topLevelImportDefs = Nil, topLevelExportDefs = Nil)(
             origJsClass.optimizerHints)
       }
 

--- a/ir/shared/src/main/scala/org/scalajs/ir/Hashers.scala
+++ b/ir/shared/src/main/scala/org/scalajs/ir/Hashers.scala
@@ -131,7 +131,7 @@ object Hashers {
     val newTopLevelExportDefs = topLevelExportDefs.map(hashTopLevelExportDef(_))
     ClassDef(name, originalName, kind, jsClassCaptures, superClass, interfaces,
         jsSuperClass, jsNativeLoadSpec, fields, newMethods, newJSConstructorDef,
-        newExportedMembers, jsNativeMembers, newTopLevelExportDefs)(
+        newExportedMembers, topLevelImportDefs, newTopLevelExportDefs)(
         optimizerHints)
   }
 

--- a/ir/shared/src/main/scala/org/scalajs/ir/Printers.scala
+++ b/ir/shared/src/main/scala/org/scalajs/ir/Printers.scala
@@ -145,6 +145,7 @@ object Printers {
         case node: ClassDef          => print(node)
         case node: MemberDef         => print(node)
         case node: JSConstructorBody => printBlock(node.allStats)
+        case node: TopLevelImportDef => print(node)
         case node: TopLevelExportDef => print(node)
       }
     }
@@ -1030,7 +1031,7 @@ object Printers {
       print(" ")
       printColumn(
           fields ::: methods ::: jsConstructor.toList :::
-          jsMethodProps ::: jsNativeMembers ::: topLevelExportDefs,
+          jsMethodProps ::: topLevelImportDefs ::: topLevelExportDefs,
           "{", "", "}")
     }
 
@@ -1108,7 +1109,11 @@ object Printers {
             printSig(arg :: Nil, None, VoidType)
             printBlock(body)
           }
+      }
+    }
 
+    def print(topLevelImportDef: TopLevelImportDef): Unit = {
+      topLevelImportDef match {
         case JSNativeMemberDef(flags, name, jsNativeLoadSpec) =>
           print(flags.namespace.prefixString)
           print("native ")

--- a/ir/shared/src/main/scala/org/scalajs/ir/Serializers.scala
+++ b/ir/shared/src/main/scala/org/scalajs/ir/Serializers.scala
@@ -671,7 +671,8 @@ object Serializers {
       writeOptTree(jsSuperClass)
       writeJSNativeLoadSpec(jsNativeLoadSpec)
       writeMemberDefs(
-          fields ::: methods ::: jsConstructor.toList ::: jsMethodProps ::: jsNativeMembers)
+          fields ::: methods ::: jsConstructor.toList ::: jsMethodProps,
+          topLevelImportDefs)
       writeTopLevelExportDefs(topLevelExportDefs)
       writeInt(OptimizerHints.toBits(optimizerHints))
     }
@@ -781,7 +782,14 @@ object Serializers {
           val length = bufferUnderlying.jumpBack()
           writeInt(length)
           bufferUnderlying.continue()
+      }
+    }
 
+    def writeTopLevelImportDef(topLevelImportDef: TopLevelImportDef): Unit = {
+      import buffer._
+      writePosition(topLevelImportDef.pos)
+
+      topLevelImportDef match {
         case JSNativeMemberDef(flags, name, jsNativeLoadSpec) =>
           writeByte(TagJSNativeMemberDef)
           writeInt(MemberFlags.toBits(flags))
@@ -790,9 +798,12 @@ object Serializers {
       }
     }
 
-    def writeMemberDefs(memberDefs: List[MemberDef]): Unit = {
-      buffer.writeInt(memberDefs.size)
-      memberDefs.foreach(writeMemberDef)
+    def writeMemberDefs(memberDefs: List[MemberDef],
+        topLevelImportDefs: List[TopLevelImportDef]): Unit = {
+      // For historical reasons, member defs and top-level import defs are in the same list
+      buffer.writeInt(memberDefs.size + topLevelImportDefs.size)
+      memberDefs.foreach(writeMemberDef(_))
+      topLevelImportDefs.foreach(writeTopLevelImportDef(_))
     }
 
     def writeTopLevelExportDef(topLevelExportDef: TopLevelExportDef): Unit = {
@@ -1770,12 +1781,14 @@ object Serializers {
 
       val jsNativeLoadSpec = readJSNativeLoadSpec()
 
-      // Read member defs
+      /* Read member defs.
+       * For historical reasons, top-level import defs are in the same list.
+       */
       val fieldsBuilder = List.newBuilder[AnyFieldDef]
       val methodsBuilder = List.newBuilder[MethodDef]
       val jsConstructorBuilder = new OptionBuilder[JSConstructorDef]
       val jsMethodPropsBuilder = List.newBuilder[JSMethodPropDef]
-      val jsNativeMembersBuilder = List.newBuilder[JSNativeMemberDef]
+      val topLevelImportsBuilder = List.newBuilder[TopLevelImportDef]
 
       for (_ <- 0 until readInt()) {
         implicit val pos = readPosition()
@@ -1786,7 +1799,7 @@ object Serializers {
           case TagJSConstructorDef  => jsConstructorBuilder += readJSConstructorDef(kind)
           case TagJSMethodDef       => jsMethodPropsBuilder += readJSMethodDef()
           case TagJSPropertyDef     => jsMethodPropsBuilder += readJSPropertyDef()
-          case TagJSNativeMemberDef => jsNativeMembersBuilder += readJSNativeMemberDef()
+          case TagJSNativeMemberDef => topLevelImportsBuilder += readJSNativeMemberDef()
         }
       }
 
@@ -1818,11 +1831,11 @@ object Serializers {
         }
       }
 
-      val jsNativeMembers = jsNativeMembersBuilder.result()
+      val topLevelImportDefs = topLevelImportsBuilder.result()
 
       val classDef = ClassDef(name, originalName, kind, jsClassCaptures, superClass, parents,
           jsSuperClass, jsNativeLoadSpec, fields, methods, jsConstructor,
-          jsMethodProps, jsNativeMembers, topLevelExportDefs)(
+          jsMethodProps, topLevelImportDefs, topLevelExportDefs)(
           optimizerHints)
 
       if (hacks.useBelow(19))
@@ -2197,7 +2210,7 @@ object Serializers {
           methods = List(newCtor), // throws away the old constructor and `apply` method
           jsConstructor,
           jsMethodProps,
-          jsNativeMembers,
+          topLevelImportDefs,
           topLevelExportDefs
         )(OptimizerHints.empty)(pos) // throws away the `@inline`
       }

--- a/ir/shared/src/main/scala/org/scalajs/ir/Transformers.scala
+++ b/ir/shared/src/main/scala/org/scalajs/ir/Transformers.scala
@@ -220,7 +220,7 @@ object Transformers {
           interfaces, transformTreeOpt(jsSuperClass), jsNativeLoadSpec,
           fields.map(transformAnyFieldDef(_)),
           methods.map(transformMethodDef), jsConstructor.map(transformJSConstructorDef),
-          jsMethodProps.map(transformJSMethodPropDef), jsNativeMembers,
+          jsMethodProps.map(transformJSMethodPropDef), topLevelImportDefs,
           topLevelExportDefs.map(transformTopLevelExportDef))(
           tree.optimizerHints)(tree.pos)
     }

--- a/ir/shared/src/main/scala/org/scalajs/ir/Trees.scala
+++ b/ir/shared/src/main/scala/org/scalajs/ir/Trees.scala
@@ -1486,7 +1486,7 @@ object Trees {
       val methods: List[MethodDef],
       val jsConstructor: Option[JSConstructorDef],
       val jsMethodProps: List[JSMethodPropDef],
-      val jsNativeMembers: List[JSNativeMemberDef],
+      val topLevelImportDefs: List[TopLevelImportDef],
       val topLevelExportDefs: List[TopLevelExportDef]
   )(
       val optimizerHints: OptimizerHints
@@ -1509,13 +1509,13 @@ object Trees {
         methods: List[MethodDef],
         jsConstructor: Option[JSConstructorDef],
         jsMethodProps: List[JSMethodPropDef],
-        jsNativeMembers: List[JSNativeMemberDef],
+        topLevelImportDefs: List[TopLevelImportDef],
         topLevelExportDefs: List[TopLevelExportDef])(
         optimizerHints: OptimizerHints)(
         implicit pos: Position): ClassDef = {
       new ClassDef(name, originalName, kind, jsClassCaptures, superClass,
           interfaces, jsSuperClass, jsNativeLoadSpec, fields, methods,
-          jsConstructor, jsMethodProps, jsNativeMembers, topLevelExportDefs)(
+          jsConstructor, jsMethodProps, topLevelImportDefs, topLevelExportDefs)(
           optimizerHints)
     }
   }
@@ -1585,10 +1585,14 @@ object Trees {
       implicit val pos: Position)
       extends JSMethodPropDef
 
+  sealed abstract class TopLevelImportDef extends IRNode {
+    val flags: MemberFlags
+  }
+
   sealed case class JSNativeMemberDef(flags: MemberFlags, name: MethodIdent,
       jsNativeLoadSpec: JSNativeLoadSpec)(
       implicit val pos: Position)
-      extends MemberDef
+      extends TopLevelImportDef
 
   // Top-level export defs
 

--- a/linker/shared/src/main/scala/org/scalajs/linker/analyzer/InfoLoader.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/analyzer/InfoLoader.scala
@@ -116,7 +116,7 @@ private[analyzer] object InfoLoader {
       prevJSMethodPropDefInfos =
         genJSMethodPropDefInfos(classDef.jsMethodProps, prevJSMethodPropDefInfos, generator)
 
-      val exportedMembers = prevJSCtorInfo.toList ::: prevJSMethodPropDefInfos
+      val jsMethodProps = prevJSCtorInfo.toList ::: prevJSMethodPropDefInfos
 
       /* We do not cache top-level exports, because they're quite rare,
        * and usually quite small when they exist.
@@ -124,13 +124,15 @@ private[analyzer] object InfoLoader {
       val topLevelExports = classDef.topLevelExportDefs
         .map(generator.generateTopLevelExportInfo(classDef.name.name, _))
 
-      val jsNativeMembers = classDef.jsNativeMembers
-        .map(m => m.name.name -> m.jsNativeLoadSpec).toMap
+      val jsNativeMembers = classDef.topLevelImportDefs.map {
+        case JSNativeMemberDef(_, name, loadSpec) =>
+          name.name -> loadSpec
+      }.toMap
 
       new Infos.ClassInfo(classDef.className, classDef.kind, syntheticKind = None,
           nonExistent = false, classDef.superClass.map(_.name),
           classDef.interfaces.map(_.name), classDef.jsNativeLoadSpec,
-          referencedFieldClasses, prevMethodInfos, jsNativeMembers, exportedMembers,
+          referencedFieldClasses, prevMethodInfos, jsNativeMembers, jsMethodProps,
           topLevelExports)
     }
 

--- a/linker/shared/src/main/scala/org/scalajs/linker/backend/emitter/KnowledgeGuardian.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/backend/emitter/KnowledgeGuardian.scala
@@ -365,12 +365,14 @@ private[emitter] final class KnowledgeGuardian(config: Emitter.Config) {
 
     private def computeJSNativeMemberLoadSpecs(
         linkedClass: LinkedClass): Map[MethodName, JSNativeLoadSpec] = {
-      if (linkedClass.jsNativeMembers.isEmpty) {
+      if (linkedClass.topLevelImportDefs.isEmpty) {
         // Fast path
         Map.empty
       } else {
-        linkedClass.jsNativeMembers
-          .map(m => m.name.name -> m.jsNativeLoadSpec)
+        linkedClass.topLevelImportDefs
+          .collect {
+            case JSNativeMemberDef(_, name, loadSpec) => name.name -> loadSpec
+          }
           .toMap
       }
     }

--- a/linker/shared/src/main/scala/org/scalajs/linker/backend/wasmemitter/DerivedClasses.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/backend/wasmemitter/DerivedClasses.scala
@@ -134,7 +134,7 @@ object DerivedClasses {
       derivedCtor :: derivedMethods,
       jsConstructorDef = None,
       exportedMembers = Nil,
-      jsNativeMembers = Nil,
+      topLevelImportDefs = Nil,
       EOH,
       pos,
       ancestors = derivedClassName :: clazz.ancestors.tail,

--- a/linker/shared/src/main/scala/org/scalajs/linker/backend/wasmemitter/Preprocessor.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/backend/wasmemitter/Preprocessor.scala
@@ -198,6 +198,10 @@ object Preprocessor {
       }
     }
 
+    val jsNativeMembers = clazz.topLevelImportDefs.collect {
+      case JSNativeMemberDef(_, name, loadSpec) => name.name -> loadSpec
+    }.toMap
+
     val resolvedMethodInfos: Map[MethodName, ConcreteMethodInfo] = {
       if (kind.isClass || kind == ClassKind.HijackedClass) {
         val inherited =
@@ -255,7 +259,7 @@ object Preprocessor {
       hasRuntimeTypeInfo,
       jsPrototypeHolder,
       clazz.jsNativeLoadSpec,
-      clazz.jsNativeMembers.map(m => m.name.name -> m.jsNativeLoadSpec).toMap,
+      jsNativeMembers,
       staticFieldMirrors,
       specialInstanceTypes,
       resolvedMethodInfos,

--- a/linker/shared/src/main/scala/org/scalajs/linker/checker/ClassDefChecker.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/checker/ClassDefChecker.scala
@@ -100,7 +100,9 @@ private final class ClassDefChecker(classDef: ClassDef,
       case jsMethodDef: JSMethodDef     => checkJSMethodDef(jsMethodDef)
       case jsPropertyDef: JSPropertyDef => checkJSPropertyDef(jsPropertyDef)
     }
-    classDef.jsNativeMembers.foreach(checkJSNativeMemberDef(_))
+    classDef.topLevelImportDefs.foreach {
+      case tli: JSNativeMemberDef => checkJSNativeMemberDef(tli)
+    }
 
     // top level exports need the lookup maps to be populated.
     classDef.topLevelExportDefs.foreach(checkTopLevelExportDef(_))
@@ -1251,7 +1253,7 @@ object ClassDefChecker {
       methods,
       jsConstructorDef,
       exportedMembers,
-      jsNativeMembers,
+      topLevelImportDefs,
       topLevelExportDefs = Nil
     )(optimizerHints)
 

--- a/linker/shared/src/main/scala/org/scalajs/linker/checker/IRChecker.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/checker/IRChecker.scala
@@ -986,7 +986,7 @@ private final class IRChecker(linkTimeProperties: LinkTimeProperties,
           classDef.hasInstances,
           classDef.jsNativeLoadSpec,
           CheckedClass.checkedFieldsOf(classDef),
-          classDef.jsNativeMembers.map(_.name.name).toSet)
+          CheckedClass.jsNativeMembersOf(classDef))
     }
 
     def lookupField(name: FieldName): Option[CheckedField] =
@@ -1005,6 +1005,12 @@ private final class IRChecker(linkTimeProperties: LinkTimeProperties,
         case FieldDef(flags, FieldIdent(name), _, tpe) =>
           new CheckedField(flags, name, tpe)
       }
+    }
+
+    private def jsNativeMembersOf(classDef: LinkedClass): Set[MethodName] = {
+      classDef.topLevelImportDefs.collect {
+        case JSNativeMemberDef(_, name, _) => name.name
+      }.toSet
     }
   }
 

--- a/linker/shared/src/main/scala/org/scalajs/linker/frontend/BaseLinker.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/frontend/BaseLinker.scala
@@ -168,8 +168,9 @@ private[frontend] object BaseLinker {
     if (classInfo.anyJSMemberNeedsDesugaring)
       desugaringRequirements = desugaringRequirements.addAnyExportedMember()
 
-    val jsNativeMembers = classDef.jsNativeMembers
-      .filter(m => classInfo.jsNativeMembersUsed.contains(m.name.name))
+    val topLevelImportDefs = classDef.topLevelImportDefs.filter {
+      case tli: JSNativeMemberDef => classInfo.jsNativeMembersUsed.contains(tli.name.name)
+    }
 
     val allMethods = methods ++ syntheticMethodDefs
 
@@ -187,7 +188,7 @@ private[frontend] object BaseLinker {
         allMethods,
         jsConstructor,
         jsMethodProps,
-        jsNativeMembers,
+        topLevelImportDefs,
         classDef.optimizerHints,
         classDef.pos,
         ancestors.toList,

--- a/linker/shared/src/main/scala/org/scalajs/linker/frontend/Desugarer.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/frontend/Desugarer.scala
@@ -93,7 +93,7 @@ final class Desugarer(config: CommonPhaseConfig, checkIR: Boolean) {
         methods = newMethods,
         jsConstructorDef = newJSConstructorDef,
         exportedMembers = newExportedMembers,
-        jsNativeMembers,
+        topLevelImportDefs,
         optimizerHints,
         pos,
         ancestors,

--- a/linker/shared/src/main/scala/org/scalajs/linker/frontend/LambdaSynthesizer.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/frontend/LambdaSynthesizer.scala
@@ -202,7 +202,7 @@ private[linker] object LambdaSynthesizer {
       methods = List(ctorDef, methodDef),
       jsConstructor = None,
       jsMethodProps = Nil,
-      jsNativeMembers = Nil,
+      topLevelImportDefs = Nil,
       topLevelExportDefs = Nil
     )(OptimizerHints.empty.withInline(true))
   }

--- a/linker/shared/src/main/scala/org/scalajs/linker/frontend/optimizer/IncOptimizer.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/frontend/optimizer/IncOptimizer.scala
@@ -188,7 +188,7 @@ final class IncOptimizer private[optimizer] (config: CommonPhaseConfig, collOps:
       newMethods,
       interface.optimizedJSConstructorDef(),
       interface.optimizedExportedMembers(),
-      linkedClass.jsNativeMembers,
+      linkedClass.topLevelImportDefs,
       newTopLevelExports
     )(linkedClass.optimizerHints)(linkedClass.pos)
 
@@ -1558,7 +1558,9 @@ final class IncOptimizer private[optimizer] (config: CommonPhaseConfig, collOps:
 
       val clazz = linkedClass.jsNativeLoadSpec.flatMap(maybeImport(_))
       val nativeMembers = for {
-        member <- linkedClass.jsNativeMembers
+        member <- linkedClass.topLevelImportDefs.collect {
+          case jsMember: JSNativeMemberDef => jsMember
+        }
         jsImport <- maybeImport(member.jsNativeLoadSpec)
       } yield {
         member.name.name -> jsImport

--- a/linker/shared/src/main/scala/org/scalajs/linker/standard/LinkedClass.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/standard/LinkedClass.scala
@@ -48,7 +48,7 @@ final class LinkedClass(
     val methods: List[MethodDef],
     val jsConstructorDef: Option[JSConstructorDef],
     val exportedMembers: List[JSMethodPropDef],
-    val jsNativeMembers: List[JSNativeMemberDef],
+    val topLevelImportDefs: List[TopLevelImportDef],
     val optimizerHints: OptimizerHints,
     val pos: Position,
 

--- a/linker/shared/src/test/scala/org/scalajs/linker/AnalyzerTest.scala
+++ b/linker/shared/src/test/scala/org/scalajs/linker/AnalyzerTest.scala
@@ -648,7 +648,7 @@ class AnalyzerTest {
     val classDefs = Seq(
       classDef("A", superClass = Some(ObjectClass),
           methods = List(mainMethod),
-          jsNativeMembers = List(nativeMember))
+          topLevelImportDefs = List(nativeMember))
     )
 
     val analysis = computeAnalysis(classDefs,

--- a/linker/shared/src/test/scala/org/scalajs/linker/OptimizerTest.scala
+++ b/linker/shared/src/test/scala/org/scalajs/linker/OptimizerTest.scala
@@ -409,7 +409,7 @@ class OptimizerTest {
       classDef(
         "Holder",
         kind = ClassKind.Interface,
-        jsNativeMembers = List(
+        topLevelImportDefs = List(
           JSNativeMemberDef(SMF, memberMethodName, JSNativeLoadSpec.Import("foo", List("bar")))
         )
       )

--- a/linker/shared/src/test/scala/org/scalajs/linker/testutils/TestIRBuilder.scala
+++ b/linker/shared/src/test/scala/org/scalajs/linker/testutils/TestIRBuilder.scala
@@ -59,14 +59,14 @@ object TestIRBuilder {
       methods: List[MethodDef] = Nil,
       jsConstructor: Option[JSConstructorDef] = None,
       jsMethodProps: List[JSMethodPropDef] = Nil,
-      jsNativeMembers: List[JSNativeMemberDef] = Nil,
+      topLevelImportDefs: List[TopLevelImportDef] = Nil,
       topLevelExportDefs: List[TopLevelExportDef] = Nil,
       optimizerHints: OptimizerHints = EOH
   ): ClassDef = {
     val notHashed = ClassDef(ClassIdent(className), NON, kind, jsClassCaptures,
         superClass.map(ClassIdent(_)), interfaces.map(ClassIdent(_)),
         jsSuperClass, jsNativeLoadSpec, fields, methods, jsConstructor,
-        jsMethodProps, jsNativeMembers, topLevelExportDefs)(
+        jsMethodProps, topLevelImportDefs, topLevelExportDefs)(
         optimizerHints)
     Hashers.hashClassDef(notHashed)
   }

--- a/project/BinaryIncompatibilities.scala
+++ b/project/BinaryIncompatibilities.scala
@@ -5,9 +5,19 @@ import com.typesafe.tools.mima.core.ProblemFilters._
 
 object BinaryIncompatibilities {
   val IR = Seq(
+    // !!! Breaking, ok in minor version
+    ProblemFilters.exclude[DirectMissingMethodProblem]("org.scalajs.ir.Trees#ClassDef.this"),
+    ProblemFilters.exclude[DirectMissingMethodProblem]("org.scalajs.ir.Trees#ClassDef.apply"),
+    ProblemFilters.exclude[DirectMissingMethodProblem]("org.scalajs.ir.Trees#ClassDef.jsNativeMembers"),
+    ProblemFilters.exclude[MissingTypesProblem]("org.scalajs.ir.Trees$JSNativeMemberDef"),
+
+    // private, not an issue
+    ProblemFilters.exclude[DirectMissingMethodProblem]("org.scalajs.ir.Serializers#Serializer.writeMemberDefs"),
   )
 
   val Linker = Seq(
+    // !!! Breaking, ok in minor version
+    ProblemFilters.exclude[DirectMissingMethodProblem]("org.scalajs.linker.standard.LinkedClass.jsNativeMembers"),
   )
 
   val LinkerInterface = Seq(

--- a/project/JavaLangObject.scala
+++ b/project/JavaLangObject.scala
@@ -184,7 +184,7 @@ object JavaLangObject {
                 ClassType(BoxedStringClass, nullable = true, exact = false))
           })(OptimizerHints.empty, Unversioned)
       ),
-      jsNativeMembers = Nil,
+      topLevelImportDefs = Nil,
       topLevelExportDefs = Nil)(OptimizerHints.empty)
 
     Hashers.hashClassDef(classDef)

--- a/project/JavalibIRCleaner.scala
+++ b/project/JavalibIRCleaner.scala
@@ -184,7 +184,7 @@ final class JavalibIRCleaner(baseDirectoryURI: URI) {
 
       val preprocessedTree = ClassDef(name, originalName, kind, jsClassCaptures,
           superClass, newInterfaces, jsSuperClass, jsNativeLoadSpec, fields,
-          newMethods, jsConstructor, jsMethodProps, jsNativeMembers,
+          newMethods, jsConstructor, jsMethodProps, topLevelImportDefs,
           topLevelExportDefs)(
           optimizerHints)(pos)
 
@@ -322,7 +322,7 @@ final class JavalibIRCleaner(baseDirectoryURI: URI) {
         newMethods2,
         classDef.jsConstructor,
         classDef.jsMethodProps,
-        classDef.jsNativeMembers,
+        classDef.topLevelImportDefs,
         classDef.topLevelExportDefs
       )(classDef.optimizerHints)(classDef.pos)
     }


### PR DESCRIPTION
This prepares for the addition of top-level Wasm imports.

Arguably, `JSNativeMemberDef` itself should be renamed to `JSImportedMemberDef`. If we do that, we should probably also rename `SelectJSNativeMember` and even `JSNativeLoadSpec`. This is left as future change.

Extracted from #5353.